### PR TITLE
PHC-4151 Cleanup TODOs in useActiveAccount

### DIFF
--- a/__mocks__/@react-native-async-storage/async-storage.js
+++ b/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,0 +1,2 @@
+import * as mockStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+export default mockStorage;

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -24,6 +24,7 @@ module.exports = {
           'react-native-screens': path.resolve(__dirname, './node_modules/react-native-screens'),
           'react-native-toast-message': path.resolve(__dirname, './node_modules/react-native-toast-message'),
           '@react-native-community/netinfo': path.resolve(__dirname, './node_modules/@react-native-community/netinfo'),
+          '@react-native-async-storage/async-storage': path.resolve(__dirname, './node_modules/@react-native-async-storage/async-storage'),
           'graphql-request': path.resolve(
             __dirname, 
             './node_modules/graphql-request'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -400,6 +400,8 @@ PODS:
     - React-jsi (= 0.71.1)
     - React-logger (= 0.71.1)
     - React-perflogger (= 0.71.1)
+  - RNCAsyncStorage (1.17.11):
+    - React-Core
   - RNDeviceInfo (10.3.0):
     - React-Core
   - RNKeychain (8.1.1):
@@ -476,6 +478,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -577,6 +580,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
   RNKeychain:
@@ -639,6 +644,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 49d531ec8498e0afa2c9b22c2205784372e3d4f3
   React-runtimeexecutor: 311feb67600774723fe10eb8801d3138cae9ad67
   ReactCommon: 03be76588338a27a88d103b35c3c44a3fd43d136
+  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
   RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-community/netinfo": "^9.3.7",
     "axios": "^1.3.2",
     "graphql": "^16.6.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1484,6 +1484,13 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-native-async-storage/async-storage@^1.17.11":
+  version "1.17.11"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
+  integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-clean@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-10.1.1.tgz#4c73ce93a63a24d70c0089d4025daac8184ff504"
@@ -7159,7 +7166,7 @@ is-path-inside@^3.0.2:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
-is-plain-obj@^2.0.0:
+is-plain-obj@^2.0.0, is-plain-obj@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
@@ -7952,6 +7959,13 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -15,3 +15,6 @@ jest.mock('i18next', () => ({
 }));
 
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo);
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@lifeomic/eslint-plugin-i18next": "^2.0.1",
+    "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-community/eslint-config": "^3.2.0",
     "@react-native-community/netinfo": "^9.3.7",
     "@react-navigation/bottom-tabs": "^6.5.5",
@@ -42,6 +43,7 @@
     "graphql-request": "^5.1.0",
     "i18next": "^22.4.9",
     "jest": "^29.4.1",
+    "jest-mock-extended": "^3.0.3",
     "metro-react-native-babel-preset": "^0.74.1",
     "nock": "^13.3.0",
     "prettier": "^2.8.3",
@@ -62,6 +64,7 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
+    "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-community/netinfo": "^9.3.7",
     "@react-navigation/bottom-tabs": "^6.5.5",
     "@react-navigation/native": "^6.1.3",

--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -7,7 +7,12 @@ import {
 } from './useActiveAccount';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AsyncStorageMock from '@react-native-async-storage/async-storage/jest/async-storage-mock';
-import { QueryClient, QueryClientProvider, UseQueryResult } from 'react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryObserverLoadingResult,
+  UseQueryResult,
+} from 'react-query';
 import { mockDeep } from 'jest-mock-extended';
 import * as GetAsyncStorage from './useGetAsyncStorage';
 
@@ -52,7 +57,7 @@ beforeEach(() => {
     refetch: refetchMock,
   });
   useGetAsyncStorageSpy.mockReturnValue({
-    ...mockDeep<UseQueryResult<string | null, unknown>>(),
+    ...mockDeep<UseQueryResult<string | null>>(),
   });
 });
 
@@ -79,6 +84,10 @@ test('exposes some props from useAccounts', async () => {
     isLoading: true,
     isFetched: true,
     error,
+  });
+  useGetAsyncStorageSpy.mockReturnValueOnce({
+    ...mockDeep<QueryObserverLoadingResult<string | null>>(),
+    isFetched: true,
   });
 
   const { result } = await renderHookInContext();

