### PR TITLE
Add support for a simpleTheme prop that takes in 2 colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,56 @@ export default function App() {
 > beyond demonstration purposes. You will need to [contact us] to request an
 > OAuth client for your account.
 
+### Custom app tile screens
+
+```typescript
+import React, { FC } from 'react';
+import { authConfig } from './authConfig';
+import { MyCustomScreen } from './src/MyCustomScreen';
+import { RootProviders, RootStack } from '@lifeomic/react-native-sdk';
+
+export default function App() {
+  return (
+    <DeveloperConfigProvider
+      developerConfig={{
+        appTileScreens: {
+          'https://mydomain.com/mobile-app-tiles/my-app-tile': MyCustomScreen,
+        },
+      }}
+    >
+      <RootProviders authConfig={authConfig}>
+        <RootStack />
+      </RootProviders>
+    </DeveloperConfigProvider>
+  );
+}
+```
+
+### Simple custom theme via two colors
+
+```typescript
+import React, { FC } from 'react';
+import { authConfig } from './authConfig';
+import { RootProviders, RootStack } from '@lifeomic/react-native-sdk';
+
+export default function App() {
+  return (
+    <DeveloperConfigProvider
+      developerConfig={{
+        simpleTheme: {
+          primaryColor: '#fb5607',
+          accentColor: '#ffbe0b',
+        },
+      }}
+    >
+      <RootProviders authConfig={authConfig}>
+        <RootStack />
+      </RootProviders>
+    </DeveloperConfigProvider>
+  );
+}
+```
+
 ### Peer dependencies
 
 We may have more peer dependencies than is typical. We have run into a number of

--- a/example/AppDemo.tsx
+++ b/example/AppDemo.tsx
@@ -15,6 +15,10 @@ function App() {
           'https://lifeomic.com/mobile-app-tiles/fhir-example':
             FhirExampleScreen,
         },
+        simpleTheme: {
+          primaryColor: '#fb5607',
+          accentColor: '#ffbe0b',
+        },
       }}
     >
       <RootProviders authConfig={authConfig}>

--- a/example/storybook/stories/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp.stories.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { authConfig } from './OAuth.stories';
-import { RootProviders, RootStack } from 'src';
+import { DeveloperConfigProvider, RootProviders, RootStack } from 'src';
+import { withKnobs, color } from '@storybook/addon-knobs';
 
-storiesOf('Example App', module).add('DemoApp', () => (
-  <RootProviders authConfig={authConfig}>
-    <RootStack />
-  </RootProviders>
-));
+storiesOf('Example App', module)
+  .addDecorator(withKnobs)
+  .add('DemoApp', () => (
+    <DeveloperConfigProvider
+      developerConfig={{
+        simpleTheme: {
+          primaryColor: color('primaryColor', '#fb5607'),
+          accentColor: color('accentColor', '#ffbe0b'),
+        },
+      }}
+    >
+      <RootProviders authConfig={authConfig}>
+        <RootStack />
+      </RootProviders>
+    </DeveloperConfigProvider>
+  ));

--- a/src/common/DeveloperConfig.test.tsx
+++ b/src/common/DeveloperConfig.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { getCustomAppTileComponent } from './DeveloperConfig';
+
+describe('getCustomAppTileComponent', () => {
+  it('returns custom component if app tile matches', () => {
+    const CustomComponent = () => <></>;
+    const customAppTileComponent = getCustomAppTileComponent(
+      {
+        'http://unit-test/app-tile-1': CustomComponent,
+      },
+      {
+        id: 'app-tile-1',
+        title: 'test app tile',
+        source: {
+          url: 'http://unit-test/app-tile-1',
+        },
+      },
+    );
+    expect(customAppTileComponent).toEqual(CustomComponent);
+  });
+
+  it('returns undefined if app tile does not match', () => {
+    const CustomComponent = () => <></>;
+    const customAppTileComponent = getCustomAppTileComponent(
+      {
+        'http://unit-test/app-tile-2': CustomComponent,
+      },
+      {
+        id: 'app-tile-1',
+        title: 'test app tile',
+        source: {
+          url: 'http://unit-test/app-tile-1',
+        },
+      },
+    );
+    expect(customAppTileComponent).toBeUndefined();
+  });
+});

--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -5,12 +5,24 @@ import { AppTile } from '../hooks/useAppConfig';
  * DeveloperConfig provides a single interface to configure the app at build-time.
  * Unlike useAppConfig, which is populated at runtime via API, properties in this
  * type are provided at dev/build time.  Another way to think about it is this is a
- * high-level development interface for dev using RootProviders and RootStack.
+ * high-level development interface for devs using RootProviders and RootStack.
  *
