### PR TITLE
Add no internet toast message

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -22,6 +22,8 @@ module.exports = {
           '@react-navigation/bottom-tabs': path.resolve(__dirname, './node_modules/@react-navigation/bottom-tabs'),
           'react-native-safe-area-context': path.resolve(__dirname, './node_modules/react-native-safe-area-context'),
           'react-native-screens': path.resolve(__dirname, './node_modules/react-native-screens'),
+          'react-native-toast-message': path.resolve(__dirname, './node_modules/react-native-toast-message'),
+          '@react-native-community/netinfo': path.resolve(__dirname, './node_modules/@react-native-community/netinfo'),
           'graphql-request': path.resolve(
             __dirname, 
             './node_modules/graphql-request'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -309,6 +309,8 @@ PODS:
     - react-native-config/App (= 1.5.0)
   - react-native-config/App (1.5.0):
     - React-Core
+  - react-native-netinfo (9.3.7):
+    - React-Core
   - react-native-safe-area-context (4.5.0):
     - RCT-Folly
     - RCTRequired
@@ -458,6 +460,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - react-native-app-auth (from `../node_modules/react-native-app-auth`)
   - react-native-config (from `../node_modules/react-native-config`)
+  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -542,6 +545,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-app-auth"
   react-native-config:
     :path: "../node_modules/react-native-config"
+  react-native-netinfo:
+    :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-webview:
@@ -618,6 +623,7 @@ SPEC CHECKSUMS:
   React-logger: 60a0b5f8bed667ecf9e24fecca1f30d125de6d75
   react-native-app-auth: fd1eaa667c0bc014199456d14a6440cb74de814e
   react-native-config: 5330c8258265c1e5fdb8c009d2cabd6badd96727
+  react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-webview: 9f111dfbcfc826084d6c507f569e5e03342ee1c1
   React-perflogger: ec8eef2a8f03ecfa6361c2c5fb9197ef4a29cc85

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "@react-native-community/netinfo": "^9.3.7",
     "axios": "^1.3.2",
     "graphql": "^16.6.0",
     "graphql-request": "^5.1.0",
@@ -19,6 +20,7 @@
     "react-native-config": "^1.5.0",
     "react-native-device-info": "^10.3.0",
     "react-native-keychain": "^8.1.1",
+    "react-native-toast-message": "^2.1.6",
     "react-native-webview": "^11.26.1",
     "react-query": "^3.39.3",
     "reactotron-react-native": "^5.0.3"

--- a/example/storybook/stories/NoInternetToastProvider.stories.tsx
+++ b/example/storybook/stories/NoInternetToastProvider.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { boolean } from '@storybook/addon-knobs';
 import { NoInternetToastProvider } from '../../../src';
 import Toast from 'react-native-toast-message';
+import { boolean } from '@storybook/addon-knobs';
 
 storiesOf('NoInternetToast', module).add('demo', () => {
-  const internetConnection = boolean('Internet connection', false);
+  const isConnected = boolean('Internet Connection', false);
   return (
-    <NoInternetToastProvider forceShowToast={internetConnection}>
+    <NoInternetToastProvider _isConnected={isConnected}>
       <Toast />
     </NoInternetToastProvider>
   );

--- a/example/storybook/stories/NoInternetToastProvider.stories.tsx
+++ b/example/storybook/stories/NoInternetToastProvider.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { boolean } from '@storybook/addon-knobs';
+import { NoInternetToastProvider } from '../../../src';
+import Toast from 'react-native-toast-message';
+
+storiesOf('NoInternetToast', module).add('demo', () => {
+  const internetConnection = boolean('Internet connection', false);
+  return (
+    <NoInternetToastProvider forceShowToast={internetConnection}>
+      <Toast />
+    </NoInternetToastProvider>
+  );
+});

--- a/example/storybook/stories/index.ts
+++ b/example/storybook/stories/index.ts
@@ -2,3 +2,4 @@ import './BrandConfigProvider/BrandConfigProvider.stories';
 import './Welcome/Welcome.stories';
 import './OAuth.stories';
 import './Tile.stories';
+import './NoInternetToastProvider.stories';

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1645,6 +1645,11 @@
     prompts "^2.4.0"
     semver "^6.3.0"
 
+"@react-native-community/netinfo@^9.3.7":
+  version "9.3.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.7.tgz#92407f679f00bae005c785a9284e61d63e292b34"
+  integrity sha512-+taWmE5WpBp0uS6kf+bouCx/sn89G9EpR4s2M/ReLvctVIFL2Qh8WnWfBxqK9qwgmFha/uqjSr2Gq03OOtiDcw==
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"
@@ -9895,6 +9900,11 @@ react-native-swipe-gestures@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==
+
+react-native-toast-message@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.1.6.tgz#322827c66901fa22cb3db614c7383cc717f5bbe2"
+  integrity sha512-VctXuq20vmRa9AE13acaNZhrLcS3FaBS2zEevS3+vhBsnVZYG0FIlWIis9tVnpnNxUb3ART+BWtwQjzSttXTng==
 
 react-native-webview@^11.26.1:
   version "11.26.1"

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,7 @@
 // @ts-ignore
 import mockDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock';
+// @ts-ignore
+import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock';
 
 jest.mock('react-native-device-info', () => mockDeviceInfo);
 
@@ -11,3 +13,5 @@ jest.mock('i18next', () => ({
   t: (_key: string, defaultValue: string, params?: any) =>
     `${defaultValue}${params ? JSON.stringify(params) : ''}`,
 }));
+
+jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-env": "^7.20.2",
     "@lifeomic/eslint-plugin-i18next": "^2.0.1",
     "@react-native-community/eslint-config": "^3.2.0",
+    "@react-native-community/netinfo": "^9.3.7",
     "@react-navigation/bottom-tabs": "^6.5.5",
     "@react-navigation/native": "^6.1.3",
     "@react-navigation/native-stack": "^6.9.9",
@@ -51,6 +52,7 @@
     "react-native-keychain": "^8.1.1",
     "react-native-safe-area-context": "^4.5.0",
     "react-native-screens": "^3.19.0",
+    "react-native-toast-message": "^2.1.6",
     "react-native-webview": "^11.26.1",
     "react-query": "^3.39.3",
     "react-test-renderer": "^18.2.0",
@@ -59,6 +61,7 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
+    "@react-native-community/netinfo": "^9.3.7",
     "@react-navigation/bottom-tabs": "^6.5.5",
     "@react-navigation/native": "^6.1.3",
     "@react-navigation/native-stack": "^6.9.9",
@@ -74,6 +77,7 @@
     "react-native-keychain": "^8.1.1",
     "react-native-safe-area-context": "^4.5.0",
     "react-native-screens": "^3.19.0",
+    "react-native-toast-message": "^2.1.6",
     "react-native-webview": "^11.26.1",
     "react-query": "^3.39.3"
   },

--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -9,6 +9,8 @@ import { HttpClientContextProvider } from '../hooks/useHttpClient';
 import { OAuthContextProvider } from '../hooks/useOAuthFlow';
 import { ActiveProjectContextProvider } from '../hooks/useActiveProject';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
+import Toast from 'react-native-toast-message';
+import { NoInternetToastProvider } from '../hooks/NoInternetToastProvider';
 
 const queryClient = new QueryClient();
 
@@ -27,9 +29,12 @@ export function RootProviders({
             <OAuthContextProvider authConfig={authConfig}>
               <ActiveAccountContextProvider>
                 <ActiveProjectContextProvider>
-                  <SafeAreaProvider>
-                    <NavigationContainer>{children}</NavigationContainer>
-                  </SafeAreaProvider>
+                  <NoInternetToastProvider>
+                    <SafeAreaProvider>
+                      <NavigationContainer>{children}</NavigationContainer>
+                      <Toast />
+                    </SafeAreaProvider>
+                  </NoInternetToastProvider>
                 </ActiveProjectContextProvider>
               </ActiveAccountContextProvider>
             </OAuthContextProvider>

--- a/src/hooks/NoInternetToastProvider.test.tsx
+++ b/src/hooks/NoInternetToastProvider.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+// @ts-ignore
+import RNCNetInfoMock from '@react-native-community/netinfo/jest/netinfo-mock';
+import { NoInternetToastProvider } from './NoInternetToastProvider';
+import Toast from 'react-native-toast-message';
+
+describe('NoInternetToast', () => {
+  test('shows and hides on connection state change', () => {
+    RNCNetInfoMock.useNetInfo.mockReturnValue({
+      isConnected: false,
+    });
+
+    const mockOnShow = jest.fn();
+    const mockOnHide = jest.fn();
+    const { rerender } = render(
+      <NoInternetToastProvider
+        toastOverrides={{ onHide: mockOnHide, onShow: mockOnShow }}
+      >
+        <Toast />
+      </NoInternetToastProvider>,
+    );
+
+    expect(mockOnShow).toHaveBeenCalledTimes(1);
+
+    RNCNetInfoMock.useNetInfo.mockReturnValue({ isConnected: true });
+    rerender(
+      <NoInternetToastProvider
+        toastOverrides={{ onHide: mockOnHide, onShow: mockOnShow }}
+      >
+        <Toast />
+      </NoInternetToastProvider>,
+    );
+
+    expect(mockOnHide).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/NoInternetToastProvider.tsx
+++ b/src/hooks/NoInternetToastProvider.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useEffect, useRef, useState } from 'react';
+import { useNetInfo } from '@react-native-community/netinfo';
+import { t } from 'i18next';
+import Toast, { ToastProps } from 'react-native-toast-message';
+
+export const NoInternetToastContext = createContext({});
+
+export const NoInternetToastProvider = ({
+  children,
+  toastOverrides,
+  forceShowToast,
+}: {
+  children?: React.ReactNode;
+  toastOverrides?: ToastProps;
+  forceShowToast?: boolean;
+}) => {
+  const { isConnected } = useNetInfo();
+  const hiddenByAPI = useRef<boolean>(false);
+  const [forceRefresh, setForceRefresh] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (isConnected === false || forceShowToast === false) {
+      hiddenByAPI.current = false;
+      Toast.show({
+        type: 'error',
+        text1: t('connection-error-title', 'No internet connection ❌'),
+        text2: t(
+          'connection-error-body',
+          'This app requires an internet connection.',
+        ),
+        autoHide: false,
+        onHide: () => {
+          if (hiddenByAPI.current === false) {
+            // If dismissed by a user force a rerender
+            // so the toast is shown again
+            setForceRefresh((currentValue) => !currentValue);
+          } else {
+            hiddenByAPI.current = false;
+          }
+        },
+        ...toastOverrides,
+      });
+    } else if (isConnected === true || forceShowToast === true) {
+      hiddenByAPI.current = true;
+      Toast.hide();
+    }
+  }, [isConnected, toastOverrides, forceRefresh, forceShowToast]);
+
+  return (
+    <NoInternetToastContext.Provider value={{}}>
+      {children}
+    </NoInternetToastContext.Provider>
+  );
+};

--- a/src/hooks/NoInternetToastProvider.tsx
+++ b/src/hooks/NoInternetToastProvider.tsx
@@ -5,21 +5,24 @@ import Toast, { ToastProps } from 'react-native-toast-message';
 
 export const NoInternetToastContext = createContext({});
 
+class NoInternetToastProviderProps {
+  children?: React.ReactNode;
+  toastOverrides?: ToastProps;
+  /** Simulate the connection state (useful for testing) */
+  _isConnected?: boolean;
+}
+
 export const NoInternetToastProvider = ({
   children,
   toastOverrides,
-  forceShowToast,
-}: {
-  children?: React.ReactNode;
-  toastOverrides?: ToastProps;
-  forceShowToast?: boolean;
-}) => {
+  _isConnected,
+}: NoInternetToastProviderProps) => {
   const { isConnected } = useNetInfo();
   const hiddenByAPI = useRef<boolean>(false);
   const [forceRefresh, setForceRefresh] = useState<boolean>(false);
 
   useEffect(() => {
-    if (isConnected === false || forceShowToast === false) {
+    if (_isConnected === false || isConnected === false) {
       hiddenByAPI.current = false;
       Toast.show({
         type: 'error',
@@ -40,11 +43,11 @@ export const NoInternetToastProvider = ({
         },
         ...toastOverrides,
       });
-    } else if (isConnected === true || forceShowToast === true) {
+    } else if (_isConnected === true || isConnected === true) {
       hiddenByAPI.current = true;
       Toast.hide();
     }
-  }, [isConnected, toastOverrides, forceRefresh, forceShowToast]);
+  }, [isConnected, toastOverrides, forceRefresh, _isConnected]);
 
   return (
     <NoInternetToastContext.Provider value={{}}>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './NoInternetToastProvider';
 export * from './useAccounts';
 export * from './useActiveAccount';
 export * from './useActiveProject';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1943,6 +1943,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.3.0.tgz#9e558170c106bbafaa1ef502bd8e6d4651012bf9"
   integrity sha512-+zDZ20NUnSWghj7Ku5aFphMzuM9JulqCW+aPXT6IfIXFbb8tzYTTOSeRFOtuekJ99ibW2fUCSsjuKNlwDIbHFg==
 
+"@react-native-community/netinfo@^9.3.7":
+  version "9.3.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.7.tgz#92407f679f00bae005c785a9284e61d63e292b34"
+  integrity sha512-+taWmE5WpBp0uS6kf+bouCx/sn89G9EpR4s2M/ReLvctVIFL2Qh8WnWfBxqK9qwgmFha/uqjSr2Gq03OOtiDcw==
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"
@@ -8275,6 +8280,11 @@ react-native-screens@^3.19.0:
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
+
+react-native-toast-message@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.1.6.tgz#322827c66901fa22cb3db614c7383cc717f5bbe2"
+  integrity sha512-VctXuq20vmRa9AE13acaNZhrLcS3FaBS2zEevS3+vhBsnVZYG0FIlWIis9tVnpnNxUb3ART+BWtwQjzSttXTng==
 
 react-native-webview@^11.26.1:
   version "11.26.1"


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
### Adds NoInternetToast
A toast message will be shown when there is no internet on the device and hidden when the connection is restored. A user can swipe the message off screen but it will reappear until internet connection is restored.

### Setup
- No additional setup required if importing/using RootProviders directly. Otherwise include the NoInternetToast as a sibling alongside the root NavigationContainer. Refer to the setup docs for react-native-toast-message [here](https://github.com/calintamas/react-native-toast-message/blob/main/docs/navigation-usage.md) for more info.

Additional setup and usage docs can be found on in `react-native-toast-message` repo [here](https://github.com/calintamas/react-native-toast-message).
      
## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<img src="https://user-images.githubusercontent.com/76954025/221961982-f7985910-1ebc-4507-b408-8204d0be899f.png" width="256">

## Next Up
- Jest test coverage


