### PR TITLE
[PE-124] Update TrackerDetails to accept reference date

### DIFF
--- a/example/storybook/stories/TrackTile/AdvancedTrackerDetails.stories.tsx
+++ b/example/storybook/stories/TrackTile/AdvancedTrackerDetails.stories.tsx
@@ -7,7 +7,7 @@ import {
   TRACKER_PILLAR_CODE,
   TRACKER_PILLAR_CODE_SYSTEM,
 } from '../../../../src/components/TrackTile/services/TrackTileService';
-import { select, withKnobs } from '@storybook/addon-knobs';
+import { date, select, withKnobs } from '@storybook/addon-knobs';
 import { activity, mindful, nutrition, sleep } from './util/ontologies';
 
 const ontology = {} as any;
@@ -23,6 +23,7 @@ storiesOf('AdvancedTrackerDetails', module)
       ['Healthy Plants', 'Activity', 'Mindfulness', 'Sleep'],
       'Healthy Plants',
     );
+    const referenceDate = date('Reference Date', undefined);
 
     Object.assign(ontology, nutrition);
     let color = '#33C317';
@@ -141,6 +142,10 @@ storiesOf('AdvancedTrackerDetails', module)
           system: TRACKER_PILLAR_CODE_SYSTEM,
           codeBelow: TRACKER_PILLAR_CODE,
         }}
+        referenceDate={new Date(referenceDate)}
+        // NOTE: This should not be necessary in production apps where the referenceDate prop does not change on the fly.
+        // https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes
+        key={referenceDate}
       />
     );
   });

--- a/example/storybook/stories/TrackTile/TrackerDetails.stories.tsx
+++ b/example/storybook/stories/TrackTile/TrackerDetails.stories.tsx
@@ -10,7 +10,7 @@ import {
   TRACKER_CODE_SYSTEM,
 } from '../../../../src/components/TrackTile/services/TrackTileService';
 import { t } from '../../../../lib/i18n';
-import { boolean, withKnobs, object } from '@storybook/addon-knobs';
+import { boolean, withKnobs, object, date } from '@storybook/addon-knobs';
 import { Anchor } from '@lifeomic/chromicons-native';
 import {
   UnitPicker,
@@ -33,6 +33,7 @@ storiesOf('TrackerDetails', module)
     })(storyFn, context),
   )
   .add('default', () => {
+    const referenceDate = date('Reference Date', undefined);
     return (
       <IconProvider
         icons={
@@ -79,6 +80,10 @@ storiesOf('TrackerDetails', module)
             system: TRACKER_CODE_SYSTEM,
             codeBelow: TRACKER_CODE,
           }}
+          referenceDate={new Date(referenceDate)}
+          // NOTE: This should not be necessary in production apps where the referenceDate prop does not change on the fly.
+          // https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes
+          key={referenceDate}
         />
       </IconProvider>
     );

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.test.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.test.tsx
@@ -294,6 +294,39 @@ describe('Tracker Advanced Details', () => {
     ).toBeDefined();
   });
 
