### PR TITLE
fix: Fetch Backfill Status Only when Enabled

### DIFF
--- a/example/AppDemo.tsx
+++ b/example/AppDemo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { authConfig, baseURL } from './storybook/stories/OAuth.stories';
+import { authConfig, baseURL } from './storybook/helpers/oauthConfig';
 import { DeveloperConfigProvider, RootProviders, RootStack } from '../src';
 import { FhirExampleScreen } from './src/screens/FhirExampleScreen';
 

--- a/src/hooks/useWearableBackfill.test.tsx
+++ b/src/hooks/useWearableBackfill.test.tsx
@@ -207,6 +207,46 @@ describe('useWearableBackfill', () => {
     expect(data).toEqual(false);
   });
 
+  it('should NOT fetch syncStatus if feature is not fetched or disabled', async () => {
+    const scope = mockGraphQLResponse(
+      `${baseURL}/v1/graphql`,
+      undefined,
+      defaultResponse,
+    );
+
+    mockUseFeature
+      .mockReturnValueOnce({ data: undefined })
+      .mockReturnValueOnce({ data: false })
+      .mockReturnValueOnce({ data: true });
+
+    const state = {
+      items: [
+        {
+          ehrId: 'ehrId',
+          ehrType: 'fitbit',
+        } as any,
+      ],
+    };
+
+    const { result, rerender } = renderHookWithInjectedClient(state);
+
+    expect(scope.isDone()).toBe(false);
+    expect(result.current.enabledBackfillWearables).toHaveLength(0);
+
+    rerender(state);
+
+    expect(scope.isDone()).toBe(false);
+    expect(result.current.enabledBackfillWearables).toHaveLength(0);
+
+    rerender(state);
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    expect(result.current.enabledBackfillWearables).toEqual(['ehrId']);
+  });
+
   it('handles an ehrType that cannot be backfilled', async () => {
     mockUseFeature.mockReturnValue({ data: true });
     const scope = mockGraphQLResponse(

--- a/src/hooks/useWearableBackfill.tsx
+++ b/src/hooks/useWearableBackfill.tsx
@@ -55,7 +55,7 @@ export const useWearableBackfill = (
         !!activeSubjectId &&
         isFetched &&
         ehrTypes.length > 0 &&
-        isBackfillEnabled,
+        !!isBackfillEnabled,
       select(data) {
         return Object.fromEntries(
           Object.entries(data).map(([type, patientData]) => {
@@ -72,7 +72,7 @@ export const useWearableBackfill = (
   );
 
   useEffect(() => {
-    if (!wearablesState?.items?.length || !syncStatus) {
+    if (!wearablesState?.items?.length || !syncStatus || !isBackfillEnabled) {
       return;
     }
 
@@ -87,7 +87,7 @@ export const useWearableBackfill = (
     };
 
     updateEnabledBackfillWearables();
-  }, [wearablesState?.items, syncStatus]);
+  }, [wearablesState?.items, syncStatus, isBackfillEnabled]);
 
   const backfillEHR = useCallback(
     async (ehrId: string) => {


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes a bug where sync status was fetched when FT was undefined, before the query had resolved, which caused the backfill button to always be visible