### PR TITLE
fix: Add Script to Fix Declared Styles for Deployment

### DIFF
--- a/bin/scripts/buildDeclaredStyles.js
+++ b/bin/scripts/buildDeclaredStyles.js
@@ -1,0 +1,66 @@
+const path = require('path');
+const fs = require('fs');
+
+function getFilesRecursively(dir) {
+  try {
+    return fs.readdirSync(dir).flatMap((file) => {
+      const absolute = path.join(dir, file);
+
+      if (fs.statSync(absolute).isDirectory())
+        return getFilesRecursively(absolute);
+
+      return absolute;
+    });
+  } catch {
+    return []; // directory does not exist
+  }
+}
+
+try {
+  const distDir = path.join(__dirname, '../../dist');
+  const styleTypeFile = path.resolve(
+    distDir,
+    'src/components/BrandConfigProvider/styles/types.d.ts',
+  );
+  const distFiles = getFilesRecursively(distDir);
+
+  const filesWithDeclaredStyle = distFiles.filter(
+    (file) =>
+      file.endsWith('.d.ts') &&
+      fs.readFileSync(file).toString().includes("declare module '@styles'"),
+  );
+
+  if (filesWithDeclaredStyle.length) {
+    filesWithDeclaredStyle.forEach((file) => {
+      const relPath = path
+        .relative(file, styleTypeFile)
+        .replace('.d.ts', '')
+        .replace('../', './');
+      const fileContents = fs.readFileSync(file).toString();
+      fs.writeFileSync(
+        file,
+        fileContents.replace(
+          "declare module '@styles'",
+          `declare module '${relPath}'`,
+        ),
+      );
+    });
+
+    const fileImports = filesWithDeclaredStyle
+      .map(
+        (file) =>
+          `import './${path.relative(distDir, file).replace('.d.ts', '')}';`,
+      )
+      .join('\n');
+
+    fs.appendFileSync(
+      path.resolve(distDir, 'index.d.ts'),
+      `\n// Components with declared style\n${fileImports}\n`,
+    );
+  }
+
+  process.exit(0);
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "lint:fix": "yarn lint --fix",
     "test": "tsc --noEmit && yarn jest",
     "test:ci": "yarn lint && yarn jest --coverage --runInBand --silent --ci --logHeapUsage --forceExit",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json --outDir dist && yarn copyAdditionalFiles",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json --outDir dist && yarn copyAdditionalFiles && yarn buildDeclaredStyles",
     "precopyToStarter": "yarn build",
     "copyToStarter": "cp -r ./dist/ ../react-native-starter/node_modules/@lifeomic/react-native-sdk",
-    "copyAdditionalFiles": "./bin/scripts/copyAdditionalFiles"
+    "copyAdditionalFiles": "./bin/scripts/copyAdditionalFiles",
+    "buildDeclaredStyles": "node ./bin/scripts/buildDeclaredStyles.js"
   },
   "author": "LifeOmic <development@lifeomic.com>",
   "license": "MIT",


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds a script that:
    - Updates all `declare module '@styles'` to be `declare module '<relative path to BrandConfigProvider/styles/types>'`
    - Adds an import to the `dist/index.d.ts` file to include the declared styles

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><b>Before
 <td><b>After
<tr>
 <td><img src="https://github.com/lifeomic/react-native-sdk/assets/2295908/a1ef238b-3819-4739-9e7d-b9cc5034c0ab" />
 <td><img src="https://github.com/lifeomic/react-native-sdk/assets/2295908/15b43b9b-7029-4761-9a39-cc261becad7d" />
</table>
