### PR TITLE
fix: Wearable Sync Type Updates Should use PUT

### DIFF
--- a/src/hooks/useWearables.ts
+++ b/src/hooks/useWearables.ts
@@ -87,7 +87,7 @@ export const useWearables = () => {
     );
 
   const setSyncTypes = async (settings: SyncTypeSettings) =>
-    httpClient.post('/v1/wearables/sync-types', settings, {
+    httpClient.put('/v1/wearables/sync-types', settings, {
       headers: accountHeaders,
     });
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Updates setting sync types to use PUT: [lifeomic/ehr-service/.../wearables.ts#L80](https://github.com/lifeomic/ehr-service/blob/master/src/api/controllers/wearables.ts#L80)