### PR TITLE
fix: Use relative paths for i18n imports

### DIFF
--- a/example/storybook/stories/TrackTile/TrackerDetails.stories.tsx
+++ b/example/storybook/stories/TrackTile/TrackerDetails.stories.tsx
@@ -9,7 +9,7 @@ import {
   TRACKER_CODE,
   TRACKER_CODE_SYSTEM,
 } from 'src/components/TrackTile/services/TrackTileService';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import { boolean, withKnobs, object } from '@storybook/addon-knobs';
 import { Anchor } from '@lifeomic/chromicons-native';
 import {

--- a/src/components/TrackTile/ManageTrackers/ManageTrackerRow.tsx
+++ b/src/components/TrackTile/ManageTrackers/ManageTrackerRow.tsx
@@ -6,7 +6,7 @@ import {
   StyleSheet,
   I18nManager,
 } from 'react-native';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import { Tracker } from '../services/TrackTileService';
 import Indicator from '../icons/indicator';
 import Chevron from '../icons/Chevron';

--- a/src/components/TrackTile/ManageTrackers/ManageTrackers.tsx
+++ b/src/components/TrackTile/ManageTrackers/ManageTrackers.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useState } from 'react';
 import { View, StyleSheet, ActivityIndicator, Switch } from 'react-native';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import { useStyleOverrides, StylesProp, NamedStyles, Text } from '../styles';
 import { Tracker, isInstalledMetric } from '../services/TrackTileService';
 import { useTrackers } from '../hooks/useTrackers';

--- a/src/components/TrackTile/OpenSettingsButton.tsx
+++ b/src/components/TrackTile/OpenSettingsButton.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { t } from '@i18n';
+import { t } from '../../../lib/i18n';
 import {
   TouchableOpacity,
   TouchableOpacityProps,

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
 } from 'react-native';
