### PR TITLE
fix: convert pageSize to string in useSearchResourcesQuery

### DIFF
--- a/src/hooks/useFhirClient.test.tsx
+++ b/src/hooks/useFhirClient.test.tsx
@@ -204,6 +204,53 @@ describe('useSearchResourcesQuery', () => {
     });
   });
 
+  test('support custom pageSize', async () => {
+    const resultBundle = {
+      entry: [
+        {
+          resource: {
+            id: 'o1',
+          },
+        },
+        {
+          resource: {
+            id: 'o2',
+          },
+        },
+      ],
+    };
+    axiosMock
+      .onPost('/v1/fhir/dstu3/Observation/_search')
+      .reply(200, resultBundle);
+
+    function useTestHook() {
+      const { useSearchResourcesQuery } = useFhirClient();
+      const searchResult = useSearchResourcesQuery({
+        resourceType: 'Observation',
+        pageSize: 20,
+      });
+      return searchResult;
+    }
+    const { result } = renderHookInContext(useTestHook);
+
+    expect(axiosMock.history.post[0].url).toBe(
+      '/v1/fhir/dstu3/Observation/_search',
+    );
+
+    expect(axiosMock.history.post[0].data).toEqual(
+      JSON.stringify({
+        _tag: 'http://lifeomic.com/fhir/dataset|projectId',
+        patient: 'subjectId',
+        next: '0',
+        resourceType: 'Observation',
+        pageSize: '20',
+      }),
+    );
+    await waitFor(() => {
+      expect(result.current.data).toEqual(resultBundle);
+    });
+  });
+
   test('supports FHIR code filters', async () => {
     const resultBundle = {
       entry: [

--- a/src/hooks/useFhirClient.tsx
+++ b/src/hooks/useFhirClient.tsx
@@ -53,7 +53,10 @@ export function useFhirClient() {
       },
       {
         resourceType: queryParams.resourceType,
-        pageSize: queryParams.pageSize,
+        pageSize:
+          queryParams.pageSize === undefined
+            ? undefined
+            : queryParams.pageSize.toString(),
       },
     );
     const resourceType = queryParams.resourceType;


### PR DESCRIPTION
`patient-service` expects `pageSize` to be a string.