### PR TITLE
PHC-4621 - Update pillar styles

### DIFF
--- a/src/components/TrackTile/PillarsTile/PillarsTile.tsx
+++ b/src/components/TrackTile/PillarsTile/PillarsTile.tsx
@@ -103,7 +103,7 @@ const defaultStyles = createStyles('PillarsTile', (theme) => ({
   pillarsTileBackgroundContainer: {
     flexDirection: 'row',
     justifyContent: 'center',
-    height: 395,
+    height: 404,
   },
   pillarsTileLoadingIndicator: {
     height: '100%',

--- a/src/components/TrackTile/icons/indicator/index.tsx
+++ b/src/components/TrackTile/icons/indicator/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { ColorValue, View } from 'react-native';
 import { SvgProps } from 'react-native-svg';
 import {
   Alcohol,
@@ -30,7 +30,7 @@ import {
 
 type IndicatorProps = {
   name: string;
-  color?: string;
+  color?: ColorValue;
   scale?: number;
   CustomIcon?: React.ComponentType<SvgProps>;
 };
@@ -59,9 +59,9 @@ const Indicator = ({
       {(!!CustomIcon && <CustomIcon {...svgProps} />) ||
         ({
           apple: <Apple {...svgProps} />,
-          'broccoli': <Broccoli {...svgProps} />,
+          broccoli: <Broccoli {...svgProps} />,
           'book-open': <BookOpen {...svgProps} />,
-          'check': <Check {...svgProps} />,
+          check: <Check {...svgProps} />,
           chroma: <Chroma {...svgProps} />,
           'clock-forward': <ClockForward {...svgProps} />,
           cocktail: <Alcohol {...svgProps} />,


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Make pillars tile slightly taller
  - Update margins on either side of pillars and between icons/text
  - Update pillar background color
  - Tighten up pillars
  - Make icons smaller
  - Make text under pillars smaller
  - Use createStyles 

## Reference from App Store PMA

<img width="362" alt="Screenshot 2023-05-03 at 1 24 25 PM" src="https://user-images.githubusercontent.com/220893/235995119-fb79e829-850b-4d42-921e-22121ca62388.png">

| Before | After |
| - | - | 
| ![image](https://user-images.githubusercontent.com/220893/235991866-a5bed589-5597-4c0a-99c3-8743d468b182.png) | ![image](https://user-images.githubusercontent.com/220893/235991365-1492e199-387a-4a78-8b46-689ebcf3b020.png) | 