-import i18n, { Trans, t } from '@i18n';
+import i18n, { Trans, t } from '../../../../../lib/i18n';
 import {
   NamedStyles,
   StylesProp,

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/QuickAddItem.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/QuickAddItem.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { StylesProp, useFontOverrides, useStyleOverrides } from '../../styles';
 import { Code } from '../../services/TrackTileService';
-import { t } from '@i18n';
+import { t } from '../../../../../lib/i18n';
 
 export type QuickAddItemProps = {
   code: Code;

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/AdvancedTrackerEditor.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/AdvancedTrackerEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View, Text, FlatList } from 'react-native';
-import i18n, { t } from '@i18n';
+import i18n, { t } from '../../../../../lib/i18n';
 import { Trans } from 'react-i18next';
 import {
   StylesProp,

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/CodingSubCategoryRow.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/CodingSubCategoryRow.tsx
@@ -12,7 +12,7 @@ import { StylesProp, useFontOverrides, useStyleOverrides } from '../../styles';
 import { useFlattenedStyles } from '../../hooks/useFlattenedStyles';
 import { Code } from '../../services/TrackTileService';
 import { ChevronRight, ChevronLeft } from '@lifeomic/chromicons-native';
-import { t } from '@i18n';
+import { t } from '../../../../../lib/i18n';
 
 export type CodingSubCategoryRowProps = TouchableOpacityProps & {
   code: Code;

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/ValueEditor/ValueDisplay.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/ValueEditor/ValueDisplay.tsx
@@ -5,7 +5,7 @@ import {
   useFontOverrides,
   useStyleOverrides,
 } from '../../../styles';
-import { t } from '@i18n';
+import { t } from '../../../../../../lib/i18n';
 import { Tracker } from '../../../services/TrackTileService';
 
 type ValueDisplayProps = {

--- a/src/components/TrackTile/TrackerDetails/DatePicker.tsx
+++ b/src/components/TrackTile/TrackerDetails/DatePicker.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, View, TouchableOpacity } from 'react-native';
 import { StylesProp, useStyleOverrides, Text } from '../styles';
 import React, { Dispatch, FC, SetStateAction, useCallback } from 'react';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import { Tracker, UnitType } from '../services/TrackTileService';
 import { ChevronLeft, ChevronRight } from '@lifeomic/chromicons-native';
 import { addDays, format, isToday } from 'date-fns';

--- a/src/components/TrackTile/TrackerDetails/TrackAmountControl.tsx
+++ b/src/components/TrackTile/TrackerDetails/TrackAmountControl.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { View, StyleSheet, TouchableOpacity, TextInput } from 'react-native';
 import { StylesProp, useStyleOverrides, Text, fontWeights } from '../styles';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import { tID } from '../common/testID';
 import { coerceToNonnegativeValue } from './coerce-to-nonnegative-value';
 import { useFlattenedStyles } from '../hooks/useFlattenedStyles';

--- a/src/components/TrackTile/TrackerDetails/TrackerDetails.tsx
+++ b/src/components/TrackTile/TrackerDetails/TrackerDetails.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { View, StyleSheet, TextInput } from 'react-native';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import {
   NamedStyles,
   StylesProp,

--- a/src/components/TrackTile/TrackerDetails/TrackerHistoryChart/Chart.tsx
+++ b/src/components/TrackTile/TrackerDetails/TrackerHistoryChart/Chart.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View, ActivityIndicator } from 'react-native';
 import { StylesProp, useStyleOverrides, Text } from '../../styles';
 import { scaleLinear } from 'd3-scale';
 import { eachDayOfInterval, format, isToday } from 'date-fns';
-import { t } from '@i18n';
+import { t } from '../../../../../lib/i18n';
 import Bar from './Bar';
 import { tID } from '../../common/testID';
 import { numberFormatters, dateFormatters } from '../../formatters';

--- a/src/components/TrackTile/TrackerDetails/TrackerHistoryChart/Paginator.tsx
+++ b/src/components/TrackTile/TrackerDetails/TrackerHistoryChart/Paginator.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import { StyleSheet, View, TouchableOpacity, I18nManager } from 'react-native';
 import { useFlattenedStyles } from '../../hooks/useFlattenedStyles';
 import { StylesProp, useStyleOverrides, Text } from '../../styles';
-import { t } from '@i18n';
+import { t } from '../../../../../lib/i18n';
 import { tID } from '../../common/testID';
 import { dateFormatters } from '../../formatters';
 import { ChevronLeft, ChevronRight } from '@lifeomic/chromicons-native';

--- a/src/components/TrackTile/TrackerDetails/UnitPicker.tsx
+++ b/src/components/TrackTile/TrackerDetails/UnitPicker.tsx
@@ -8,7 +8,7 @@ import {
 import { StylesProp, useStyleOverrides, Text } from '../styles';
 import React, { FC, useCallback, useState } from 'react';
 import { Picker, PickerIOS } from '@react-native-picker/picker';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import { MetricType } from '../services/TrackTileService';
 import { useFlattenedStyles } from '../hooks/useFlattenedStyles';
 import { IosPickerIcon } from './IosPickerIcon';

--- a/src/components/TrackTile/TrackerDetails/unit-display.ts
+++ b/src/components/TrackTile/TrackerDetails/unit-display.ts
@@ -1,6 +1,6 @@
 import { Tracker, UnitType } from '../services/TrackTileService';
 import { convertToPreferredUnit } from '../util/convert-value';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 
 type UnitDisplayConfig = {
   value: number;

--- a/src/components/TrackTile/TrackerRow/Tracker.tsx
+++ b/src/components/TrackTile/TrackerRow/Tracker.tsx
@@ -4,7 +4,7 @@ import Indicator, { INDICATOR_HEIGHT } from '../icons/indicator';
 import { Tracker as TrackerType } from '../services/TrackTileService';
 import { StylesProp, useStyleOverrides, Text } from '../styles';
 import { RadialProgress } from './RadialProgress';
-import { t } from '@i18n';
+import { t } from '../../../../lib/i18n';
 import { useFlattenedStyles } from '../hooks/useFlattenedStyles';
 import { tID } from '../common/testID';
 import {

--- a/src/components/TrackTile/formatters/dateFormatter/index.ts
+++ b/src/components/TrackTile/formatters/dateFormatter/index.ts
@@ -1,4 +1,4 @@
-import { t } from '@i18n';
+import { t } from '../../../../../lib/i18n';
 import {
   shortMonthNumericDay,
   shortWeekday,

--- a/src/components/TrackTile/formatters/formatters.test.ts
+++ b/src/components/TrackTile/formatters/formatters.test.ts
@@ -1,4 +1,4 @@
-import i18n from '@i18n';
+import i18n from '../../../../lib/i18n';
 import { dateFormatters, numberFormatters } from '.';
 
 jest.unmock('i18next');

--- a/src/components/TrackTile/formatters/numberFormatter/index.ts
+++ b/src/components/TrackTile/formatters/numberFormatter/index.ts
@@ -1,4 +1,4 @@
-import { t } from '@i18n';
+import { t } from '../../../../../lib/i18n';
 
 const numberFormatters = {
   numberFormat: (value: number) =>

--- a/src/components/TrackTile/util/convert-value.test.ts
+++ b/src/components/TrackTile/util/convert-value.test.ts
@@ -1,4 +1,4 @@
-import i18n from '@i18n';
+import i18n from '../../../../lib/i18n';
 import {
   getPreferredUnitType,
   getStoredUnitType,

--- a/src/components/TrackTile/util/convert-value.ts
+++ b/src/components/TrackTile/util/convert-value.ts
@@ -1,4 +1,4 @@
-import i18n from '@i18n';
+import i18n from '../../../../lib/i18n';
 import { Tracker, UnitType } from '../services/TrackTileService';
 
 type Unit = 's' | 'min' | 'h' | string;

--- a/src/screens/TrackTileTrackerScreen.tsx
+++ b/src/screens/TrackTileTrackerScreen.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { TrackerDetails } from '../components/TrackTile/TrackerDetails/TrackerDetails';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { HomeStackParamList } from '../navigators/HomeStack';
-import { t } from '@i18n';
+import { t } from '../../lib/i18n';
 
 const styles = StyleSheet.create({
   container: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,6 @@
     "typeRoots": ["./node_modules/@types", "src/typings"],
     "paths": {
       "@styles": ["./src/components/BrandConfigProvider/styles/types"],
-      "@i18n": ["lib/i18n"],
-      "@i18n/*": ["lib/i18n/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Make it so we no longer need to add an alias to the metro configuration
  
## Screenshots
<!-- include screen recordings, if relevant to your changes -->