### PR TITLE
PHC-4075 - Improve test development

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': ['ts-jest', { diagnostics: false }],
   },
   testRunner: 'jest-circus/runner',
   testMatch: [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format:check": "yarn format --check",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "yarn lint --fix",
-    "test": "yarn jest",
+    "test": "tsc --noEmit && yarn jest",
     "test:ci": "yarn lint && yarn jest --coverage --runInBand --silent --ci --logHeapUsage",
     "build": "rm -rf dist && tsc -p tsconfig.build.json --outDir dist && cp package.json README.md ./dist",
     "precopyToStarter": "yarn build",

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -103,7 +103,12 @@ export const ActiveAccountContextProvider = ({
       try {
         const selectedAccount = getValidAccount(accountsWithProduct, accountId);
         if (!selectedAccount) {
-          console.warn('Ignoring attempt to set invalid accountId', accountId);
+          if (process.env.NODE_ENV !== 'test') {
+            console.warn(
+              'Ignoring attempt to set invalid accountId',
+              accountId,
+            );
+          }
           return;
         }
 
@@ -116,7 +121,9 @@ export const ActiveAccountContextProvider = ({
         });
         await setStoredAccountId(selectedAccount.id);
       } catch (error) {
-        console.warn('Unable to set active account', error);
+        if (process.env.NODE_ENV !== 'test') {
+          console.warn('Unable to set active account', error);
+        }
       }
     },
     [accountsWithProduct, setStoredAccountId],

--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -49,7 +49,9 @@ const findProjectAndSubjectById = (
   const selectedProject = projects?.find((p) => p.id === projectId);
   const selectedSubject = subjects?.find((s) => s.projectId === projectId);
   if (!selectedProject || !selectedSubject) {
-    console.warn('Ignoring attempt to set invalid projectId', projectId);
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn('Ignoring attempt to set invalid projectId', projectId);
+    }
     return getDefault();
   }
   return { selectedProject, selectedSubject };

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -80,7 +80,7 @@ export const AuthContextProvider = ({
 
   const refreshAuthResult = useCallback(
     async (_refreshHandler: RefreshHandler, _authResult: AuthResult) => {
-      if (__DEV__) {
+      if (__DEV__ && process.env.NODE_ENV !== 'test') {
         console.warn('Attempting access token refresh');
       }
       try {
@@ -93,7 +93,9 @@ export const AuthContextProvider = ({
           refreshToken: refreshResult.refreshToken || _authResult.refreshToken,
         });
       } catch (error) {
-        console.warn('Error occurred refreshing access token', error);
+        if (process.env.NODE_ENV !== 'test') {
+          console.warn('Error occurred refreshing access token', error);
+        }
         clearAuthResult();
       }
     },
@@ -116,7 +118,12 @@ export const AuthContextProvider = ({
           }
         }
       } catch (error) {
-        console.warn(error, 'Error occurred loading or refreshing auth token');
+        if (process.env.NODE_ENV !== 'test') {
+          console.warn(
+            error,
+            'Error occurred loading or refreshing auth token',
+          );
+        }
       }
       setLoading(false);
     },

--- a/src/hooks/useHttpClient.tsx
+++ b/src/hooks/useHttpClient.tsx
@@ -63,7 +63,7 @@ export const HttpClientContextProvider = ({
       undefined,
       async function (error: Error) {
         if (axios.isAxiosError(error)) {
-          if (__DEV__) {
+          if (__DEV__ && process.env.NODE_ENV !== 'test') {
             console.warn('Request Failed: ', error.toJSON());
           }
 

--- a/src/hooks/useOAuthFlow.tsx
+++ b/src/hooks/useOAuthFlow.tsx
@@ -51,7 +51,9 @@ export const OAuthContextProvider = ({
 
   // PKCE is required
   if (!authConfig.usePKCE) {
-    console.warn('NOTE: LifeOmic requires PKCE. Overriding to usePKCE=true');
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn('NOTE: LifeOmic requires PKCE. Overriding to usePKCE=true');
+    }
     authConfig.usePKCE = true;
   }
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Move TypeScript compilation step out of Jest so that tests can be run with `yarn jest` and not get TypeScript errors
  - Update `yarn test` to do a full build with `tsc --noEmit`
  - Add `process.env.NODE_ENV !== 'test'` conditional around `console.warn` statements to clean up test output

(Note, I tried adding `tsc --noEmit` to CI, but that ran into a bunch of errors because `example/**/*` isn't being built yet.)
