### PR TITLE
chore: Handle auth error

### DIFF
--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,19 +1,61 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { View } from 'react-native';
 import { t } from 'i18next';
 import { OAuthLoginButton } from '../components/OAuthLoginButton';
 import { useStyles } from '../hooks/useStyles';
-import { createStyles } from '../components/BrandConfigProvider';
+import { createStyles, useIcons } from '../components/BrandConfigProvider';
 import { EnvironmentSelection } from '../components/EnvironmentSelection';
+import { Dialog, Portal, Text } from 'react-native-paper';
 
 export const LoginScreen: FC = () => {
   const { styles } = useStyles(defaultStyles);
+  const [visible, setVisible] = useState(false);
+  const [errorText, setErrorText] = useState('');
+  const { AlertTriangle } = useIcons();
+  const hideDialog = () => {
+    setVisible(false);
+    setErrorText('');
+  };
+
+  const onFail = (error: any) => {
+    const errorString: string = error.toString();
+    if (errorString.includes('User cancelled flow')) {
+      return;
+    }
+
+    if (__DEV__) {
+      setErrorText(errorString);
+    } else {
+      setErrorText(
+        t(
+          'login-error-message',
+          'We encountered an error trying to log you in.',
+        ),
+      );
+    }
+    setVisible(true);
+  };
+
   return (
     <>
       <View style={styles.containerView}>
-        <OAuthLoginButton label={t('login-button-title', 'Login')} />
+        <OAuthLoginButton
+          label={t('login-button-title', 'Login')}
+          onFail={onFail}
+        />
         <EnvironmentSelection />
       </View>
+      <Portal>
+        <Dialog visible={visible} onDismiss={hideDialog}>
+          <Dialog.Icon icon={AlertTriangle} />
+          <Dialog.Title>
+            {t('login-error-title', 'Authentication Error')}
+          </Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">{errorText}</Text>
+          </Dialog.Content>
+        </Dialog>
+      </Portal>
     </>
   );
 };


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Show dialog when auth fails instead of silently navigating back to the login screen
  - Only reveal error text in __DEV__ mode otherwise show generic message

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<img width="291" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/76954025/c8a8238c-f63d-4cba-aa52-f47f67c6dcda">
