### PR TITLE
chore: Load initial state from async storage

### DIFF
--- a/src/hooks/useEnvironmentSelection.tsx
+++ b/src/hooks/useEnvironmentSelection.tsx
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useEffect, useState } from 'react';
 import { NativeEventEmitter } from 'react-native';
 
@@ -13,6 +14,13 @@ export const emitEnvironmentToggled = (value: string) =>
 
 export const useEnvironmentSelection = () => {
   const [usePrimaryEnvironment, setUsePrimaryEnvironment] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const environment = await AsyncStorage.getItem('environment-toggle');
+      setUsePrimaryEnvironment(environment !== 'secondary');
+    })();
+  }, []);
 
   useEffect(() => {
     const subscription = eventEmitter.addListener(


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
In the event you load straight into the app and never render the EnvironmentSelection toggle, the useEnvironmentSelection hook would default to using the primary environment. This fixes the hook to sync with the value in async storage.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->