### PR TITLE
feat: Inject custom screens in the Home navigation stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,85 @@ export default function App() {
 }
 ```
 
+### Inject custom screens to the root stack
+
+1- Define your own custom screens.
+
+```typescript
+import React from 'react';
+import { StyleSheet, Text, Button } from 'react-native';
+import { HomeStackParamList } from '@lifeomic/react-native-sdk';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RouteProp } from '@react-navigation/native';
+
+type CustomHomeStackParamsList = HomeStackParamList & {
+  'CustomHomeScreen/Users': undefined;
+  'CustomHomeScreen/UserDetails': { userId: string };
+};
+
+type UserDetailsScreenNavigationProp = NativeStackNavigationProp<
+  CustomHomeStackParamsList,
+  'CustomHomeScreen/Users'
+>;
+
+type UserDetailsScreenRouteProp = RouteProp<
+  CustomHomeStackParamsList,
+  'CustomHomeScreen/Users'
+>;
+
+export const UsersScreen = () => {
+  const navigation = useNavigation<UserDetailsScreenNavigationProp>();
+  const route = useRoute<UserDetailsScreenRouteProp>();
+
+  return (
+    <>
+      <Text>Users</Text>
+      <Button
+        title="Navigate to the user details screen"
+        onPress={() =>
+          navigation.navigate('CustomHomeScreen/UserDetails', { userId: '123' })
+        }
+      />
+    </>
+  );
+};
+```
+
+2- Add your custom screens to the Home navigation stack.
+
+```typescript
+import React, { FC } from 'react';
+import { authConfig } from './authConfig';
+import { RootProviders, RootStack } from '@lifeomic/react-native-sdk';
+import { UserDetailsScreen, UsersScreen } from './screens';
+
+export default function App() {
+  return (
+    <DeveloperConfigProvider
+      developerConfig={{
+        getAdditionalHomeScreens: (HomeStack) => {
+          return [
+            <HomeStack.Screen
+              name="CustomHomeScreen/Users"
+              component={UsersScreen}
+            />,
+            <HomeStack.Screen
+              name="CustomHomeScreen/UserDetails"
+              component={UserDetailsScreen}
+            />,
+          ];
+        },
+      }}
+    >
+      <RootProviders authConfig={authConfig}>
+        <RootStack />
+      </RootProviders>
+    </DeveloperConfigProvider>
+  );
+}
+```
+
 ### Peer dependencies
 
 We may have more peer dependencies than is typical. We have run into a number of

--- a/__mocks__/ImageMock.tsx
+++ b/__mocks__/ImageMock.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const ImageMock = () => <React.Fragment />;
+
+export default ImageMock;

--- a/__mocks__/svgMock.tsx
+++ b/__mocks__/svgMock.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-const SvgMock = () => <React.Fragment />;
-
-export default SvgMock;

--- a/example/storybook/index.tsx
+++ b/example/storybook/index.tsx
@@ -32,7 +32,7 @@ configure(() => {
 // To find allowed options for getStorybookUI
 const StorybookUIRoot = getStorybookUI({
   asyncStorage: null,
-  onDeviceUI: false,
+  onDeviceUI: true,
 });
 
 // If you are using React Native vanilla and after installation you don't see your app name here, write it manually.

--- a/example/storybook/stories/CustomScreenInjection/CustomScreenInjection.stories.tsx
+++ b/example/storybook/stories/CustomScreenInjection/CustomScreenInjection.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { authConfig } from '../../helpers/oauthConfig';
+import {
+  DeveloperConfigProvider,
+  RootProviders,
+  RootStack,
+} from '../../../../src';
+import { withKnobs } from '@storybook/addon-knobs';
+import {
+  NavigationPlaygroundScreen,
+  UserDetailsScreen,
+  UsersScreen,
+} from './customScreens';
+import { Navigation } from '@lifeomic/chromicons-native';
+
+storiesOf('Custom Screen Injection', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    return (
+      <DeveloperConfigProvider
+        developerConfig={{
+          getAdditionalHomeScreens: (HomeStack) => {
+            return [
+              <HomeStack.Screen
+                name="CustomHomeScreen/Users"
+                component={UsersScreen}
+                options={{ title: 'Users' }}
+              />,
+              <HomeStack.Screen
+                name="CustomHomeScreen/UserDetails"
+                component={UserDetailsScreen}
+              />,
+            ];
+          },
+          additionalNavigationTabs: [
+            {
+              name: 'CustomTab',
+              component: NavigationPlaygroundScreen,
+              options: {
+                tabBarLabel: 'Navigation',
+                tabBarIcon: Navigation,
+              },
+            },
+          ],
+        }}
+      >
+        <RootProviders authConfig={authConfig}>
+          <RootStack />
+        </RootProviders>
+      </DeveloperConfigProvider>
+    );
+  });

--- a/example/storybook/stories/CustomScreenInjection/customScreens/NavigationPlaygroundScreen.tsx
+++ b/example/storybook/stories/CustomScreenInjection/customScreens/NavigationPlaygroundScreen.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button, Text, View } from 'react-native';
+import { CustomHomeStackParamsList } from './types';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+type NavigationProp = NativeStackNavigationProp<CustomHomeStackParamsList>;
+
+export const NavigationPlaygroundScreen = () => {
+  const navigation = useNavigation<NavigationProp>();
+
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <Text>Navigation Playground Screen</Text>
+      <Button
+        title="Users Screen"
+        onPress={() => navigation.navigate('CustomHomeScreen/Users')}
+      />
+      <Button
+        title="User Details Screen: Joe"
+        onPress={() =>
+          navigation.navigate('CustomHomeScreen/UserDetails', {
+            userId: 'Joe',
+            name: 'Joe',
+          })
+        }
+      />
+    </View>
+  );
+};

--- a/example/storybook/stories/CustomScreenInjection/customScreens/UserDetailsScreen.tsx
+++ b/example/storybook/stories/CustomScreenInjection/customScreens/UserDetailsScreen.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import { CustomHomeStackParamsList } from './types';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RouteProp } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+type UserDetailsNavigationProp = NativeStackNavigationProp<
+  CustomHomeStackParamsList,
+  'CustomHomeScreen/UserDetails'
+>;
+
+type UserDetailsRouteProp = RouteProp<
+  CustomHomeStackParamsList,
+  'CustomHomeScreen/UserDetails'
+>;
+
+export const UserDetailsScreen = () => {
+  const navigation = useNavigation<UserDetailsNavigationProp>();
+  const route = useRoute<UserDetailsRouteProp>();
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: route.params.name,
+    });
+  }, [navigation, route.params.name]);
+
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <Text>{`User ID: ${route.params.userId}`}</Text>
+    </View>
+  );
+};

--- a/example/storybook/stories/CustomScreenInjection/customScreens/UsersScreen.tsx
+++ b/example/storybook/stories/CustomScreenInjection/customScreens/UsersScreen.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Button, View } from 'react-native';
+import { CustomHomeStackParamsList } from './types';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
+
+type UsersScreenNavigationProp = NativeStackNavigationProp<
+  CustomHomeStackParamsList,
+  'CustomHomeScreen/Users'
+>;
+
+export const UsersScreen = () => {
+  const navigation = useNavigation<UsersScreenNavigationProp>();
+
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <Button
+        title="Joe's user screen"
+        onPress={() =>
+          navigation.navigate('CustomHomeScreen/UserDetails', {
+            userId: 'joe',
+            name: 'Joe',
+          })
+        }
+      />
+      <Button
+        title="Amy's user screen"
+        onPress={() =>
+          navigation.navigate('CustomHomeScreen/UserDetails', {
+            userId: 'amy',
+            name: 'Amy',
+          })
+        }
+      />
+    </View>
+  );
+};

--- a/example/storybook/stories/CustomScreenInjection/customScreens/index.tsx
+++ b/example/storybook/stories/CustomScreenInjection/customScreens/index.tsx
@@ -1,0 +1,4 @@
+export * from './UserDetailsScreen';
+export * from './UsersScreen';
+export * from './types';
+export * from './NavigationPlaygroundScreen';

--- a/example/storybook/stories/CustomScreenInjection/customScreens/types.ts
+++ b/example/storybook/stories/CustomScreenInjection/customScreens/types.ts
@@ -1,0 +1,6 @@
+import { HomeStackParamList } from '../../../../../src';
+
+export type CustomHomeStackParamsList = HomeStackParamList & {
+  'CustomHomeScreen/Users': undefined;
+  'CustomHomeScreen/UserDetails': { userId: string; name: string };
+};

--- a/example/storybook/stories/index.ts
+++ b/example/storybook/stories/index.ts
@@ -1,5 +1,6 @@
 import './BrandConfigProvider/BrandConfigProvider.stories';
 import './CustomAppTileScreen.stories';
+import './CustomScreenInjection/CustomScreenInjection.stories';
 import './ExampleApp/ExampleApp.stories';
 import './NoInternetToastProvider.stories';
 import './Notifications/NotificationsScreen.stories';

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     '<rootDir>/src/**/*.test.{js,jsx,ts,tsx}',
   ],
   moduleNameMapper: {
-    '\\.svg': '<rootDir>/__mocks__/svgMock.tsx',
+    '\\.(svg|png)': '<rootDir>/__mocks__/ImageMock.tsx',
   },
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx', 'jsx', 'node', 'mjs'],
   modulePathIgnorePatterns: [

--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -3,6 +3,16 @@ import { getBundleId } from 'react-native-device-info';
 import { AppTile } from '../hooks/useAppConfig';
 import { SvgProps } from 'react-native-svg';
 import { Theme } from '../components/BrandConfigProvider';
+import {
+  NavigationState,
+  ParamListBase,
+  TypedNavigator,
+} from '@react-navigation/native';
+import {
+  NativeStackNavigationEventMap,
+  NativeStackNavigationOptions,
+} from '@react-navigation/native-stack';
+import { NativeStackNavigatorProps } from '@react-navigation/native-stack/lib/typescript/src/types';
 
 /**
  * DeveloperConfig provides a single interface to configure the app at build-time.
@@ -29,6 +39,17 @@ export interface RouteColor {
   color: (theme: Theme) => string;
 }
 
+export type Navigator<
+  ParamList extends ParamListBase,
+  Props extends Record<string, unknown>,
+> = TypedNavigator<
+  ParamList,
+  NavigationState,
+  NativeStackNavigationOptions,
+  NativeStackNavigationEventMap,
+  React.ComponentType<Props>
+>;
+
 export type DeveloperConfig = {
   appTileScreens?: AppTileScreens;
   simpleTheme?: SimpleTheme;
@@ -54,6 +75,9 @@ export type DeveloperConfig = {
     };
   };
   pushNotificationsConfig?: PushNotificationsConfig;
+  getAdditionalHomeScreens?: <ParamList extends ParamListBase>(
+    HomeStack: Navigator<ParamList, NativeStackNavigatorProps>,
+  ) => JSX.Element[];
 };
 
 export type AppTileScreens = {

--- a/src/navigators/HomeStack.tsx
+++ b/src/navigators/HomeStack.tsx
@@ -19,10 +19,13 @@ import {
 import { AuthedAppTileScreen } from '../screens/AuthedAppTileScreen';
 import { HomeStackParamList } from './types';
 import { CircleDiscussionScreen } from '../screens/CircleDiscussionScreen';
+import { useDeveloperConfig } from '../hooks';
 
 const Stack = createNativeStackNavigator<HomeStackParamList>();
 
 export function HomeStack() {
+  const { getAdditionalHomeScreens } = useDeveloperConfig();
+
   return (
     <Stack.Navigator screenOptions={{ header: AppNavHeader }}>
       <Stack.Screen name="Home" component={HomeScreen} />
@@ -50,6 +53,7 @@ export function HomeStack() {
           headerRight: SaveEditorButton,
         })}
       />
+      {getAdditionalHomeScreens?.(Stack)}
     </Stack.Navigator>
   );
 }

--- a/src/navigators/index.ts
+++ b/src/navigators/index.ts
@@ -3,3 +3,4 @@ export * from './NotificationsStack';
 export * from './RootStack';
 export * from './SettingsStack';
 export * from './TabNavigator';
+export * from './types';


### PR DESCRIPTION
## Changes
- This PR exposes the Home navigation stack so custom screens can be added to it.

## Screenshots
- In this video, The FHIR Example screen is a custom screen that was added to the Home navigation stack.
- The `App Tile` screen is an existing screen, and demonstrates that we can from custom screens to "LifeOmic" screens.

https://github.com/lifeomic/react-native-sdk/assets/19395435/ccea8236-41fd-4175-9fa1-8a98459dacff

