### PR TITLE
chore: Standardize route names based on stack

### DIFF
--- a/example/storybook/stories/CustomAppTileScreen.stories.tsx
+++ b/example/storybook/stories/CustomAppTileScreen.stories.tsx
@@ -54,7 +54,7 @@ function HomeScreen() {
               id="app-tile-invalid"
               title="Error 2"
               onPress={() => {
-                navigate('tiles/CustomAppTile', {
+                navigate('Home/CustomAppTile', {
                   appTile: {
                     id: 'app-tile-invalid',
                     title: 'Title 3',
@@ -76,7 +76,7 @@ function HomeScreen() {
             case.
           </Text>
           <Text>
-            Error 2 is an edge case where tiles/CustomAppTile is manually
+            Error 2 is an edge case where Home/CustomAppTile is manually
             navigated to with a bogus appTile configuration
           </Text>
         </View>
@@ -92,9 +92,9 @@ function HomeStack() {
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="tiles/AppTile" component={AppTileScreen} />
+        <Stack.Screen name="Home/AppTile" component={AppTileScreen} />
         <Stack.Screen
-          name="tiles/CustomAppTile"
+          name="Home/CustomAppTile"
           component={CustomAppTileScreen}
         />
       </Stack.Navigator>

--- a/src/components/tiles/TilesList.tsx
+++ b/src/components/tiles/TilesList.tsx
@@ -28,9 +28,9 @@ export function TilesList({ styles: instanceStyles }: Props) {
   const onAppTilePress = useCallback(
     (appTile: AppTile) => () => {
       if (getCustomAppTileComponent(appTileScreens, appTile)) {
-        navigate('tiles/CustomAppTile', { appTile });
+        navigate('Home/CustomAppTile', { appTile });
       } else {
-        navigate('tiles/AppTile', { appTile });
+        navigate('Home/AppTile', { appTile });
       }
     },
     [navigate, appTileScreens],
@@ -41,12 +41,12 @@ export function TilesList({ styles: instanceStyles }: Props) {
       {trackTileEnabled && (
         <TrackTile
           onOpenSettings={(valuesContext) =>
-            navigate('tiles/trackTileSettings', {
+            navigate('Home/TrackTileSettings', {
               valuesContext,
             })
           }
           onOpenTracker={(tracker, valuesContext) =>
-            navigate('tiles/TrackTile', {
+            navigate('Home/TrackTile', {
               tracker,
               valuesContext,
             })

--- a/src/navigators/HomeStack.tsx
+++ b/src/navigators/HomeStack.tsx
@@ -8,14 +8,14 @@ import { TrackTileTrackerScreen } from '../screens/TrackTileTrackerScreen';
 import { AppNavHeader } from '../components/AppNavHeader';
 import { TrackerValuesContext } from '../components/TrackTile/main';
 import TrackTileSettingsScreen from '../screens/TrackTileSettingsScreen';
-import { t } from '@i18n';
+import { t } from '../../lib/i18n';
 
 export type HomeStackParamList = {
   Home: undefined;
-  'tiles/AppTile': { appTile: AppTile };
-  'tiles/CustomAppTile': { appTile: AppTile };
-  'tiles/TrackTile': { tracker: any; valuesContext: any };
-  'tiles/trackTileSettings': {
+  'Home/AppTile': { appTile: AppTile };
+  'Home/CustomAppTile': { appTile: AppTile };
+  'Home/TrackTile': { tracker: any; valuesContext: any };
+  'Home/TrackTileSettings': {
     valuesContext: TrackerValuesContext;
   };
 };
@@ -30,17 +30,14 @@ export function HomeStack() {
       }}
     >
       <Stack.Screen name="Home" component={HomeScreen} />
-      <Stack.Screen name="tiles/AppTile" component={AppTileScreen} />
+      <Stack.Screen name="Home/AppTile" component={AppTileScreen} />
+      <Stack.Screen name="Home/CustomAppTile" component={CustomAppTileScreen} />
+      <Stack.Screen name="Home/TrackTile" component={TrackTileTrackerScreen} />
       <Stack.Screen
-        name="tiles/CustomAppTile"
-        component={CustomAppTileScreen}
-      />
-      <Stack.Screen
-        name="tiles/trackTileSettings"
+        name="Home/TrackTileSettings"
         component={TrackTileSettingsScreen}
         options={{ title: t('Track-It Items') }}
       />
-      <Stack.Screen name="tiles/TrackTile" component={TrackTileTrackerScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/navigators/SettingsStack.tsx
+++ b/src/navigators/SettingsStack.tsx
@@ -9,9 +9,9 @@ import WearablesScreen from '../screens/WearablesScreen';
 
 export type SettingsStackParamList = {
   Settings: undefined;
-  Profile: undefined;
-  AccountSelection: undefined;
-  Wearables: undefined;
+  'Settings/Profile': undefined;
+  'Settings/AccountSelection': undefined;
+  'Settings/Wearables': undefined;
 };
 
 const Stack = createNativeStackNavigator<SettingsStackParamList>();
@@ -25,19 +25,19 @@ export function SettingsStack() {
     >
       <Stack.Screen name="Settings" component={SettingsScreen} />
       <Stack.Screen
-        name="Profile"
+        name="Settings/Profile"
         component={ProfileScreen}
         options={{
           title: t('profile-screen-title', 'Profile'),
         }}
       />
       <Stack.Screen
-        name="AccountSelection"
+        name="Settings/AccountSelection"
         component={AccountSelectionScreen}
         options={{ title: t('account', 'Account') }}
       />
       <Stack.Screen
-        name="Wearables"
+        name="Settings/Wearables"
         component={WearablesScreen}
         options={{ title: t('sync-data', 'Sync Data') }}
       />

--- a/src/screens/AppTileScreen.tsx
+++ b/src/screens/AppTileScreen.tsx
@@ -3,7 +3,7 @@ import { WebView } from 'react-native-webview';
 import { HomeStackParamList } from '../navigators/HomeStack';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-type Props = NativeStackScreenProps<HomeStackParamList, 'tiles/AppTile'>;
+type Props = NativeStackScreenProps<HomeStackParamList, 'Home/AppTile'>;
 
 export const AppTileScreen = ({ navigation, route }: Props) => {
   const appTile = route.params.appTile;

--- a/src/screens/CustomAppTileScreen.tsx
+++ b/src/screens/CustomAppTileScreen.tsx
@@ -9,7 +9,7 @@ import { createStyles } from '../components/BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
 import { tID } from '../common/testID';
 
-type Props = NativeStackScreenProps<HomeStackParamList, 'tiles/CustomAppTile'>;
+type Props = NativeStackScreenProps<HomeStackParamList, 'Home/CustomAppTile'>;
 
 export const CustomAppTileScreen = ({ navigation, route }: Props) => {
   const { appTileScreens } = useDeveloperConfig();

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -79,7 +79,7 @@ test('handles app tile taps via navigation', async () => {
   const { getByTestId } = render(<HomeScreen />);
   const firstTile = exampleAppConfig.homeTab?.appTiles?.[0];
   fireEvent.press(getByTestId(`tile-button-${firstTile?.id}`));
-  expect(navigateMock).toHaveBeenCalledWith('tiles/AppTile', {
+  expect(navigateMock).toHaveBeenCalledWith('Home/AppTile', {
     appTile: firstTile,
   });
 });

--- a/src/screens/SettingsScreen.test.tsx
+++ b/src/screens/SettingsScreen.test.tsx
@@ -59,7 +59,7 @@ test('navigates to user profile', async () => {
   });
   fireEvent.press(getByText('Profile'));
 
-  expect(navigateMock).toHaveBeenCalledWith('Profile');
+  expect(navigateMock).toHaveBeenCalledWith('Settings/Profile');
 });
 
 test('navigates to account selection', async () => {
@@ -70,5 +70,5 @@ test('navigates to account selection', async () => {
   });
   fireEvent.press(getByText('Account Name'));
 
-  expect(navigateMock).toHaveBeenCalledWith('AccountSelection');
+  expect(navigateMock).toHaveBeenCalledWith('Settings/AccountSelection');
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -33,17 +33,17 @@ export const SettingsScreen = () => {
         <ScrollView style={styles.scroll}>
           <MainMenuItem
             title={t('settings-profile-row-title', 'Profile')}
-            action={() => navigate('Profile')}
+            action={() => navigate('Settings/Profile')}
           />
           <Divider />
           <MainMenuItem
             title={account?.name || t('settings-account-selection', 'Accounts')}
-            action={() => navigate('AccountSelection')}
+            action={() => navigate('Settings/AccountSelection')}
           />
           <Divider />
           <MainMenuItem
             title={t('settings-sync-data', 'Sync Data')}
-            action={() => navigate('Wearables')}
+            action={() => navigate('Settings/Wearables')}
           />
           <Divider />
         </ScrollView>

--- a/src/screens/TrackTileSettingsScreen.tsx
+++ b/src/screens/TrackTileSettingsScreen.tsx
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
 
 type Props = NativeStackScreenProps<
   HomeStackParamList,
-  'tiles/trackTileSettings'
+  'Home/TrackTileSettings'
 >;
 
 export const SettingsScreen = ({ navigation, route: { params } }: Props) => {
@@ -23,7 +23,7 @@ export const SettingsScreen = ({ navigation, route: { params } }: Props) => {
     <View style={styles.container}>
       <ManageTrackers
         onOpenTracker={(tracker) =>
-          navigation.navigate('tiles/TrackTile', {
+          navigation.navigate('Home/TrackTile', {
             valuesContext,
             tracker,
           })

--- a/src/screens/TrackTileTrackerScreen.tsx
+++ b/src/screens/TrackTileTrackerScreen.tsx
@@ -11,7 +11,7 @@ const styles = StyleSheet.create({
   },
 });
 
-type Props = NativeStackScreenProps<HomeStackParamList, 'tiles/TrackTile'>;
+type Props = NativeStackScreenProps<HomeStackParamList, 'Home/TrackTile'>;
 
 export const TrackTileTrackerScreen = ({
   navigation,


### PR DESCRIPTION
This addresses some feedback and fixes an incorrect import resulting (I think) from a merge error

## Changes
<!-- list your changes here -->
  - Fix import
  - Update route names to reflect their stack location