### PR TITLE
Allow and detect custom app tiles with bundleId

### DIFF
--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.lifeomic.components-app";
 				PRODUCT_NAME = example;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -528,7 +528,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.lifeomic.components-app";
 				PRODUCT_NAME = example;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,7 +1,10 @@
 import mockDeviceInfo from 'react-native-device-info/jest/react-native-device-info-mock';
 import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock';
 
-jest.mock('react-native-device-info', () => mockDeviceInfo);
+jest.mock('react-native-device-info', () => ({
+  ...mockDeviceInfo,
+  getBundleId: () => 'com.unit-test.app',
+}));
 
 jest.mock('./src/common/testID', () => ({
   tID: (id: string) => id,

--- a/src/common/DeveloperConfig.test.tsx
+++ b/src/common/DeveloperConfig.test.tsx
@@ -19,7 +19,7 @@ describe('getCustomAppTileComponent', () => {
     expect(customAppTileComponent).toEqual(CustomComponent);
   });
 
-  it('returns undefined if app tile does not match', () => {
+  it('returns false if app tile does not match', () => {
     const CustomComponent = () => <></>;
     const customAppTileComponent = getCustomAppTileComponent(
       {
@@ -33,6 +33,21 @@ describe('getCustomAppTileComponent', () => {
         },
       },
     );
-    expect(customAppTileComponent).toBeUndefined();
+    expect(customAppTileComponent).toBe(false);
+  });
+
+  it('returns true if url starts with bundleId, even if not configured', () => {
+    const bundleId = 'com.unit-test.app'; // NOTE: the bundleId from react-native-device-info mock
+    const customAppTileComponent = getCustomAppTileComponent(
+      {},
+      {
+        id: 'app-tile-1',
+        title: 'test app tile',
+        source: {
+          url: `${bundleId}://custom-screen`,
+        },
+      },
+    );
+    expect(customAppTileComponent).toBe(true);
   });
 });

--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -1,4 +1,5 @@
 import { ComponentType } from 'react';
+import { getBundleId } from 'react-native-device-info';
 import { AppTile } from '../hooks/useAppConfig';
 
 /**
@@ -36,5 +37,9 @@ export function getCustomAppTileComponent(
   appTileScreens?: AppTileScreens,
   appTile?: AppTile,
 ) {
-  return !!appTile?.source.url && appTileScreens?.[appTile.source.url];
+  return (
+    !!appTile?.source.url &&
+    (appTileScreens?.[appTile.source.url] ||
+      appTile.source.url.startsWith(getBundleId()))
+  );
 }

--- a/src/screens/CustomAppTileScreen.tsx
+++ b/src/screens/CustomAppTileScreen.tsx
@@ -26,7 +26,7 @@ export const CustomAppTileScreen = ({
     });
   }, [navigation, route.params.appTile.title]);
 
-  if (CustomAppTileComponent) {
+  if (typeof CustomAppTileComponent !== 'boolean') {
     return <CustomAppTileComponent />;
   }
 
@@ -47,6 +47,7 @@ const defaultStyles = createStyles('CustomAppTileScreen', (theme) => ({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    paddingHorizontal: theme.spacing.medium,
   },
   errorLabel: {
     textAlign: 'center',


### PR DESCRIPTION
This makes it so that, if you configure an app tile with a bundle id like `com.lifeomic.components-app://device-config` (in this app's example), and that URL is NOT configured in `developerConfig`, then it'll show an error screen (below) instead of attempting to load the URL in a browser.

![Simulator Screen Shot - iPhone 14 Pro - 2023-05-16 at 10 59 14](https://github.com/lifeomic/react-native-sdk/assets/1445395/d123a7c5-02ed-44fe-a4da-7e08db78b307)