--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -1,17 +1,24 @@
 import React from 'react';
-import { act, renderHook } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useAccounts } from './useAccounts';
 import {
   ActiveAccountContextProvider,
   useActiveAccount,
 } from './useActiveAccount';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import AsyncStorageMock from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+import { QueryClient, QueryClientProvider, UseQueryResult } from 'react-query';
+import { mockDeep } from 'jest-mock-extended';
+import * as GetAsyncStorage from './useGetAsyncStorage';
 
 jest.mock('./useAccounts', () => ({
   useAccounts: jest.fn(),
 }));
 
 const useAccountsMock = useAccounts as jest.Mock;
+
 const refetchMock = jest.fn();
+let useGetAsyncStorageSpy = jest.spyOn(GetAsyncStorage, 'useGetAsyncStorage');
 
 const accountId1 = 'acct1';
 const accountId2 = 'acct2';
@@ -27,10 +34,14 @@ const mockAccounts = [
   },
 ];
 
-const renderHookInContext = async () => {
+const renderHookInContext = async (accountIdToSelect?: string) => {
   return renderHook(() => useActiveAccount(), {
     wrapper: ({ children }) => (
-      <ActiveAccountContextProvider>{children}</ActiveAccountContextProvider>
+      <QueryClientProvider client={new QueryClient()}>
+        <ActiveAccountContextProvider accountIdToSelect={accountIdToSelect}>
+          {children}
+        </ActiveAccountContextProvider>
+      </QueryClientProvider>
     ),
   });
 };
@@ -39,6 +50,9 @@ beforeEach(() => {
   useAccountsMock.mockReturnValue({
     data: mockAccounts,
     refetch: refetchMock,
+  });
+  useGetAsyncStorageSpy.mockReturnValue({
+    ...mockDeep<UseQueryResult<string | null, unknown>>(),
   });
 });
 
@@ -68,7 +82,6 @@ test('exposes some props from useAccounts', async () => {
   });
 
   const { result } = await renderHookInContext();
-
   expect(result.current).toMatchObject({
     isLoading: true,
     isFetched: true,
@@ -132,4 +145,62 @@ test('indicates expired trial', async () => {
     account: expiredTrialAccount,
     trialExpired: true,
   });
+});
+
+test('provider allows for account override by id', async () => {
+  const { result } = await renderHookInContext(accountId2);
+  expect(result.current).toMatchObject({
+    account: mockAccounts[1],
+  });
+});
+
+test('uses account from async storage', async () => {
+  useGetAsyncStorageSpy.mockRestore();
+
+  AsyncStorageMock.getItem = jest.fn().mockResolvedValueOnce(accountId1);
+  const { result, rerender } = await renderHookInContext();
+  await waitFor(() => result.current.isLoading === false);
+  rerender({});
+  expect(AsyncStorage.getItem).toBeCalledWith('selectedAccountId');
+  expect(result.current).toMatchObject({
+    account: mockAccounts[0],
+    accountHeaders: { 'LifeOmic-Account': mockAccounts[0].id },
+    accountsWithProduct: mockAccounts,
+  });
+
+  AsyncStorageMock.getItem = jest.fn().mockResolvedValueOnce(accountId2);
+  const { result: nextResult, rerender: nextRerender } =
+    await renderHookInContext();
+  await waitFor(() => nextResult.current.isLoading === false);
+  nextRerender({});
+  expect(nextResult.current).toMatchObject({
+    account: mockAccounts[1],
+    accountHeaders: { 'LifeOmic-Account': mockAccounts[1].id },
+    accountsWithProduct: mockAccounts,
+  });
+
+  useGetAsyncStorageSpy = jest.spyOn(GetAsyncStorage, 'useGetAsyncStorage');
+});
+
+test('initial render writes selected account to async storage', async () => {
+  await renderHookInContext(accountId2);
+  expect(AsyncStorageMock.setItem).toBeCalledWith(
+    'selectedAccountId',
+    accountId2,
+  );
+});
+
+test('setAccountAccountId writes selected account to async storage', async () => {
+  const { result } = await renderHookInContext();
+  expect(AsyncStorageMock.setItem).toBeCalledWith(
+    'selectedAccountId',
+    accountId1,
+  );
+  await act(async () => {
+    result.current.setActiveAccountId(accountId2);
+  });
+  expect(AsyncStorageMock.setItem).toBeCalledWith(
+    'selectedAccountId',
+    accountId2,
+  );
 });

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -137,8 +137,12 @@ export const ActiveAccountContextProvider = ({
         accountsWithProduct,
         refetch,
         setActiveAccountId,
-        isLoading: accountsResult.isLoading || storedAccountResult.isLoading,
-        isFetched: accountsResult.isFetched && storedAccountResult.isFetched,
+        isLoading: !!(
+          accountsResult.isLoading || storedAccountResult.isLoading
+        ),
+        isFetched: !!(
+          accountsResult.isFetched && storedAccountResult.isFetched
+        ),
         error: accountsResult.error || storedAccountResult.error,
       }}
     >

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -138,8 +138,8 @@ export const ActiveAccountContextProvider = ({
         refetch,
         setActiveAccountId,
         isLoading: accountsResult.isLoading || storedAccountResult.isLoading,
-        isFetched: accountsResult.isFetched,
-        error: accountsResult.error,
+        isFetched: accountsResult.isFetched && storedAccountResult.isFetched,
+        error: accountsResult.error || storedAccountResult.error,
       }}
     >
       {children}

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -5,8 +5,10 @@ import React, {
   useContext,
   useCallback,
 } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Account, useAccounts } from './useAccounts';
 import { QueryObserverResult } from 'react-query';
