### PR TITLE
fix: Refresh auth token on 401 http errors

### DIFF
--- a/src/hooks/useHttpClient.test.tsx
+++ b/src/hooks/useHttpClient.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import axios from 'axios';
 import { act, renderHook } from '@testing-library/react-native';
 import MockAdapter from 'axios-mock-adapter';
 import { AuthResult, useAuth } from './useAuth';
@@ -37,6 +38,20 @@ test('initial state test', async () => {
   expect(result.current.httpClient).toBeDefined();
 });
 
+test('provides default baseURL if one is not provided', async () => {
+  const axiosInstance = axios.create();
+  const { result } = renderHook(() => useHttpClient(), {
+    wrapper: ({ children }) => (
+      <HttpClientContextProvider injectedAxiosInstance={axiosInstance}>
+        {children}
+      </HttpClientContextProvider>
+    ),
+  });
+  expect(result.current.httpClient.defaults.baseURL).toEqual(
+    'https://api.us.lifeomic.com',
+  );
+});
+
 test('if authResult is not present, has no Authorization header', async () => {
   const { result } = await renderHookInContext();
   const axiosMock = new MockAdapter(result.current.httpClient);
@@ -63,4 +78,15 @@ test('once authResult is set, adds bearer token', async () => {
   const getHeaders = axiosMock.history.get[0].headers;
   expect(getHeaders?.Authorization).toBe(`Bearer ${authResult.accessToken}`);
   expect(getHeaders?.['Content-Type']).toBe('application/json');
+});
+
+test('reports 401 errors to useAuth and throws', async () => {
+  const refreshForAuthFailure = jest.fn().mockResolvedValue({});
+  useAuthMock.mockReturnValue({ authResult, refreshForAuthFailure });
+  const { result } = await renderHookInContext();
+
+  const axiosMock = new MockAdapter(result.current.httpClient);
+  axiosMock.onGet('/v1/accounts').reply(401);
+  await expect(result.current.httpClient.get('/v1/accounts')).rejects.toThrow();
+  expect(refreshForAuthFailure).toHaveBeenCalled();
 });

--- a/src/navigators/RootStack.tsx
+++ b/src/navigators/RootStack.tsx
@@ -19,7 +19,7 @@ export type NotLoggedInRootParamList = {
 export function RootStack() {
   const { isLoggedIn, loading } = useAuth();
 
-  if (loading) {
+  if (!isLoggedIn && loading) {
     return (
       <ActivityIndicatorView
         message={t('root-stack-waiting-for-auth', 'Waiting for authorization')}


### PR DESCRIPTION
## Changes
- Allow for API consumers to report 401s to useAuth
- Have useHttpClient report 401s to useAuth

## Screenshots
### Refresh retries:
https://user-images.githubusercontent.com/1445395/221244825-8ec42efe-abc5-487f-86e2-eb70a950d0a3.mov

### Refresh fail:
https://user-images.githubusercontent.com/1445395/221244903-d365095a-569d-4618-afb3-ece98251f373.mov

☝️ waiting for future PR on `Alert` (user error message dialog) usage, error reporting, etc.