+  it('should render from referenceDate when provided', async () => {
+    mockUseTrackerValues.mockReturnValue({
+      loading: false,
+      trackerValues: [{}],
+    } as any);
+
+    const upsertTrackerResource = jest.fn();
+    const fetchOntology = jest.fn().mockResolvedValue([]);
+    const onError = jest.fn();
+    const referenceDate = new Date('2023-03-17T03:24:00');
+
+    const { findByText } = render(
+      <AdvancedTrackerDetailsProvider
+        trackTileService={{ upsertTrackerResource, fetchOntology } as any}
+        tracker={
+          {
+            id: 'tracker-id',
+            metricId: 'metric-id',
+            resourceType: 'Observation',
+            units: [{ display: 'Servings', target: 5, unit: 'unit' }],
+          } as any
+        }
+        valuesContext={valuesContext}
+        onEditValue={jest.fn()}
+        onError={onError}
+        referenceDate={referenceDate}
+      />,
+    );
+
+    await findByText('Friday, March 17');
+    await findByText('Mar 11, 2023 - Mar 17, 2023 ');
+  });
+
   it('calls onEditValue when tapping on a value row', async () => {
     const trackerValue = {
       id: 'first-value',

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.test.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.test.tsx
@@ -8,7 +8,7 @@ import {
   TRACKER_CODE_SYSTEM,
   Tracker,
 } from '../../services/TrackTileService';
-import { addDays, format } from 'date-fns';
+import { add, addDays, endOfWeek, format, startOfWeek } from 'date-fns';
 import { useRecentCodedValues } from '../../hooks/useRecentCodedValues';
 import { notifier } from '../../services/EmitterService';
 
@@ -324,7 +324,46 @@ describe('Tracker Advanced Details', () => {
     );
 
     await findByText('Friday, March 17');
-    await findByText('Mar 11, 2023 - Mar 17, 2023 ');
+    await findByText('Mar 13, 2023 - Mar 19, 2023');
+  });
+
+  it('should NOT render from referenceDate in the future', async () => {
+    mockUseTrackerValues.mockReturnValue({
+      loading: false,
+      trackerValues: [{}],
+    } as any);
+
+    const upsertTrackerResource = jest.fn();
+    const fetchOntology = jest.fn().mockResolvedValue([]);
+    const onError = jest.fn();
+    const now = new Date();
+    const referenceDate = add(now, { months: 2 });
+
+    const { findByText } = render(
+      <AdvancedTrackerDetailsProvider
+        trackTileService={{ upsertTrackerResource, fetchOntology } as any}
+        tracker={
+          {
+            id: 'tracker-id',
+            metricId: 'metric-id',
+            resourceType: 'Observation',
+            units: [{ display: 'Servings', target: 5, unit: 'unit' }],
+          } as any
+        }
+        valuesContext={valuesContext}
+        onEditValue={jest.fn()}
+        onError={onError}
+        referenceDate={referenceDate}
+      />,
+    );
+
+    await findByText("Today's Servings");
+    await findByText(
+      `${format(startOfWeek(now, { weekStartsOn: 1 }), 'MMM d, Y')} - ${format(
+        endOfWeek(now, { weekStartsOn: 1 }),
+        'MMM d, Y',
+      )}`,
+    );
   });
 
   it('calls onEditValue when tapping on a value row', async () => {

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
@@ -25,7 +25,13 @@ import {
   getStoredUnitType,
 } from '../../util/convert-value';
 import { numberFormatters } from '../../formatters';
-import { addDays, endOfToday, startOfToday, isBefore } from 'date-fns';
+import {
+  addDays,
+  startOfToday,
+  isBefore,
+  startOfDay,
+  endOfDay,
+} from 'date-fns';
 import { toFhirResource } from '../to-fhir-resource';
 import { throttle, flattenDepth } from 'lodash';
 import { notifier } from '../../services/EmitterService';
@@ -48,6 +54,7 @@ export type AdvancedTrackerDetailsProps = {
   onEditValue: (value: TrackerValue) => void;
   children?: React.ReactNode;
   editsDisabledAfterNumberOfDays?: number;
+  referenceDate?: Date;
 };
 
 const { numberFormat } = numberFormatters;
@@ -68,14 +75,24 @@ const extractCodeImage = (
 
 export const AdvancedTrackerDetails = (props: AdvancedTrackerDetailsProps) => {
   const { children, editsDisabledAfterNumberOfDays = 7 } = props;
-  const { tracker, icons = {}, valuesContext, onEditValue, onError } = props;
+  const {
+    tracker,
+    icons = {},
+    valuesContext,
+    onEditValue,
+    onError,
+    referenceDate: incomingReferenceDate,
+  } = props;
   const defaultUnit = getStoredUnitType(tracker);
   const { styles } = useStyles(defaultStyles);
   const fontWeights = useFontOverrides();
   const svc = useTrackTileService();
-  const [dateRange, setDateRange] = useState({
-    start: startOfToday(),
-    end: endOfToday(),
+  const [dateRange, setDateRange] = useState(() => {
+    const referenceDate = incomingReferenceDate ?? Date.now();
+    return {
+      start: startOfDay(referenceDate),
+      end: endOfDay(referenceDate),
+    };
   });
   const {
     trackerValues: [activeValues],
@@ -403,6 +420,7 @@ export const AdvancedTrackerDetails = (props: AdvancedTrackerDetailsProps) => {
             tracker={tracker}
             valuesContext={valuesContext}
             dateRangeType="calendarWeek"
+            referenceDate={dateRange.start}
           />
         </View>
       </View>

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
@@ -88,7 +88,11 @@ export const AdvancedTrackerDetails = (props: AdvancedTrackerDetailsProps) => {
   const fontWeights = useFontOverrides();
   const svc = useTrackTileService();
   const [dateRange, setDateRange] = useState(() => {
-    const referenceDate = incomingReferenceDate ?? Date.now();
+    const referenceDate =
+      incomingReferenceDate && isBefore(incomingReferenceDate, new Date())
+        ? incomingReferenceDate
+        : new Date();
+
     return {
       start: startOfDay(referenceDate),
       end: endOfDay(referenceDate),

--- a/src/components/TrackTile/TrackerDetails/TrackerDetails.test.tsx
+++ b/src/components/TrackTile/TrackerDetails/TrackerDetails.test.tsx
@@ -270,6 +270,40 @@ describe('Tracker Details', () => {
     );
   });
 
+  it('should render from referenceDate when provided', async () => {
+    mockUseTrackerValues.mockReturnValue({
+      loading: false,
+      trackerValues: [{}],
+    } as any);
+
+    const upsertTrackerResource = jest.fn();
+    const referenceDate = new Date('2023-03-17T03:24:00');
+
+    const { findByText } = render(
+      <TrackerDetailsProvider
+        trackTileService={
+          {
+            datastoreSettings: {},
+            upsertTrackerResource,
+            upsertTracker: jest.fn(),
+          } as any
+        }
+        tracker={
+          {
+            id: 'metric-id',
+            resourceType: 'Observation',
+            units: [{ display: '', target: 5, unit: 'unit' }],
+          } as any
+        }
+        valuesContext={valuesContext}
+        referenceDate={referenceDate}
+      />,
+    );
+
+    await findByText('Friday, March 17');
+    await findByText('Mar 11, 2023 - Mar 17, 2023 ');
+  });
+
   it('should allow decrementing across multiple observations', async () => {
     const notifierSpy = jest.spyOn(notifier, 'emit');
     mockUseTrackerValues.mockReturnValue({

--- a/src/components/TrackTile/TrackerDetails/TrackerDetails.tsx
+++ b/src/components/TrackTile/TrackerDetails/TrackerDetails.tsx
@@ -26,7 +26,7 @@ import {
 } from '../util/convert-value';
 import { coerceToNonnegativeValue } from './coerce-to-nonnegative-value';
 import { numberFormatters } from '../formatters';
-import { endOfDay, isToday, startOfDay } from 'date-fns';
+import { endOfDay, isBefore, isToday, startOfDay } from 'date-fns';
 import { DatePicker } from './DatePicker';
 import { NumberPicker } from './NumberPicker';
 import { createStyles } from '../../../components/BrandConfigProvider';
@@ -56,7 +56,11 @@ export const TrackerDetails: FC<TrackerDetailsProps> = (props) => {
   const svc = useTrackTileService();
   const [saveInProgress, setSaveInProgress] = useState(false);
   const [dateRange, setDateRange] = useState(() => {
-    const referenceDate = incomingReferenceDate ?? Date.now();
+    const referenceDate =
+      incomingReferenceDate && isBefore(incomingReferenceDate, new Date())
+        ? incomingReferenceDate
+        : new Date();
+
     return {
       start: startOfDay(referenceDate),
       end: endOfDay(referenceDate),

--- a/src/components/TrackTile/TrackerDetails/TrackerHistoryChart/TrackerHistoryChart.tsx
+++ b/src/components/TrackTile/TrackerDetails/TrackerHistoryChart/TrackerHistoryChart.tsx
@@ -1,12 +1,12 @@
-import React, { FC, useState, useCallback, useEffect } from 'react';
+import React, { FC, useState, useCallback } from 'react';
 import { useTrackerValues } from '../../hooks/useTrackerValues';
 import { Chart, ChartProps } from './Chart';
 import {
-  endOfToday,
   startOfToday,
   addDays,
   startOfWeek,
   endOfWeek,
+  endOfDay,
 } from 'date-fns';
 import Paginator from './Paginator';
 import { convertToPreferredUnit } from '../../util/convert-value';
@@ -23,19 +23,20 @@ type TrackerHistoryChartProps = {
   unit?: string;
   stepperPosition?: 'top' | 'bottom';
   dateRangeType?: DateRangeType;
+  referenceDate?: Date;
 } & Pick<ChartProps, 'variant' | 'color'>;
 
-const getInitialRange = (dateRangeType: DateRangeType) => {
+const getInitialRange = (dateRangeType: DateRangeType, referenceDate: Date) => {
   switch (dateRangeType) {
     case 'calendarWeek':
       return {
-        start: startOfWeek(startOfToday(), { weekStartsOn: 1 }),
-        end: endOfWeek(startOfToday(), { weekStartsOn: 1 }),
+        start: startOfWeek(referenceDate, { weekStartsOn: 1 }),
+        end: endOfWeek(referenceDate, { weekStartsOn: 1 }),
       };
     case 'past7Days':
       return {
-        start: addDays(startOfToday(), -6),
-        end: endOfToday(),
+        start: addDays(referenceDate, -6),
+        end: endOfDay(referenceDate),
       };
   }
 };
@@ -43,16 +44,20 @@ const getInitialRange = (dateRangeType: DateRangeType) => {
 export const TrackerHistoryChart: FC<TrackerHistoryChartProps> = (props) => {
   const theme = useTheme();
   const { metricId, stepperPosition = 'top', tracker, valuesContext } = props;
-  const { variant, target, unit, dateRangeType = 'past7Days' } = props;
-  const [dateRange, setDateRange] = useState(getInitialRange(dateRangeType));
+  const {
+    variant,
+    target,
+    unit,
+    dateRangeType = 'past7Days',
+    referenceDate = startOfToday(),
+  } = props;
+  const [dateRange, setDateRange] = useState(
+    getInitialRange(dateRangeType, referenceDate),
+  );
   const { loading, error, trackerValues } = useTrackerValues(
     valuesContext,
     dateRange,
   );
-
-  useEffect(() => {
-    setDateRange(getInitialRange(dateRangeType));
-  }, [dateRangeType]);
 
   const advanceDays = useCallback(
     (shiftByDays: number) =>

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -68,6 +68,7 @@ export type HomeStackParamList = {
   'Home/AdvancedTrackerDetails': {
     tracker: Tracker;
     valuesContext: TrackerValuesContext;
+    referenceDate?: Date;
   };
   'Home/AdvancedTrackerEditor': {
     tracker: Tracker;

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -60,6 +60,7 @@ export type HomeStackParamList = {
   'Home/TrackTile': {
     tracker: Tracker;
     valuesContext: TrackerValuesContext;
+    referenceDate?: Date;
   };
   'Home/TrackTileSettings': {
     valuesContext: TrackerValuesContext;

--- a/src/screens/TrackTileAdvancedDetailsScreen.tsx
+++ b/src/screens/TrackTileAdvancedDetailsScreen.tsx
@@ -6,7 +6,7 @@ export const AdvancedTrackerDetailsScreen = ({
   navigation,
   route: { params },
 }: HomeStackScreenProps<'Home/AdvancedTrackerDetails'>) => {
-  const { tracker, valuesContext } = params;
+  const { tracker, valuesContext, referenceDate } = params;
 
   React.useLayoutEffect(() =>
     navigation.setOptions({ headerTitle: tracker?.name }),
@@ -16,6 +16,7 @@ export const AdvancedTrackerDetailsScreen = ({
     <AdvancedTrackerDetails
       tracker={tracker}
       valuesContext={valuesContext}
+      referenceDate={referenceDate}
       onEditValue={(trackerValue) =>
         navigation.push('Home/AdvancedTrackerEditor', {
           tracker,

--- a/src/screens/TrackTileTrackerScreen.tsx
+++ b/src/screens/TrackTileTrackerScreen.tsx
@@ -13,7 +13,7 @@ export const TrackTileTrackerScreen = ({
   navigation,
   route: { params },
 }: Props) => {
-  const { tracker, valuesContext } = params;
+  const { tracker, valuesContext, referenceDate } = params;
   const { styles } = useStyles(defaultStyles);
 
   React.useLayoutEffect(() => {
@@ -27,6 +27,7 @@ export const TrackTileTrackerScreen = ({
       <TrackerDetails
         tracker={tracker}
         valuesContext={valuesContext}
+        referenceDate={referenceDate}
         canEditUnit={true}
       />
     </View>


### PR DESCRIPTION
## Changes
* Adds optional prop to `TrackerDetails` and `AdvancedTrackerDetails` to receive a date
* If the `referenceDate` is provided, the component uses that date instead of the current date
* Prevents passing a `referenceDate` in the future
* Adds `knobs` to storybook

## Screenshots

https://github.com/lifeomic/react-native-sdk/assets/600650/091bf3f5-b3c3-484c-88f9-d4078da55628

