### PR TITLE
fix: Correct header margins for Android

### DIFF
--- a/example/storybook/helpers/oauthConfig.ts
+++ b/example/storybook/helpers/oauthConfig.ts
@@ -1,0 +1,19 @@
+import { AuthConfiguration } from 'react-native-app-auth';
+import { oauthConfig, apiBaseUrl } from '../../config';
+
+export const authConfig: AuthConfiguration = {
+  clientId: oauthConfig.clientId,
+  redirectUrl: oauthConfig.redirectUrl,
+  serviceConfiguration: {
+    authorizationEndpoint: oauthConfig.authorizationEndpoint,
+    tokenEndpoint: oauthConfig.tokenEndpoint,
+    revocationEndpoint: oauthConfig.revokeEndpoint,
+  },
+  usePKCE: true,
+  scopes: ['openid', 'offline_access'],
+  additionalParameters: {
+    prompt: 'consent',
+  },
+};
+
+export const baseURL = apiBaseUrl;

--- a/example/storybook/stories/ActivityIndicatorView.stories.tsx
+++ b/example/storybook/stories/ActivityIndicatorView.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { authConfig } from './OAuth.stories';
+import { authConfig } from '../helpers/oauthConfig';
 import {
   ActivityIndicatorView,
   DeveloperConfigProvider,

--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { authConfig } from '../OAuth.stories';
+import { authConfig } from '../../helpers/oauthConfig';
 import {
   DeveloperConfigProvider,
   RootProviders,

--- a/example/storybook/stories/OAuth.stories.tsx
+++ b/example/storybook/stories/OAuth.stories.tsx
@@ -3,31 +3,14 @@ import { Text, View, ViewStyle } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, select } from '@storybook/addon-knobs';
-import { AuthConfiguration, AuthorizeResult } from 'react-native-app-auth';
+import { AuthorizeResult } from 'react-native-app-auth';
 import { OAuthLoginButton } from '../../../src/components/OAuthLoginButton';
 import { OAuthLogoutButton } from '../../../src/components/OAuthLogoutButton';
 import { OAuthContextProvider } from '../../../src/hooks/useOAuthFlow';
 import { AuthContextProvider, useAuth } from '../../../src/hooks/useAuth';
 import { CenterView } from '../helpers/CenterView';
 import { BrandConfigProvider } from '../../../src/components/BrandConfigProvider';
-import { oauthConfig, apiBaseUrl } from '../../config';
-
-export const authConfig: AuthConfiguration = {
-  clientId: oauthConfig.clientId,
-  redirectUrl: oauthConfig.redirectUrl,
-  serviceConfiguration: {
-    authorizationEndpoint: oauthConfig.authorizationEndpoint,
-    tokenEndpoint: oauthConfig.tokenEndpoint,
-    revocationEndpoint: oauthConfig.revokeEndpoint,
-  },
-  usePKCE: true,
-  scopes: ['openid', 'offline_access'],
-  additionalParameters: {
-    prompt: 'consent',
-  },
-};
-
-export const baseURL = apiBaseUrl;
+import { authConfig } from '../helpers/oauthConfig';
 
 storiesOf('OAuth', module)
   .addDecorator((story) => <CenterView>{story()}</CenterView>)

--- a/src/components/AppNavHeader.tsx
+++ b/src/components/AppNavHeader.tsx
@@ -44,7 +44,7 @@ export function AppNavHeader({
       ) : null}
       <Appbar.Content
         title={<Title text={title} style={titleStyles} />}
-        style={styles.content}
+        style={styles.contentView}
       />
     </Appbar.Header>
   );
@@ -85,7 +85,9 @@ const defaultStyles = createStyles('AppNavHeader', (theme) => ({
   view: {
     backgroundColor: theme.colors.background,
   },
-  content: {},
+  contentView: {
+    alignItems: 'center',
+  },
   titleText: {
     color: theme.colors.onSurfaceVariant,
   },

--- a/src/components/LogoHeader.tsx
+++ b/src/components/LogoHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { View, Image, ImageSourcePropType } from 'react-native';
+import { View, Image, ImageSourcePropType, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { createStyles } from './BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
@@ -11,12 +11,13 @@ interface Props {
 
 export function LogoHeader({ imageSource }: Props) {
   const { styles } = useStyles(defaultStyles);
+  const androidFix = Platform.OS === 'android' ? { marginTop: 12 } : {};
 
   return (
     <View style={styles.view}>
       <SafeAreaView
         edges={['left', 'right', 'top']}
-        style={styles.safeAreaView}
+        style={[androidFix, styles.safeAreaView]}
       >
         <Image source={imageSource} style={styles.image} />
       </SafeAreaView>


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Correct header margins for Android
  - Prevent OAuth.stories from loading more than once

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

| Before | After |
|-|-|
|![Screenshot 2023-06-05 at 5 38 35 PM](https://github.com/lifeomic/react-native-sdk/assets/220893/011a3db8-0dfe-49ba-8861-bfb21d04ba6c)|![Screenshot 2023-06-05 at 5 39 29 PM](https://github.com/lifeomic/react-native-sdk/assets/220893/57b66c71-5507-4726-b9a1-d0abf9111209)|




