### PR TITLE
feat: Update safe area view

### DIFF
--- a/example/AppDemo.tsx
+++ b/example/AppDemo.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import { authConfig, baseURL } from './storybook/stories/OAuth.stories';
 import { DeveloperConfigProvider, RootProviders, RootStack } from '../src';
 import { FhirExampleScreen } from './src/screens/FhirExampleScreen';
-import { HelloWorldScreen } from './src/screens/HelloWorldScreen';
-import { t } from 'i18next';
-import { Menu } from '@lifeomic/chromicons-native';
 
 if (__DEV__) {
   import('./reactotron').then(() => console.log('Reactotron Configured'));
@@ -22,16 +19,6 @@ function App() {
           primaryColor: '#fb5607',
         },
         apiBaseURL: baseURL,
-        additionalNavigationTabs: [
-          {
-            name: 'AdditionalTab',
-            component: HelloWorldScreen,
-            options: {
-              tabBarLabel: t('tabs-settings', 'Settings'),
-              tabBarIcon: Menu,
-            },
-          },
-        ],
       }}
     >
       <RootProviders authConfig={authConfig}>

--- a/example/storybook/helpers/CenterView.tsx
+++ b/example/storybook/helpers/CenterView.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 
-import { View, ViewStyle } from 'react-native';
+import { ViewStyle } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 interface Props {
   children: React.ReactNode;
+  style?: ViewStyle;
 }
 
-export function CenterView({ children }: Props) {
-  return <View style={container}>{children}</View>;
+export function CenterView({ children, style }: Props) {
+  return (
+    <SafeAreaView
+      edges={['top', 'bottom', 'left', 'right']}
+      style={[container, style]}
+    >
+      {children}
+    </SafeAreaView>
+  );
 }
 
 const container: ViewStyle = {

--- a/example/storybook/helpers/SafeView.tsx
+++ b/example/storybook/helpers/SafeView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export function SafeView({ children }: Props) {
+  return (
+    <SafeAreaView edges={['top', 'bottom', 'left', 'right']}>
+      {children}
+    </SafeAreaView>
+  );
+}

--- a/example/storybook/index.tsx
+++ b/example/storybook/index.tsx
@@ -32,6 +32,7 @@ configure(() => {
 // To find allowed options for getStorybookUI
 const StorybookUIRoot = getStorybookUI({
   asyncStorage: null,
+  onDeviceUI: false,
 });
 
 // If you are using React Native vanilla and after installation you don't see your app name here, write it manually.

--- a/example/storybook/stories/BrandConfigProvider/BrandConfigProvider.stories.tsx
+++ b/example/storybook/stories/BrandConfigProvider/BrandConfigProvider.stories.tsx
@@ -7,7 +7,7 @@ import { ThemeExampleScreen } from './ThemeExampleScreen';
 import * as baseTheme from '../../../../src/components/BrandConfigProvider/theme/base';
 import { ExampleBox, ExampleBoxStyles } from './ExampleBox';
 import { BrandConfigProviderStyles } from '../../../../src/components/BrandConfigProvider/styles/types';
-import { CenterView } from 'example/storybook/helpers/CenterView';
+import { CenterView } from '../../helpers/CenterView';
 import Svg, { Path } from 'react-native-svg';
 import { List } from 'react-native-paper';
 import { Apple } from '@lifeomic/chromicons-native';

--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -11,6 +11,9 @@ import {
 import { withKnobs, color } from '@storybook/addon-knobs';
 import Color from 'color';
 import logo from './header-logo.png';
+import { t } from 'i18next';
+import { Menu } from '@lifeomic/chromicons-native';
+import { HelloWorldScreen } from '../../../src/screens/HelloWorldScreen';
 
 storiesOf('Example App', module)
   .addDecorator(withKnobs)
@@ -24,6 +27,34 @@ storiesOf('Example App', module)
           simpleTheme: {
             primaryColor,
           },
+        }}
+      >
+        <RootProviders authConfig={authConfig}>
+          <RootStack />
+        </RootProviders>
+      </DeveloperConfigProvider>
+    );
+  })
+  .add('With additional navigation tab', () => {
+    const rgbColorString = color('Primary Color', '#0477BF');
+    const primaryColor = Color(rgbColorString).hex();
+
+    return (
+      <DeveloperConfigProvider
+        developerConfig={{
+          simpleTheme: {
+            primaryColor,
+          },
+          additionalNavigationTabs: [
+            {
+              name: 'AdditionalTab',
+              component: HelloWorldScreen,
+              options: {
+                tabBarLabel: t('tabs-settings', 'Settings'),
+                tabBarIcon: Menu,
+              },
+            },
+          ],
         }}
       >
         <RootProviders authConfig={authConfig}>
@@ -86,6 +117,7 @@ storiesOf('Example App', module)
                 color: (theme) => theme.colors.onTertiary,
               },
             ],
+            statusBarHeight: 0,
           },
         }}
       >