- * NOTE: All props must be optional - see DeveloperConfigProvider
+ * NOTE: All props are optional, and DeveloperConfigProvider is not required in
+ * your app.
+ *
+ * @param appTileScreens Allows for custom screens to be registered to be launched
+ * when an app tile with a matching URL is tapped.
+ *
+ * @param simpleTheme Allows for configuring a theme via a primary and accent color.
  */
 export type DeveloperConfig = {
   appTileScreens?: AppTileScreens;
+  simpleTheme?: SimpleTheme;
+};
+
+export type SimpleTheme = {
+  primaryColor: string;
+  accentColor: string;
 };
 
 export type AppTileScreens = {

--- a/src/common/Notifications.ts
+++ b/src/common/Notifications.ts
@@ -24,7 +24,7 @@ export const registerDeviceToken = ({
     deviceToken,
     application,
   };
-  httpClient.post('/device-endpoints', params);
+  httpClient.post('/v1/device-endpoints', params);
 };
 
 export const getInitialNotification = () => {

--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -13,6 +13,7 @@ import Toast from 'react-native-toast-message';
 import { NoInternetToastProvider } from '../hooks/NoInternetToastProvider';
 import { BrandConfigProvider } from '../components/BrandConfigProvider';
 import { TrackTileProvider } from '../components/TrackTile/TrackTileProvider';
+import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
 
 const queryClient = new QueryClient();
 
@@ -23,6 +24,8 @@ export function RootProviders({
   authConfig: AuthConfiguration;
   children?: React.ReactNode;
 }) {
+  const { theme } = useDeveloperConfig();
+
   return (
     <QueryClientProvider client={queryClient}>
       <AuthContextProvider>
@@ -32,7 +35,7 @@ export function RootProviders({
               <ActiveAccountContextProvider>
                 <ActiveProjectContextProvider>
                   <TrackTileProvider>
-                    <BrandConfigProvider>
+                    <BrandConfigProvider theme={theme}>
                       <NoInternetToastProvider>
                         <SafeAreaProvider>
                           <ThemedNavigationContainer>

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,4 @@
+export * from './DeveloperConfig';
 export * from './init';
 export * from './LoggedInProviders';
 export * from './Notifications';

--- a/src/components/DeveloperConfigProvider.test.tsx
+++ b/src/components/DeveloperConfigProvider.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-native';
+import { DeveloperConfigProvider } from './DeveloperConfigProvider';
+import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
+import { DeveloperConfig } from '../common/DeveloperConfig';
+
+// NOTE: This file purposefully tests both useDeveloperConfig and
+// DeveloperConfigProvider.
+
+const renderHookInContext = async (developerConfig: DeveloperConfig) => {
+  return renderHook(() => useDeveloperConfig(), {
+    wrapper: ({ children }) => (
+      <DeveloperConfigProvider developerConfig={developerConfig}>
+        {children}
+      </DeveloperConfigProvider>
+    ),
+  });
+};
+
+test('default context allows provider to not be present in app', async () => {
+  const { result } = renderHook(() => useDeveloperConfig());
+  expect(result.current).toEqual({});
+});
+
+describe('with developerConfig injected into provider', () => {
+  test('allows for appTileScreens to be configured', async () => {
+    const appTileScreensConfig = {
+      'http://unit-test/app-tile-1': () => <></>,
+    };
+    const { result } = await renderHookInContext({
+      appTileScreens: appTileScreensConfig,
+    });
+    expect(result.current.appTileScreens).toEqual(appTileScreensConfig);
+  });
+
+  test('expands simpleTheme into theme prop', async () => {
+    const simpleTheme = {
+      primaryColor: '#000',
+      accentColor: '#fff',
+    };
+    const { result } = await renderHookInContext({
+      simpleTheme,
+    });
+    expect(result.current.theme).toEqual({
+      colors: {
+        primary: simpleTheme.primaryColor,
+        primaryContainer: simpleTheme.accentColor,
+      },
+    });
+  });
+});

--- a/src/components/DeveloperConfigProvider.tsx
+++ b/src/components/DeveloperConfigProvider.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
-import { DeveloperConfig } from 'src/common/DeveloperConfig';
+import { DeveloperConfig } from '../common/DeveloperConfig';
+import { ThemeProp } from './BrandConfigProvider';
+
+export type ExpandedDeveloperConfig = DeveloperConfig & {
+  theme?: ThemeProp;
+};
 
 // NOTE: An empty object should always be the default, so that
 // DeveloperConfigProvider doesn't _have_ to be present.  This
 // means all props must be optional.
-export const DeveloperConfigContext = React.createContext<DeveloperConfig>({});
+export const DeveloperConfigContext =
+  React.createContext<ExpandedDeveloperConfig>({});
 
 interface Props {
   developerConfig: DeveloperConfig;
@@ -12,8 +18,21 @@ interface Props {
 }
 
 export function DeveloperConfigProvider({ developerConfig, children }: Props) {
+  const expandedDevConfig: ExpandedDeveloperConfig = developerConfig;
+
+  // simpleTheme expansion to theme prop
+  if (developerConfig.simpleTheme) {
+    const { primaryColor, accentColor } = developerConfig.simpleTheme;
+    expandedDevConfig.theme = {
+      colors: {
+        primary: primaryColor,
+        primaryContainer: accentColor,
+      },
+    };
+  }
+
   return (
-    <DeveloperConfigContext.Provider value={developerConfig}>
+    <DeveloperConfigContext.Provider value={expandedDevConfig}>
       {children}
     </DeveloperConfigContext.Provider>
   );


### PR DESCRIPTION
This really opens the door to seeing which theme color props we're using and which we aren't (e.g. `primaryContainer`), and which components are utilizing theme props and which aren't yet.

This is (obviously) not fully baked in regards to components utilizing the simpleTheme as documented in @JayMoore75's doc.  This PR focuses primarily on the interface for providing a simple theme, and how it's consumed in `RootProviders`.  I considered consuming `useDeveloperConfig` from areas like `ThemeProvider` - but I think I like keeping those components dumb and not tied to DeveloperConfig.  The disadvantage is if a dev re-creates RootProviders, they'll need to also re-create `useDeveloperConfig` consumption.  I'm ok with this and think it matches how `DeveloperConfig` primarily targets devs/apps that _want_ to utilize `RootProviders` for its simplicity.  If we continue down that path, we can get better about documenting where each dev config prop is consumed.

https://user-images.githubusercontent.com/1445395/231596864-42466e20-76f1-4424-82bf-677f13f69945.mp4