+import { useGetAsyncStorage } from './useGetAsyncStorage';
 
 export type ActiveAccountProps = {
   account?: Account;
@@ -30,40 +32,58 @@ const ActiveAccountContext = createContext({
   isFetched: false,
 } as ActiveAccountContextProps);
 
-// TODO: add configuration for product to check
-const filterAccounts = (accounts?: Account[]) =>
+const selectedAccountIdKey = 'selectedAccountId';
+
+const filterNonLRAccounts = (accounts?: Account[]) =>
   accounts?.filter((a) => a.products?.indexOf('LR') > -1) || [];
+
+const getValidAccount = (validAccounts?: Account[], accountId?: string) => {
+  return validAccounts?.find((a) => a.id === accountId);
+};
 
 const getTrialExpired = (account: Account) =>
   account.type === 'FREE'
     ? !account.trialActive || new Date(account.trialEndDate) < new Date()
     : undefined;
 
-// TODO: allow for injecting account which is always used
 export const ActiveAccountContextProvider = ({
   children,
+  accountIdToSelect,
 }: {
   children?: React.ReactNode;
+  /** Force provider to select the available account
+   * that matches the specified account id.
+   * Uses first available account if not specified.
+   */
+  accountIdToSelect?: string;
 }) => {
   const accountsResult = useAccounts();
-  const [accountsWithProduct, setAccountsWithProduct] = useState<Account[]>([]);
+  const accountsWithProduct = filterNonLRAccounts(accountsResult.data);
   const [activeAccount, setActiveAccount] = useState<ActiveAccountProps>({});
+  const storedAccountResult = useGetAsyncStorage(selectedAccountIdKey);
+
+  const storeAccountId = useCallback(async (accountId: string) => {
+    await AsyncStorage.setItem(selectedAccountIdKey, accountId);
+  }, []);
 
   /**
    * Initial setting of activeAccount
    */
   useEffect(() => {
-    if (activeAccount?.account?.id) {
+    if (
+      storedAccountResult.isLoading || // wait for async storage result
+      activeAccount?.account?.id || // activeAccount already set
+      accountsWithProduct.length < 1 // no valid accounts found server side
+    ) {
       return;
     }
-    const filteredAccounts = filterAccounts(accountsResult.data);
-    if (filteredAccounts.length < 1) {
-      return;
-    }
-    setAccountsWithProduct(filteredAccounts);
 
-    // TODO: use previously-selected account logic
-    const selectedAccount = filteredAccounts[0];
+    const accountToSelect =
+      accountIdToSelect ?? storedAccountResult.data ?? undefined;
+
+    const selectedAccount =
+      getValidAccount(accountsWithProduct, accountToSelect) ??
+      accountsWithProduct[0];
 
     setActiveAccount({
       account: selectedAccount,
@@ -72,20 +92,24 @@ export const ActiveAccountContextProvider = ({
       },
       trialExpired: getTrialExpired(selectedAccount),
     });
-  }, [accountsResult.data, activeAccount?.account?.id]);
+    storeAccountId(selectedAccount.id);
+  }, [
+    accountsWithProduct,
+    activeAccount?.account?.id,
+    accountIdToSelect,
+    storeAccountId,
+    storedAccountResult.data,
+    storedAccountResult.isLoading,
+  ]);
 
   const setActiveAccountId = useCallback(
     async (accountId: string) => {
       try {
-        const selectedAccount = filterAccounts(accountsWithProduct).find(
-          (a) => a.id === accountId,
-        );
+        const selectedAccount = getValidAccount(accountsWithProduct, accountId);
         if (!selectedAccount) {
           console.warn('Ignoring attempt to set invalid accountId', accountId);
           return;
         }
-
-        // TODO: Save for previously-selected account logic
 
         setActiveAccount({
           account: selectedAccount,
@@ -94,11 +118,12 @@ export const ActiveAccountContextProvider = ({
           },
           trialExpired: getTrialExpired(selectedAccount),
         });
+        storeAccountId(selectedAccount.id);
       } catch (error) {
         console.warn('Unable to set active account', error);
       }
     },
-    [accountsWithProduct],
+    [accountsWithProduct, storeAccountId],
   );
 
   const refetch = useCallback(async () => {
@@ -112,7 +137,7 @@ export const ActiveAccountContextProvider = ({
         accountsWithProduct,
         refetch,
         setActiveAccountId,
-        isLoading: accountsResult.isLoading,
+        isLoading: accountsResult.isLoading || storedAccountResult.isLoading,
         isFetched: accountsResult.isFetched,
         error: accountsResult.error,
       }}

--- a/src/hooks/useGetAsyncStorage.ts
+++ b/src/hooks/useGetAsyncStorage.ts
@@ -1,0 +1,6 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useQuery } from 'react-query';
+
+export function useGetAsyncStorage(key: string) {
+  return useQuery('async-storage-get', () => AsyncStorage.getItem(key));
+}

--- a/src/hooks/useGetAsyncStorage.ts
+++ b/src/hooks/useGetAsyncStorage.ts
@@ -2,5 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useQuery } from 'react-query';
 
 export function useGetAsyncStorage(key: string) {
-  return useQuery('async-storage-get', () => AsyncStorage.getItem(key));
+  return useQuery<string | null>('async-storage-get', () =>
+    AsyncStorage.getItem(key),
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,6 +1750,13 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
+"@react-native-async-storage/async-storage@^1.17.11":
+  version "1.17.11"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
+  integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-debugger-ui@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-7.0.3.tgz#3eeeacc5a43513cbcae56e5e965d77726361bcb4"
@@ -5411,6 +5418,11 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -5782,6 +5794,13 @@ jest-message-util@^29.4.1:
     pretty-format "^29.4.1"
     slash "^3.0.0"
     stack-utils "^2.0.3"
+
+jest-mock-extended@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-3.0.3.tgz#570e33b099f8da87487acb4cd7d820712dcc3b52"
+  integrity sha512-yqpzvwFr2JWFArj4sPco4hPSanYH3erFgdkv7ahP8EMiAbVH+Rgjc8/cpAHJVG7+sZnQgl0AuTkxofD7eLJN+g==
+  dependencies:
+    ts-essentials "^7.0.3"
 
 jest-mock@^29.4.1:
   version "29.4.1"
@@ -6625,6 +6644,13 @@ meow@^8.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -9624,6 +9650,11 @@ ts-easing@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
   integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
+
+ts-essentials@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
 ts-jest@^29.0.5:
   version "29.0.5"


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Allow passing in accountId to provider to force an account selection. This takes priority over what is in async storage and also still honors the list of accounts returned from `/accounts`, i.e., if the specified account is not present an error is thrown. 
  - Reads and writes the selected accountId from async storage so selections persist between sessions
  - Add react-query wrapped get async storage hook to simplify usage