--- a/example/storybook/stories/NoInternetToastProvider.stories.tsx
+++ b/example/storybook/stories/NoInternetToastProvider.stories.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react-native';
 import { NoInternetToastProvider } from '../../../src';
 import Toast from 'react-native-toast-message';
 import { StyleSheet, Text, View } from 'react-native';
+import { CenterView } from '../helpers/CenterView';
 
 const styles = StyleSheet.create({
   view: {
@@ -19,24 +20,26 @@ const styles = StyleSheet.create({
   },
 });
 
-storiesOf('NoInternetToast', module).add('demo', () => {
-  return (
-    <View>
-      <NoInternetToastProvider />
-      <View style={styles.view}>
-        <Text style={styles.text}>
-          This component depends on the connection state of your device. The
-          toast will be displayed when you disconnect from internet and hidden
-          when you've restored your connection. The NetInfo library recommends
-          that you do not use an iOS Simulator for testing this.{'\n\n'}
-          <Text style={styles.textBold}>
-            "There is a known issue with the iOS Simulator which causes it to
-            not receive network change notifications correctly when the host
-            machine disconnects and then connects to Wifi."
+storiesOf('NoInternetToast', module)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
+  .add('demo', () => {
+    return (
+      <View>
+        <NoInternetToastProvider />
+        <View style={styles.view}>
+          <Text style={styles.text}>
+            This component depends on the connection state of your device. The
+            toast will be displayed when you disconnect from internet and hidden
+            when you've restored your connection. The NetInfo library recommends
+            that you do not use an iOS Simulator for testing this.{'\n\n'}
+            <Text style={styles.textBold}>
+              "There is a known issue with the iOS Simulator which causes it to
+              not receive network change notifications correctly when the host
+              machine disconnects and then connects to Wifi."
+            </Text>
           </Text>
-        </Text>
+        </View>
+        <Toast />
       </View>
-      <Toast />
-    </View>
-  );
-});
+    );
+  });

--- a/example/storybook/stories/TrackTile/AdvancedTrackerDetails.stories.tsx
+++ b/example/storybook/stories/TrackTile/AdvancedTrackerDetails.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../../src/components/TrackTile/services/TrackTileService';
 import { date, select, withKnobs } from '@storybook/addon-knobs';
 import { activity, mindful, nutrition, sleep } from './util/ontologies';
+import { CenterView } from '../../helpers/CenterView';
 
 const ontology = {} as any;
 
@@ -17,6 +18,7 @@ storiesOf('AdvancedTrackerDetails', module)
   .addDecorator((storyFn, context) =>
     MockEnvironmentDecorator({ ontology })(storyFn, context),
   )
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => {
     const pillarType = select(
       'Pillar Type',

--- a/example/storybook/stories/TrackTile/Indicator.stories.tsx
+++ b/example/storybook/stories/TrackTile/Indicator.stories.tsx
@@ -7,32 +7,35 @@ import Indicator, {
 import * as Icons from '@lifeomic/chromicons-native';
 import { kebabCase, invert } from 'lodash';
 import { View, Text, ScrollView } from 'react-native';
+import { CenterView } from '../../helpers/CenterView';
 
-storiesOf('Indicator', module).add('default', () => {
-  const names = Object.keys(Icons).map(kebabCase);
+storiesOf('Indicator', module)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
+  .add('default', () => {
+    const names = Object.keys(Icons).map(kebabCase);
 
-  return (
-    <ScrollView
-      style={{ paddingHorizontal: 10 }}
-      contentContainerStyle={{ flexDirection: 'row', flexWrap: 'wrap' }}
-    >
-      {names.map((name) => {
-        const alias = invert(aliases)[name];
-        return (
-          <View
-            key={name}
-            style={{
-              width: '33%',
-              alignItems: 'center',
-              height: 60,
-            }}
-          >
-            <Indicator name={name} />
-            <Text>{name}</Text>
-            {alias && <Text>{`(${alias})`}</Text>}
-          </View>
-        );
-      })}
-    </ScrollView>
-  );
-});
+    return (
+      <ScrollView
+        style={{ paddingHorizontal: 10 }}
+        contentContainerStyle={{ flexDirection: 'row', flexWrap: 'wrap' }}
+      >
+        {names.map((name) => {
+          const alias = invert(aliases)[name];
+          return (
+            <View
+              key={name}
+              style={{
+                width: '33%',
+                alignItems: 'center',
+                height: 60,
+              }}
+            >
+              <Indicator name={name} />
+              <Text>{name}</Text>
+              {alias && <Text>{`(${alias})`}</Text>}
+            </View>
+          );
+        })}
+      </ScrollView>
+    );
+  });

--- a/example/storybook/stories/TrackTile/ManageTrackers.stories.tsx
+++ b/example/storybook/stories/TrackTile/ManageTrackers.stories.tsx
@@ -14,6 +14,7 @@ import {
   Aperture,
 } from '@lifeomic/chromicons-native';
 import { IconProvider } from '../../../../src';
+import { CenterView } from '../../helpers/CenterView';
 
 const defaultMetricTypes: Partial<Tracker>[] = [
   {
@@ -62,6 +63,7 @@ storiesOf('ManageTrackers', module)
   .addDecorator((storyFn, context) =>
     MockEnvironmentDecorator()(storyFn, context),
   )
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => (
     <IconProvider
       icons={

--- a/example/storybook/stories/TrackTile/Pillar.stories.tsx
+++ b/example/storybook/stories/TrackTile/Pillar.stories.tsx
@@ -14,6 +14,7 @@ import { boolean } from '@storybook/addon-knobs';
 import { Anchor, CheckCircle, PlusSquare } from '@lifeomic/chromicons-native';
 import { IconProvider } from '../../../../src';
 import { StylesProvider } from '../../../../src/components/BrandConfigProvider/styles/StylesProvider';
+import { CenterView } from '../../helpers/CenterView';
 
 const nutritionTracker: Tracker = {
   id: 'nutrition',
@@ -107,6 +108,7 @@ const initialValue: TrackerValue = {
 
 storiesOf('Pillar', module)
   .addDecorator(MockEnvironmentDecorator())
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => <InteractivePillar />)
   .add('loading', () => (
     <View style={defaultStyles.pillarsTile}>

--- a/example/storybook/stories/TrackTile/PillarsTile.stories.tsx
+++ b/example/storybook/stories/TrackTile/PillarsTile.stories.tsx
@@ -19,6 +19,8 @@ import {
   PlusSquare,
 } from '@lifeomic/chromicons-native';
 import { IconProvider } from '../../../../src';
+import { CenterView } from '../../helpers/CenterView';
+
 const baseTracker = {
   account: 'accountid',
   description: 'desc',
@@ -149,6 +151,7 @@ storiesOf('PillarsTile', module)
       ],
     })(storyFn, context),
   )
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => (
     <IconProvider
       icons={

--- a/example/storybook/stories/TrackTile/TrackTiles.stories.tsx
+++ b/example/storybook/stories/TrackTile/TrackTiles.stories.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react-native';
 import { MockEnvironmentDecorator } from './util/MockEnvironmentDecorator';
 import { action } from '@storybook/addon-actions';
 import { TrackTile } from '../../../../src/components/TrackTile';
+import { CenterView } from '../../helpers/CenterView';
 
 storiesOf('TrackTile', module)
   .addDecorator((storyFn, context) =>
@@ -29,6 +30,7 @@ storiesOf('TrackTile', module)
       ],
     })(storyFn, context),
   )
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => (
     <TrackTile
       onOpenSettings={action('onOpenSettings')}

--- a/example/storybook/stories/TrackTile/Tracker.stories.tsx
+++ b/example/storybook/stories/TrackTile/Tracker.stories.tsx
@@ -12,9 +12,11 @@ import {
   text,
   boolean,
 } from '@storybook/addon-knobs';
+import { CenterView } from '../../helpers/CenterView';
 
 storiesOf('Tracker', module)
   .addDecorator(withKnobs)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => {
     const unit = text('unit', 'ounces');
     return (

--- a/example/storybook/stories/TrackTile/TrackerDetails.stories.tsx
+++ b/example/storybook/stories/TrackTile/TrackerDetails.stories.tsx
@@ -17,6 +17,7 @@ import {
   UnitPickerProps,
 } from '../../../../src/components/TrackTile/TrackerDetails/UnitPicker';
 import { IconProvider } from '../../../../src';
+import { SafeView } from '../../helpers/SafeView';
 
 storiesOf('TrackerDetails', module)
   .addDecorator(withKnobs)
@@ -32,6 +33,7 @@ storiesOf('TrackerDetails', module)
       ],
     })(storyFn, context),
   )
+  .addDecorator((story) => <SafeView>{story()}</SafeView>)
   .add('default', () => {
     const referenceDate = date('Reference Date', undefined);
     return (

--- a/example/storybook/stories/TrackTile/TrackerHistoryChart.stories.tsx
+++ b/example/storybook/stories/TrackTile/TrackerHistoryChart.stories.tsx
@@ -15,7 +15,9 @@ const defaultProps = {
 
 storiesOf('Tracker History Chart', module)
   .addDecorator((Story) => (
-    <View style={{ margin: 34, height: 250 }}>{Story()}</View>
+    <View style={{ marginHorizontal: 34, marginVertical: 128, height: 250 }}>
+      {Story()}
+    </View>
   ))
   .add('default', () => <Chart {...defaultProps} />)
   .add('loading', () => <Chart {...defaultProps} loading />)

--- a/example/storybook/stories/Wearables/SelectorRow.stories.tsx
+++ b/example/storybook/stories/Wearables/SelectorRow.stories.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
 import { SelectorRow } from '../../../../src/components/Wearables/SelectorRow';
+import { CenterView } from '../../helpers/CenterView';
 
 export const exampleProps = {
   id: 'rowId',
@@ -12,6 +13,7 @@ export const exampleProps = {
 
 storiesOf('Selector Row', module)
   .addDecorator(withKnobs)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => (
     <SelectorRow
       disabled={boolean('disabled', false)}

--- a/example/storybook/stories/Wearables/SelectorView.stories.tsx
+++ b/example/storybook/stories/Wearables/SelectorView.stories.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import { boolean, object, withKnobs } from '@storybook/addon-knobs';
 import { SelectorView } from '../../../../src/components/Wearables/SelectorView';
+import { CenterView } from '../../helpers/CenterView';
 
 export const exampleProps = {
   data: [
@@ -25,6 +26,7 @@ export const exampleProps = {
 
 storiesOf('Selector View', module)
   .addDecorator(withKnobs)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => (
     <SelectorView
       data={object('data', exampleProps.data)}

--- a/example/storybook/stories/Wearables/SwitchRow.stories.tsx
+++ b/example/storybook/stories/Wearables/SwitchRow.stories.tsx
@@ -3,9 +3,11 @@ import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
 import { SwitchRow } from '../../../../src/components/Wearables//SwitchRow';
+import { CenterView } from '../../helpers/CenterView';
 
 storiesOf('Switch Row', module)
   .addDecorator(withKnobs)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => <DefaultView />)
   .add('disabled', () => <DefaultView disabled={true} />);
 

--- a/example/storybook/stories/Wearables/SyncTypeSelectionRow.stories.tsx
+++ b/example/storybook/stories/Wearables/SyncTypeSelectionRow.stories.tsx
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
 import { SyncTypeSelectionRow } from '../../../../src/components/Wearables/SyncTypeSelectionRow';
 import { WearableIntegration } from '../../../../src/components/Wearables/WearableTypes';
+import { CenterView } from '../../helpers/CenterView';
 
 export const exampleProps = {
   selectedEHRId: 'garmin',
@@ -30,6 +31,7 @@ export const exampleProps = {
 
 storiesOf('SyncType Selection Row', module)
   .addDecorator(withKnobs)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => (
     <SyncTypeSelectionRow
       disabled={boolean('disabled', false)}

--- a/example/storybook/stories/Wearables/SyncTypeSelectionView.stories.tsx
+++ b/example/storybook/stories/Wearables/SyncTypeSelectionView.stories.tsx
@@ -10,6 +10,7 @@ import {
   WearableIntegration,
   WearableStateSyncType,
 } from '../../../../src/components/Wearables/WearableTypes';
+import { SafeView } from '../../helpers/SafeView';
 
 export const exampleProps: SyncTypeSelectionViewProps = {
   wearables: [
@@ -43,6 +44,7 @@ export const exampleProps: SyncTypeSelectionViewProps = {
 
 storiesOf('SyncType Selection View', module)
   .addDecorator(withKnobs)
+  .addDecorator((story) => <SafeView>{story()}</SafeView>)
   .add('default', () => (
     <SyncTypeSelectionView
       disabled={boolean('disabled', false)}

--- a/example/storybook/stories/Wearables/WearablesView.stories.tsx
+++ b/example/storybook/stories/Wearables/WearablesView.stories.tsx
@@ -20,9 +20,11 @@ export const viewActions = {
   ...rowActions,
   onSyncTypeSelectionsUpdate: action('onSyncTypeSelectionsUpdate'),
 };
+import { CenterView } from '../../helpers/CenterView';
 
 storiesOf('Wearables View', module)
   .addDecorator(withKnobs)
+  .addDecorator((story) => <CenterView>{story()}</CenterView>)
   .add('default', () => <DefaultView loading={false} />)
   .add('loading (initially)', () => <WearablesView {...loadingProps} />)
   .add('loading (after wearables change)', () => <DefaultView loading={true} />)

--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -37,6 +37,7 @@ export type DeveloperConfig = {
   AppNavHeader?: {
     headerColors?: RouteColor[];
     onHeaderColors?: RouteColor[];
+    statusBarHeight?: number;
   };
 };
 

--- a/src/components/AppNavHeader.tsx
+++ b/src/components/AppNavHeader.tsx
@@ -30,9 +30,10 @@ export function AppNavHeader({
     route,
     styles.titleText,
   );
+  const statusBarHeight = config.AppNavHeader?.statusBarHeight;
 
   return (
-    <Appbar.Header statusBarHeight={0} style={headerStyles}>
+    <Appbar.Header statusBarHeight={statusBarHeight} style={headerStyles}>
       {back ? (
         <Appbar.Action
           icon={ChevronLeft}


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Turned on-simulator storybook UI off to prevent safe-area-view from automatically being added
  - Fixed all stories related to this change
  - Added a developerConfig prop to control `statusBarHeight` of the AppNavHeader
  - Moved example of additional tab navigator tab to the stories
