### PR TITLE
fix: Resolve some consent bugs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,17 +15,17 @@ module.exports = {
     ],
     'no-alert': [
       'off',
-      { 
+      {
         paths: ['example/storybook'],
         patterns: ['example/storybook/*'],
       },
     ],
     'react-native/no-inline-styles': [
-    'off',
-    { 
-      paths: ['example/storybook'],
-      patterns: ['example/storybook/*'],
-    }
+      'off',
+      {
+        paths: ['example/storybook'],
+        patterns: ['example/storybook/*'],
+      },
     ],
   },
 };

--- a/src/navigators/RootStack.tsx
+++ b/src/navigators/RootStack.tsx
@@ -13,7 +13,8 @@ import { CircleThreadScreen } from '../screens/CircleThreadScreen';
 export function RootStack() {
   const { isLoggedIn, loading: loadingAuth } = useAuth();
   const { useShouldRenderConsentScreen } = useConsent();
-  const { shouldRenderConsentScreen } = useShouldRenderConsentScreen();
+  const { shouldRenderConsentScreen, isLoading: loadingConsents } =
+    useShouldRenderConsentScreen();
 
   if (!isLoggedIn && loadingAuth) {
     return (
@@ -24,6 +25,14 @@ export function RootStack() {
   }
 
   if (isLoggedIn) {
+    if (loadingConsents) {
+      return (
+        <ActivityIndicatorView
+          message={t('root-stack-waiting-for-consent', 'Waiting for consent')}
+        />
+      );
+    }
+
     const Stack = createNativeStackNavigator<LoggedInRootParamList>();
     const initialRouteName = shouldRenderConsentScreen
       ? 'screens/ConsentScreen'

--- a/src/screens/ConsentScreen.test.tsx
+++ b/src/screens/ConsentScreen.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../hooks/useConsent', () => ({
 const useOAuthFlowMock = useOAuthFlow as jest.Mock;
 const logoutMock = jest.fn();
 const useConsentMock = useConsent as jest.Mock;
-const useDefaultConsentMock = jest.fn();
+const useShouldRenderConsentScreenMock = jest.fn();
 const useUpdateProjectConsentDirectiveMock = jest.fn();
 const updateConsentDirectiveMutationMock = {
   mutateAsync: jest.fn().mockResolvedValue({}),
@@ -25,13 +25,21 @@ const navigateMock = {
   replace: jest.fn(),
 };
 
-const defaultConsent = {
-  id: 'consentId',
-  item: [
-    {
-      text: 'Consent body',
-    },
-  ],
+const defaultConsentDirective = {
+  id: 'directiveId',
+  form: {
+    id: 'consentId',
+    item: [
+      {
+        linkId: 'terms',
+        text: 'Consent body',
+      },
+      {
+        linkId: 'acceptance',
+        text: 'I accept',
+      },
+    ],
+  },
 };
 
 const alertSpy = jest.spyOn(Alert, 'alert');
@@ -46,25 +54,25 @@ beforeEach(() => {
   useUpdateProjectConsentDirectiveMock.mockReturnValue(
     updateConsentDirectiveMutationMock,
   );
-  useDefaultConsentMock.mockReturnValue({
+  useShouldRenderConsentScreenMock.mockReturnValue({
     isLoading: false,
-    data: defaultConsent,
+    consentDirectives: [defaultConsentDirective],
   });
   useConsentMock.mockReturnValue({
-    useDefaultConsent: useDefaultConsentMock,
+    useShouldRenderConsentScreen: useShouldRenderConsentScreenMock,
     useUpdateProjectConsentDirective: useUpdateProjectConsentDirectiveMock,
   });
 });
 
-test('render the activity indicator when loading the default consent', () => {
-  useDefaultConsentMock.mockReturnValue({ isLoading: true });
+test('render the activity indicator when loading', () => {
+  useShouldRenderConsentScreenMock.mockReturnValue({ isLoading: true });
   const { getByTestId } = render(consentScreen);
   expect(getByTestId('activity-indicator-view')).toBeDefined();
 });
 
 test('renders the consent body', () => {
   const { getByText } = render(consentScreen);
-  expect(getByText(defaultConsent.item[0].text)).toBeDefined();
+  expect(getByText(defaultConsentDirective.form.item[0].text)).toBeDefined();
 });
 
 test('should accept the consent and navigate to the home screen', async () => {
@@ -72,13 +80,16 @@ test('should accept the consent and navigate to the home screen', async () => {
   fireEvent.press(getByText('Agree'));
   await waitFor(() => {
     expect(updateConsentDirectiveMutationMock.mutateAsync).toHaveBeenCalledWith(
-      true,
+      {
+        directiveId: defaultConsentDirective.id,
+        accept: true,
+      },
     );
     expect(navigateMock.replace).toHaveBeenCalledWith('app');
   });
 });
 
-test('it should open an alert', async () => {
+test('it should open an alert if consent is declined', async () => {
   const { getByText } = render(consentScreen);
   fireEvent.press(getByText('Decline'));
   expect(alertSpy).toHaveBeenCalled();
@@ -89,8 +100,9 @@ test('Pressing logout declines the consent and logs the the user out', async () 
   fireEvent.press(getByText('Decline'));
   alertSpy.mock.calls[0]?.[2]?.[1].onPress!();
   await waitFor(() => {});
-  expect(updateConsentDirectiveMutationMock.mutateAsync).toHaveBeenCalledWith(
-    false,
-  );
+  expect(updateConsentDirectiveMutationMock.mutateAsync).toHaveBeenCalledWith({
+    directiveId: defaultConsentDirective.id,
+    accept: false,
+  });
   expect(logoutMock).toHaveBeenCalled();
 });


### PR DESCRIPTION
1. Avoid rendering home screen before consent by being eager with useConsent's `isLoading`
2. Resolve a duplicate-consent-created issue, and also simplify logic, by relying on assigned consents (instead of default-form) and using PATCH instead of POST