### PR TITLE
fix: PHC-4697 Remove double convert logic for Procedure trackers

### DIFF
--- a/src/components/TrackTile/TrackerRow/TrackerRow.tsx
+++ b/src/components/TrackTile/TrackerRow/TrackerRow.tsx
@@ -6,7 +6,6 @@ import {
   View,
 } from 'react-native';
 import { SvgProps } from 'react-native-svg';
-import { convertToPreferredUnit } from '../util/convert-value';
 import { tID } from '../common/testID';
 import {
   Tracker as TrackerType,
@@ -64,13 +63,12 @@ export function TrackerRow(props: TrackerRowProps) {
             <Tracker
               {...tracker}
               icons={icons}
-              value={convertToPreferredUnit(
+              value={
                 values[tracker.metricId ?? '']?.reduce(
                   (total, { value }) => total + value,
                   0,
-                ) ?? 0,
-                tracker,
-              )}
+                ) ?? 0
+              }
             />
           </TouchableOpacity>
         ))}
@@ -78,7 +76,7 @@ export function TrackerRow(props: TrackerRowProps) {
   );
 }
 
-const defaultStyles = createStyles('TrackerRowx', (theme) => ({
+const defaultStyles = createStyles('TrackerRow', (theme) => ({
   trackerRowLoadingIndicator: {
     height: 131,
     paddingHorizontal: theme.spacing.medium,


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes the double conversion issue. `Tracker` assumes values are the raw value. For Procedures, it assumes values are in seconds and then converts it to the display value. The `TrackerRow` was pre-converting the which resulted in double conversions.
  - Also fixes the name of the style to match the component

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

https://user-images.githubusercontent.com/2295908/234898043-d1ff30b7-e94c-4bc8-935e-51d0ee4a25ba.mov

