### PR TITLE
PHC-4621 - Update style and surfaces toward new design

### DIFF
--- a/src/components/ActivityIndicatorView.tsx
+++ b/src/components/ActivityIndicatorView.tsx
@@ -28,7 +28,7 @@ export function ActivityIndicatorView({
         size="large"
         animating
         testID={tID('activity-indicator-view')}
-        color={colors.primary}
+        color={colors.primarySource}
         {...props}
       />
       {timeOutMessage && showMessage() && (

--- a/src/components/AppNavHeader.tsx
+++ b/src/components/AppNavHeader.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { Appbar } from 'react-native-paper';
+import { Appbar, Text } from 'react-native-paper';
 import { NativeStackHeaderProps } from '@react-navigation/native-stack';
 import { createStyles } from './BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
+import { TextStyle } from 'react-native';
 
 export function AppNavHeader({
   back,
@@ -15,21 +16,35 @@ export function AppNavHeader({
   const title = options.title || route.name;
 
   return (
-    <Appbar.Header style={styles.style}>
+    <Appbar.Header style={styles.style} elevated>
       {back ? (
         <Appbar.BackAction
           onPress={navigation.goBack}
           style={styles.backAction}
         />
       ) : null}
-      <Appbar.Content title={title} style={styles.content} />
+      <Appbar.Content
+        title={<Title text={title} style={styles.titleText} />}
+        style={styles.content}
+      />
     </Appbar.Header>
   );
 }
 
-const defaultStyles = createStyles('AppNavHeader', () => ({
-  style: {},
+const Title = ({ text, style }: { text: string; style?: TextStyle }) => (
+  <Text variant="titleMedium" style={style}>
+    {text}
+  </Text>
+);
+
+const defaultStyles = createStyles('AppNavHeader', (theme) => ({
+  style: {
+    backgroundColor: '#fff',
+  },
   content: {},
+  titleText: {
+    color: theme.colors.onSurfaceVariant,
+  },
   backAction: {},
 }));
 

--- a/src/components/ScreenSurface.tsx
+++ b/src/components/ScreenSurface.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { Surface } from 'react-native-paper';
+import { createStyles } from './BrandConfigProvider';
+import { useStyles } from '../hooks/useStyles';
+import { ScrollView, View } from 'react-native';
+
+type Props = {
+  children?: React.ReactNode;
+  styles?: ScreenSurfaceStyles;
+} & React.ComponentProps<typeof Surface>;
+
+export function ScreenSurface({
+  children,
+  styles: instanceStyles,
+  ...props
+}: Props) {
+  const { styles } = useStyles(defaultStyles, instanceStyles);
+
+  return (
+    <Surface style={styles.surface} {...props}>
+      <ScrollView overScrollMode="always" showsVerticalScrollIndicator={false}>
+        <View style={styles.container}>{children}</View>
+      </ScrollView>
+    </Surface>
+  );
+}
+
+const defaultStyles = createStyles('ScreenSurface', (theme) => ({
+  surface: {
+    flex: 1,
+    backgroundColor: theme.colors.elevation.level1,
+  },
+  scrollView: {},
+  container: {
+    marginTop: theme.spacing.medium,
+    marginBottom: theme.spacing.extraLarge,
+  },
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}
+
+export type ScreenSurfaceStyles = NamedStylesProp<typeof defaultStyles>;

--- a/src/components/TrackTile/PillarsTile/Pillar.tsx
+++ b/src/components/TrackTile/PillarsTile/Pillar.tsx
@@ -219,7 +219,7 @@ export const Pillar: FC<PillarProps> = (props) => {
             CustomIcon={icons?.[metricId]}
             name={icon}
             color={hasMetGoal ? metGoalColor : notMetGoalColor}
-            scale={1.4}
+            scale={2.0}
           />
           <View style={styles.pillarBase}>
             <View style={styles.pillarBackground} />
@@ -302,7 +302,7 @@ export const Pillar: FC<PillarProps> = (props) => {
       <Text
         testID={tID(`pillar-value-${metricId}`)}
         variant="bold"
-        style={{ color, marginTop: 4 }}
+        style={{ color, marginTop: 4, fontSize: 22 }}
       >
         {currentValue}
       </Text>
@@ -317,14 +317,14 @@ export const Pillar: FC<PillarProps> = (props) => {
           CustomIcon={icons?.['pillars-add-data-button-icon']}
           name="plus-circle"
           color={color}
-          scale={1.3}
+          scale={2.2}
         />
       </TouchableOpacity>
     </View>
   );
 };
 
-const defaultPillarWidth = 32;
+const defaultPillarWidth = 40;
 
 const defaultStyles = StyleSheet.create({
   pillarViewWrapper: {

--- a/src/components/TrackTile/PillarsTile/PillarsTile.tsx
+++ b/src/components/TrackTile/PillarsTile/PillarsTile.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, View } from 'react-native';
 import { SvgProps } from 'react-native-svg';
 import { tID } from '../common/testID';
 import { useTrackers } from '../hooks/useTrackers';
@@ -11,9 +11,11 @@ import {
   TRACKER_PILLAR_CODE,
   TRACKER_PILLAR_CODE_SYSTEM,
 } from '../services/TrackTileService';
-import { NamedStyles, StylesProp, useStyleOverrides } from '../styles';
+import { NamedStyles, StylesProp } from '../styles';
 import { Pillar } from './Pillar';
 import { Card } from 'react-native-paper';
+import { createStyles } from '../../../components/BrandConfigProvider';
+import { useStyles } from '../../../hooks/useStyles';
 
 export interface Styles extends NamedStyles, StylesProp<typeof defaultStyles> {}
 
@@ -29,14 +31,16 @@ export type PillarsTileProps = {
   ) => void;
   background?: ReactNode;
   icons?: Record<string, React.ComponentType<SvgProps>>;
+  styles?: PillarsTileStyles;
 };
 
 export const PillarsTile = ({
   onOpenDetails,
   onSaveNewValueOverride,
   icons,
+  styles: instanceStyles,
 }: PillarsTileProps) => {
-  const styles = useStyleOverrides(defaultStyles);
+  const { styles } = useStyles(defaultStyles, instanceStyles);
   const valuesContext: TrackerValuesContext = {
     system: TRACKER_PILLAR_CODE_SYSTEM,
     codeBelow: TRACKER_PILLAR_CODE,
@@ -89,18 +93,26 @@ export const PillarsTile = ({
   );
 };
 
-const defaultStyles = StyleSheet.create({
+const defaultStyles = createStyles('PillarsTile', (theme) => ({
   pillarsTile: {
     overflow: 'hidden',
-    marginHorizontal: 24,
+    marginHorizontal: theme.spacing.medium,
+    backgroundColor: theme.colors.background,
   },
   pillarsTileBackgroundContainer: {
     flexDirection: 'row',
     justifyContent: 'center',
-    height: 326,
+    height: 395,
   },
   pillarsTileLoadingIndicator: {
     height: '100%',
     justifyContent: 'center',
   },
-});
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}
+
+export type PillarsTileStyles = NamedStylesProp<typeof defaultStyles>;

--- a/src/components/TrackTile/TrackTile.test.tsx
+++ b/src/components/TrackTile/TrackTile.test.tsx
@@ -94,7 +94,11 @@ describe('Track Tile', () => {
 
     const { findByLabelText } = render(
       <TrackTileProvider>
-        <TrackTile onOpenSettings={onOpenSettings} onOpenTracker={jest.fn()} />
+        <TrackTile
+          onOpenSettings={onOpenSettings}
+          onOpenTracker={jest.fn()}
+          title="Test Title"
+        />
       </TrackTileProvider>,
     );
 

--- a/src/components/TrackTile/TrackTile.tsx
+++ b/src/components/TrackTile/TrackTile.tsx
@@ -52,23 +52,23 @@ export function TrackTile({
   };
 
   return (
-    <Card style={styles.card}>
-      <Card.Title
-        title={title}
-        titleStyle={styles.titleText}
-        right={settingsButton}
-        rightStyle={styles.settingsButton}
-        style={styles.title}
-      />
-      <Card.Content style={styles.content}>
-        <TrackerRow
-          onOpenTracker={(tracker) => onOpenTracker(tracker, valuesContext)}
-          trackers={trackers}
-          values={trackerValues[0]}
-          loading={trackersLoading || valuesLoading}
-          icons={icons}
+    <Card elevation={0} style={styles.card}>
+      {title && (
+        <Card.Title
+          title={title}
+          titleStyle={styles.titleText}
+          right={settingsButton}
+          rightStyle={styles.settingsButton}
+          style={styles.title}
         />
-      </Card.Content>
+      )}
+      <TrackerRow
+        onOpenTracker={(tracker) => onOpenTracker(tracker, valuesContext)}
+        trackers={trackers}
+        values={trackerValues[0]}
+        loading={trackersLoading || valuesLoading}
+        icons={icons}
+      />
     </Card>
   );
 }
@@ -79,13 +79,13 @@ const defaultStyles = createStyles('TrackTile', (theme) => ({
   },
   titleText: {},
   card: {
-    margin: theme.spacing.large,
+    marginVertical: theme.spacing.large,
+    padding: 0,
   },
   settingsButton: {
     marginRight: theme.spacing.medium,
     marginTop: -8,
   },
-  content: {},
 }));
 
 declare module '@styles' {

--- a/src/components/TrackTile/TrackerRow/RadialProgress.tsx
+++ b/src/components/TrackTile/TrackerRow/RadialProgress.tsx
@@ -5,13 +5,14 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Animated, Easing, View, StyleSheet } from 'react-native';
+import { Animated, Easing, View, StyleSheet, ViewStyle } from 'react-native';
 import { Svg, Circle } from 'react-native-svg';
 import { useFlattenedStyles } from '../hooks/useFlattenedStyles';
 import { StylesProp, useStyleOverrides } from '../styles';
 import { usePrevious } from '../hooks/usePrevious';
 import { darkenHexColor } from '../util/darken-hex-color';
 import { useTheme } from '../../../hooks/useTheme';
+import { shadow } from 'react-native-paper';
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
@@ -26,7 +27,7 @@ type Props = {
 
 export const RadialProgress: FC<Props> = (props) => {
   const { target: incomingTarget, value } = props;
-  const { color = '', radius = 25, strokeWidth = 7, disabled = false } = props;
+  const { color = '', radius = 25, strokeWidth = 5, disabled = false } = props;
   const circumference = Math.PI * 2 * radius;
   const size = radius * 2 + strokeWidth;
   const target = incomingTarget || 1;
@@ -119,7 +120,7 @@ export const RadialProgress: FC<Props> = (props) => {
   ]);
 
   return (
-    <View style={{ position: 'relative' }}>
+    <View style={[{ position: 'relative' }, shadow(3) as ViewStyle]}>
       <Svg viewBox={`0 0 ${size} ${size}`}>
         <Circle
           stroke={flatStyles.trackerCircleBorder.borderColor}
@@ -166,7 +167,7 @@ export const RadialProgress: FC<Props> = (props) => {
             strokeLinecap="round"
             strokeDasharray={circumference}
             strokeDashoffset={ref.current}
-            fill={theme.colors.surfaceVariant}
+            fill={theme.colors.surface}
           />
         </Svg>
       )}
@@ -183,7 +184,7 @@ const defaultStyles = StyleSheet.create({
     opacity: 0.3,
   },
   trackerCircleBorder: {
-    borderWidth: 1,
+    borderWidth: 2,
     opacity: 0.4,
     borderColor: '#B2B9C0',
     backgroundColor: undefined,

--- a/src/components/TrackTile/TrackerRow/Tracker.tsx
+++ b/src/components/TrackTile/TrackerRow/Tracker.tsx
@@ -36,8 +36,8 @@ export function Tracker(tracker: TrackerProps) {
   const id = tracker.metricId || tracker.id;
 
   const scale = isInstalled
-    ? styles.trackerIconInstalledHeight?.height ?? 20
-    : styles.trackerIconInstalledUninstalledHeight?.height ?? 25;
+    ? styles.trackerIconInstalledHeight?.height ?? 30
+    : styles.trackerIconInstalledUninstalledHeight?.height ?? 35;
 
   return (
     <View style={styles.tracker}>
@@ -90,7 +90,7 @@ export function Tracker(tracker: TrackerProps) {
   );
 }
 
-const size = 70;
+const size = 95;
 const defaultStyles = createStyles('Tracker', (theme) => ({
   trackerNameText: {},
   trackerNameDisabledText: {
@@ -98,13 +98,12 @@ const defaultStyles = createStyles('Tracker', (theme) => ({
   },
   trackerUnitText: { fontSize: 10, color: '#7B8996' },
   trackerCurrentValueText: {
-    fontSize: 14,
-    color: theme.colors.onSurfaceVariant,
+    fontSize: 24,
+    color: theme.colors.onSurface,
     textAlign: 'center',
   },
   tracker: {
-    marginBottom: 8,
-    marginHorizontal: 10,
+    marginHorizontal: 8,
     alignItems: 'center',
     position: 'relative',
   },

--- a/src/components/TrackTile/TrackerRow/TrackerRow.tsx
+++ b/src/components/TrackTile/TrackerRow/TrackerRow.tsx
@@ -41,6 +41,7 @@ export function TrackerRow(props: TrackerRowProps) {
       horizontal
       scrollEnabled={true}
       contentContainerStyle={styles.trackerRowContainer}
+      showsHorizontalScrollIndicator={false}
     >
       {loading && (
         <View style={styles.trackerRowLoadingIndicator}>

--- a/src/components/tiles/Tile.tsx
+++ b/src/components/tiles/Tile.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Dimensions, TouchableOpacity, View } from 'react-native';
-import { Text } from 'react-native-paper';
+import { Dimensions, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { Text, shadow } from 'react-native-paper';
 import { useStyles } from '../../hooks/useStyles';
 import { createStyles } from '../BrandConfigProvider';
 import TileSelectIcon from './icons/tile-select-chevron.svg';
@@ -80,16 +80,10 @@ const defaultStyles = createStyles('Tile', (theme) => ({
     height: 55,
     borderRadius: 10,
     backgroundColor: theme.colors.surface,
-    shadowColor: theme.colors.shadow,
-    shadowOpacity: 0.1,
-    shadowOffset: {
-      height: 2,
-      width: 0,
-    },
-    shadowRadius: 8,
-    marginHorizontal: theme.spacing.large,
-    marginBottom: theme.spacing.extraSmall,
-  },
+    marginHorizontal: theme.spacing.medium,
+    marginBottom: theme.spacing.medium,
+    ...shadow(2),
+  } as ViewStyle,
   titleText: {
     ...theme.fonts.titleMedium,
     color: theme.colors.text,

--- a/src/components/tiles/TilesList.tsx
+++ b/src/components/tiles/TilesList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ScrollView, Image } from 'react-native';
+import { Image, View } from 'react-native';
 import { AppTile, useAppConfig } from '../../hooks/useAppConfig';
 import { tID } from '../../common';
 import { Tile, TileStyles } from './Tile';
@@ -8,7 +8,6 @@ import { useNavigation } from '@react-navigation/native';
 import { HomeScreenNavigation } from '../../screens/HomeScreen';
 import { useStyles, useDeveloperConfig } from '../../hooks';
 import { getCustomAppTileComponent } from '../../common/DeveloperConfig';
-import { spacing } from '../BrandConfigProvider/theme/base';
 import { createStyles } from '../BrandConfigProvider';
 import { SvgUri } from 'react-native-svg';
 import { PillarsTile } from '../TrackTile/PillarsTile/PillarsTile';
@@ -40,7 +39,7 @@ export function TilesList({ styles: instanceStyles }: Props) {
   );
 
   return (
-    <ScrollView testID={tID('tiles-list')} style={styles.scrollView}>
+    <View testID={tID('tiles-list')} style={styles.view}>
       {pillarsTileEnabled && (
         <PillarsTile
           onOpenDetails={(tracker, valuesContext) => {
@@ -81,7 +80,7 @@ export function TilesList({ styles: instanceStyles }: Props) {
           Icon={appTileIcon(appTile.icon)}
         />
       ))}
-    </ScrollView>
+    </View>
   );
 }
 
@@ -98,10 +97,7 @@ const appTileIcon = (uri?: string) =>
   };
 
 const defaultStyles = createStyles('TilesList', () => ({
-  scrollView: {
-    flexDirection: 'column',
-    marginBottom: spacing.extraLarge,
-  },
+  view: {},
 }));
 
 declare module '@styles' {

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -5,6 +5,11 @@ import { t } from 'i18next';
 import { SettingsStack, SettingsStackParamList } from './SettingsStack';
 import { HomeStack } from './HomeStack';
 import { NotificationsStack } from './NotificationsStack';
+import { useStyles } from '../hooks/useStyles';
+import { createStyles } from '../components/BrandConfigProvider';
+import { useTheme } from '../hooks/useTheme';
+import { shadow } from 'react-native-paper';
+import { ViewStyle } from 'react-native';
 
 export type TabParamList = {
   HomeTab: undefined;
@@ -15,8 +20,17 @@ export type TabParamList = {
 const Tab = createMaterialBottomTabNavigator<TabParamList>();
 
 export function TabNavigator() {
+  const { styles } = useStyles(defaultStyles);
+  const theme = useTheme();
+
   return (
-    <Tab.Navigator shifting={true}>
+    <Tab.Navigator
+      shifting={true}
+      barStyle={styles.barStyle}
+      activeColor={theme.colors.onSurface}
+      inactiveColor={theme.colors.onSurfaceDisabled}
+      labeled
+    >
       <Tab.Screen
         name="HomeTab"
         component={HomeStack}
@@ -45,3 +59,18 @@ export function TabNavigator() {
     </Tab.Navigator>
   );
 }
+
+const defaultStyles = createStyles('TabNavigator', () => ({
+  barStyle: {
+    backgroundColor: '#fff',
+    zIndex: 1,
+    ...shadow(4),
+  } as ViewStyle,
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}
+
+export type TabNavigatorStyles = NamedStylesProp<typeof defaultStyles>;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { t } from 'i18next';
 import { HomeStackParamList } from '../navigators/HomeStack';
@@ -7,6 +6,7 @@ import { useActiveAccount } from '../hooks/useActiveAccount';
 import { useAppConfig } from '../hooks/useAppConfig';
 import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
 import { TilesList } from '../components/tiles/TilesList';
+import { ScreenSurface } from '../components/ScreenSurface';
 
 type Props = NativeStackScreenProps<HomeStackParamList, 'Home'>;
 export type HomeScreenNavigation = Props['navigation'];
@@ -35,16 +35,8 @@ export const HomeScreen = () => {
   }
 
   return (
-    <View style={styles.container} testID="home-screen">
-      <ScrollView overScrollMode="always" showsVerticalScrollIndicator={false}>
-        <TilesList />
-      </ScrollView>
-    </View>
+    <ScreenSurface testID="home-screen">
+      <TilesList />
+    </ScreenSurface>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Add elevated light style to the header and tab navigation
  - Smaller and more relaxed title typography
  - Fixed issue with nested ScrollView in both TileList and HomeScreen.  Replaced with new ScreenSurface.
  - New ScreenSurface component.   This is meant to be the base of any scrolling screen like notifications or settings, but just focused on the home screen in this PR
  - Tweaked Pillar and TrackTile styles to be more like PMA
  - Updated to our createStyles/useStyles system in a couple components where it made sense as I was adjusting default styles

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

# before
https://user-images.githubusercontent.com/220893/235037731-03dc8419-3ecd-4845-b9a0-70a9c32d3db0.mov

# after


https://user-images.githubusercontent.com/220893/235037776-98c5d8e6-a8d1-409e-b75d-579542b7a3df.mov


