### PR TITLE
fix: PHC-4968 Add Chart Style Overrides

### DIFF
--- a/src/components/BrandConfigProvider/styles/createStyles.ts
+++ b/src/components/BrandConfigProvider/styles/createStyles.ts
@@ -40,7 +40,7 @@ export type NamedStyles<T> = {
     ? ImageStyle
     : P extends `${string}${IgnoreCapitals<ViewSuffix>}`
     ? ViewStyle
-    : T[P];
+    : Partial<T[P]>;
 };
 
 /**

--- a/src/components/MyData/LineChart/DataSelector.tsx
+++ b/src/components/MyData/LineChart/DataSelector.tsx
@@ -6,7 +6,8 @@ import { eachDayOfInterval, format, isSameDay } from 'date-fns';
 import { sortBy } from 'lodash';
 import { PointData } from './useChartData';
 import { G, Text, Circle, Rect } from 'react-native-svg';
-import { useTheme } from '../../../hooks';
+import { useStyles } from '../../../hooks';
+import { defaultChartStyles } from '../styles';
 
 type Props = {
   xDomain: [number, number];
@@ -28,7 +29,7 @@ type Selection = {
 
 export const DataSelector = (props: Props) => {
   const { trace1, trace2, xDomain } = props;
-  const theme = useTheme();
+  const { styles } = useStyles(defaultChartStyles);
   const common = useCommonChartProps();
   const [selection, setSelection] = useState<Selection>();
 
@@ -109,7 +110,7 @@ export const DataSelector = (props: Props) => {
           barWidth={StyleSheet.hairlineWidth}
           style={{
             data: {
-              fill: theme.colors.onBackground,
+              fill: styles.dataSelectionTooltip?.lineColor,
             },
           }}
         />
@@ -162,7 +163,7 @@ type CustomLabelProps = {
 };
 
 const CustomLabel = ({ selection, x = 0, y = 0 }: CustomLabelProps) => {
-  const theme = useTheme();
+  const { styles } = useStyles(defaultChartStyles);
 
   const decreaseBy = !selection.point1 || !selection.point2 ? 25 : 0;
   const shiftX = Math.min(selection.chartWidth - (x + 115 - decreaseBy), 0);
@@ -179,30 +180,35 @@ const CustomLabel = ({ selection, x = 0, y = 0 }: CustomLabelProps) => {
         x={-shiftX}
         y={0}
         height={25}
-        strokeWidth={1}
-        stroke={theme.colors.onBackground}
+        strokeWidth={styles.dataSelectionTooltip?.lineWidth}
+        stroke={styles.dataSelectionTooltip?.lineColor}
       />
       <Rect
         x={-12}
         y={-20}
         width={115 - decreaseBy}
         height={30}
-        fill={theme.colors.primaryContainer}
-        stroke={theme.colors.border}
-        strokeWidth={StyleSheet.hairlineWidth}
+        fill={styles.dataSelectionTooltip?.backgroundColor}
+        stroke={styles.dataSelectionTooltip?.border}
+        strokeWidth={styles.dataSelectionTooltip?.borderWidth}
       />
-      <Text x={0} y={0} fill={theme.colors.onPrimaryContainer}>
+      <Text x={0} y={0} fill={styles.dataSelectionTooltip?.dateTextColor}>
         {dateString}
       </Text>
       {selection.point1 && (
         <>
-          <Circle x={55} y={-5} r={9} fill={theme.colors.primary} />
+          <Circle
+            x={55}
+            y={-5}
+            r={9}
+            fill={selection.point1.trace.color ?? styles.colors?.trace1}
+          />
           <Text
             x={55}
             y={-4}
             textAnchor="middle"
             alignmentBaseline="middle"
-            fill={theme.colors.onPrimary}
+            fill={styles.dataSelectionTooltip?.bubble1TextColor}
           >
             {Math.round(selection.point1?.y)}
           </Text>
@@ -214,14 +220,14 @@ const CustomLabel = ({ selection, x = 0, y = 0 }: CustomLabelProps) => {
             x={80 - decreaseBy}
             y={-5}
             r={9}
-            fill={theme.colors.secondary}
+            fill={selection.point2.trace.color ?? styles.colors?.trace2}
           />
           <Text
             x={80 - decreaseBy}
             y={-4}
             textAnchor="middle"
             alignmentBaseline="middle"
-            fill={theme.colors.onSecondary}
+            fill={styles.dataSelectionTooltip?.bubble2TextColor}
           >
             {Math.round(selection.point2?.y)}
           </Text>

--- a/src/components/MyData/LineChart/Title.tsx
+++ b/src/components/MyData/LineChart/Title.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Trace } from './TraceLine';
-import { useVictoryTheme } from '../useVictoryTheme';
 import { Text } from 'react-native-paper';
 import { View } from 'react-native';
 import { Svg, Line, Circle } from 'react-native-svg';
-import type { StringOrNumberOrCallback } from 'victory-core/lib/types/callbacks';
 import { createStyles } from '../../BrandConfigProvider';
 import { useStyles } from '../../../hooks';
+import { defaultChartStyles } from '../styles';
 
 type Props = {
   title: string;
@@ -17,11 +16,7 @@ type Props = {
 export const Title = (props: Props) => {
   const { title, trace1, trace2 } = props;
   const { styles } = useStyles(defaultStyles);
-  const primaryTheme = useVictoryTheme('primary');
-  const secondaryTheme = useVictoryTheme('secondary');
-
-  const primaryColor = primaryTheme.line?.style?.data?.stroke;
-  const secondaryColor = secondaryTheme.line?.style?.data?.stroke;
+  const { styles: chartStyles } = useStyles(defaultChartStyles);
 
   return (
     <View style={styles.container}>
@@ -29,11 +24,11 @@ export const Title = (props: Props) => {
         {title}
       </Text>
       <View style={styles.traceContainer}>
-        <DotLine color={toColor(primaryColor)} />
+        <DotLine color={trace1.color ?? chartStyles.colors?.trace1} />
         <Text style={styles.traceLabelText}>{trace1.label}</Text>
         {trace2 && (
           <>
-            <DotLine color={toColor(secondaryColor)} />
+            <DotLine color={trace2.color ?? chartStyles.colors?.trace2} />
             <Text style={styles.traceLabelText}>{trace2.label}</Text>
           </>
         )}
@@ -42,12 +37,7 @@ export const Title = (props: Props) => {
   );
 };
 
-const toColor = (creator?: StringOrNumberOrCallback) => {
-  const value = typeof creator === 'function' ? creator({}) : creator;
-  return value?.toString() ?? '';
-};
-
-const DotLine = ({ color }: { color: string }) => (
+const DotLine = ({ color }: { color?: string }) => (
   <Svg width={44} height={12}>
     <Line x1={0} y1={6} x2={44} y2={6} strokeWidth={2} stroke={color} />
     <Circle x={22} y={6} r={6} fill={color} />

--- a/src/components/MyData/LineChart/TraceLine.tsx
+++ b/src/components/MyData/LineChart/TraceLine.tsx
@@ -9,20 +9,21 @@ export type Trace = {
   type: 'Observation';
   label: string;
   code: Pick<fhir3.Coding, 'code' | 'system'>;
+  color?: string;
 };
 
 type Props = {
   trace: Trace;
   xDomain: [number, number];
   data: PointData[];
-  variant?: 'primary' | 'secondary';
+  variant?: 'trace1' | 'trace2';
 };
 
 export const TraceLine = (props: Props) => {
-  const { trace, data, xDomain, variant = 'primary' } = props;
-  const isPrimary = variant === 'primary';
+  const { trace, data, xDomain, variant = 'trace1' } = props;
+  const isTrace1 = variant === 'trace1';
   const common = useCommonChartProps();
-  const theme = useVictoryTheme(variant);
+  const theme = useVictoryTheme(trace, variant);
 
   if (!data?.length) {
     return null;
@@ -43,7 +44,7 @@ export const TraceLine = (props: Props) => {
         minDomain={domainMin}
         tickCount={domainMax === domainMin ? 1 : undefined}
         tickFormat={(value) => round(value, 1)}
-        orientation={isPrimary ? 'left' : 'right'}
+        orientation={isTrace1 ? 'left' : 'right'}
       />
       <VictoryLine
         {...common}

--- a/src/components/MyData/LineChart/index.test.tsx
+++ b/src/components/MyData/LineChart/index.test.tsx
@@ -33,7 +33,7 @@ const mockDateLabel = format(mockDate, 'MMM dd');
 describe('LineChart', () => {
   it('should render the chart', async () => {
     mockUseChartData.mockReturnValue({
-      trace1Data: [{ x: Number(mockDate), y: 5 }],
+      trace1Data: [{ x: Number(mockDate), y: 5, trace: {} }],
       trace2Data: [],
     });
 
@@ -63,8 +63,8 @@ describe('LineChart', () => {
 
   it('should render the chart with second trace when supplied', async () => {
     mockUseChartData.mockReturnValue({
-      trace1Data: [{ x: Number(mockDate), y: 5 }],
-      trace2Data: [{ x: Number(mockDate), y: 6 }],
+      trace1Data: [{ x: Number(mockDate), y: 5, trace: {} }],
+      trace2Data: [{ x: Number(mockDate), y: 6, trace: {} }],
     });
 
     const { findAllByText } = render(
@@ -119,7 +119,7 @@ describe('LineChart', () => {
 
   it('should allow selecting the data to see details', async () => {
     mockUseChartData.mockReturnValue({
-      trace1Data: [{ x: Number(mockDate), y: 5 }],
+      trace1Data: [{ x: Number(mockDate), y: 5, trace: {} }],
       trace2Data: [],
     });
 
@@ -146,10 +146,10 @@ describe('LineChart', () => {
   it('should allow selecting data details and display two points of data', async () => {
     mockUseChartData.mockReturnValue({
       trace1Data: [
-        { x: Number(mockDate), y: 5 },
-        { x: Number(addDays(mockDate, 1)), y: 10 },
+        { x: Number(mockDate), y: 5, trace: {} },
+        { x: Number(addDays(mockDate, 1)), y: 10, trace: {} },
       ],
-      trace2Data: [{ x: Number(mockDate), y: 6 }],
+      trace2Data: [{ x: Number(mockDate), y: 6, trace: {} }],
     });
 
     const { getByTestId } = render(
@@ -182,7 +182,7 @@ describe('LineChart', () => {
 
   it('can deselect data details', async () => {
     mockUseChartData.mockReturnValue({
-      trace1Data: [{ x: Number(mockDate), y: 5 }],
+      trace1Data: [{ x: Number(mockDate), y: 5, trace: {} }],
       trace2Data: [],
     });
 

--- a/src/components/MyData/LineChart/index.tsx
+++ b/src/components/MyData/LineChart/index.tsx
@@ -76,7 +76,7 @@ const LineChart = (props: Props) => {
             trace={trace2}
             data={trace2Data}
             xDomain={domain}
-            variant="secondary"
+            variant="trace2"
           />
         )}
         <DataSelector

--- a/src/components/MyData/LineChart/useChartData.test.ts
+++ b/src/components/MyData/LineChart/useChartData.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-native';
 import { startOfDay } from 'date-fns';
 import { useFhirClient } from '../../../hooks';
 import { useChartData } from './useChartData';
+import { Trace } from './TraceLine';
 
 jest.mock('../../../hooks/useFhirClient', () => ({
   useFhirClient: jest.fn(),
@@ -40,14 +41,16 @@ describe('useChartData', () => {
         data: undefined,
       });
 
+    const trace1: Trace = {
+      label: 'Label',
+      type: 'Observation',
+      code: { code: 'code', system: 'system' },
+    };
+
     const { result } = renderHook(() =>
       useChartData({
         dateRange: [new Date(0), new Date(0)],
-        trace1: {
-          label: 'Label',
-          type: 'Observation',
-          code: { code: 'code', system: 'system' },
-        },
+        trace1,
       }),
     );
 
@@ -68,6 +71,7 @@ describe('useChartData', () => {
         size: 5,
         x: Number(startOfDay(new Date(0))),
         y: 5,
+        trace: trace1,
       },
     ]);
     expect(result.current.trace2Data).toEqual([]);
@@ -112,19 +116,22 @@ describe('useChartData', () => {
         },
       });
 
+    const trace1: Trace = {
+      label: 'Label',
+      type: 'Observation',
+      code: { code: 'code', system: 'system' },
+    };
+    const trace2: Trace = {
+      label: 'Label',
+      type: 'Observation',
+      code: { code: 'code2', system: 'system2' },
+    };
+
     const { result } = renderHook(() =>
       useChartData({
         dateRange: [new Date(0), new Date(0)],
-        trace1: {
-          label: 'Label',
-          type: 'Observation',
-          code: { code: 'code', system: 'system' },
-        },
-        trace2: {
-          label: 'Label',
-          type: 'Observation',
-          code: { code: 'code2', system: 'system2' },
-        },
+        trace1,
+        trace2,
       }),
     );
 
@@ -142,10 +149,12 @@ describe('useChartData', () => {
       {
         x: Number(startOfDay(new Date(0))),
         y: 0,
+        trace: trace1,
       },
       {
         x: Number(startOfDay(new Date(0))),
         y: 3,
+        trace: trace1,
       },
     ]);
     expect(result.current.trace2Data).toEqual([
@@ -153,6 +162,7 @@ describe('useChartData', () => {
         size: 5,
         x: Number(startOfDay(new Date(0))),
         y: 5,
+        trace: trace2,
       },
     ]);
   });

--- a/src/components/MyData/LineChart/useChartData.ts
+++ b/src/components/MyData/LineChart/useChartData.ts
@@ -26,8 +26,8 @@ export const useChartData = (props: Props) => {
     enabled: !!trace2,
   });
 
-  const trace1Data = sortBy(extractPointData(trace1Res), 'x');
-  const trace2Data = sortBy(extractPointData(trace2Res), 'x');
+  const trace1Data = sortBy(extractPointData(trace1Res, trace1), 'x');
+  const trace2Data = sortBy(extractPointData(trace2Res, trace2!), 'x');
 
   return {
     trace1Data,
@@ -35,15 +35,19 @@ export const useChartData = (props: Props) => {
   };
 };
 
-const extractPointData = ({
-  data,
-}: {
-  data?: fhir3.Bundle<fhir3.Observation>;
-}) =>
+const extractPointData = (
+  {
+    data,
+  }: {
+    data?: fhir3.Bundle<fhir3.Observation>;
+  },
+  trace: Trace,
+) =>
   data?.entry?.map((entry) => ({
     y: entry.resource?.valueQuantity?.value ?? 0,
     x: Number(startOfDay(new Date(entry.resource?.effectiveDateTime ?? ''))),
     size: data.entry?.length === 1 ? 5 : undefined, // TODO: Make size configurable
+    trace,
   })) ?? [];
 
 export type PointData = ReturnType<typeof extractPointData>[number];

--- a/src/components/MyData/styles.ts
+++ b/src/components/MyData/styles.ts
@@ -1,0 +1,59 @@
+import { StyleSheet } from 'react-native';
+import { VictoryThemeDefinition } from 'victory-core';
+import { createStyles } from '../BrandConfigProvider';
+
+type StyleExtractor<T> = T extends { style: unknown } ? T['style'] : never;
+type VictoryStyleProp<K extends keyof VictoryThemeDefinition> = StyleExtractor<
+  Required<Required<VictoryThemeDefinition>[K]>
+>;
+
+export const defaultChartStyles = createStyles('ChartStyles', (theme) => ({
+  independentAxis: {
+    grid: {
+      strokeDasharray: '0 2 0',
+      stroke: theme.colors.outline,
+    },
+    axis: {
+      stroke: theme.colors.onBackground,
+    },
+    tickLabels: {
+      padding: 8,
+      fill: theme.colors.onBackground,
+    },
+  } as VictoryStyleProp<'axis'>,
+  dependentAxis: {
+    grid: {
+      display: 'none',
+    },
+    tickLabels: {
+      padding: 4,
+    },
+  } as VictoryStyleProp<'dependentAxis'>,
+  line: {
+    data: {
+      strokeWidth: 2,
+    },
+  } as VictoryStyleProp<'line'>,
+  scatter: {} as VictoryStyleProp<'scatter'>,
+  dataSelectionTooltip: {
+    lineColor: theme.colors.onBackground,
+    lineWidth: 1,
+    border: theme.colors.border,
+    backgroundColor: theme.colors.primaryContainer,
+    borderWidth: StyleSheet.hairlineWidth,
+    dateTextColor: theme.colors.onPrimaryContainer,
+    bubble1TextColor: theme.colors.onPrimary,
+    bubble2TextColor: theme.colors.onSecondary,
+  },
+  colors: {
+    trace1: theme.colors.primary,
+    trace2: theme.colors.secondary,
+  },
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultChartStyles> {}
+}
+
+export type LogoHeaderStyles = NamedStylesProp<typeof defaultChartStyles>;

--- a/src/components/MyData/useVictoryTheme.ts
+++ b/src/components/MyData/useVictoryTheme.ts
@@ -1,58 +1,54 @@
-import { useTheme } from '../../hooks';
-import { VictoryTheme } from 'victory-native';
-
-type Theme = (typeof VictoryTheme)['grayscale'];
+import { useStyles } from '../../hooks';
+import { VictoryThemeDefinition } from 'victory-core';
+import { Trace } from './LineChart/TraceLine';
+import { defaultChartStyles } from './styles';
+import { merge } from 'lodash';
 
 export const useVictoryTheme = (
-  variant: 'primary' | 'secondary' = 'primary',
-): Theme => {
-  const theme = useTheme();
+  trace?: Trace,
+  variant: 'trace1' | 'trace2' = 'trace1',
+): VictoryThemeDefinition => {
+  const { styles } = useStyles(defaultChartStyles);
 
   return {
     axis: {
-      style: {
-        grid: {
-          strokeDasharray: '0 2 0',
-          stroke: theme.colors.outline,
-        },
-        axis: {
-          stroke: theme.colors.onBackground,
-        },
-        tickLabels: {
-          padding: 8,
-        },
-      },
+      style: styles.independentAxis,
     },
     dependentAxis: {
-      style: {
-        axis: {
-          stroke: theme.colors[variant],
+      style: merge(
+        {
+          axis: {
+            stroke: trace?.color ?? styles.colors?.[variant],
+          },
+          tickLabels: {
+            fill: trace?.color ?? styles.colors?.[variant],
+          },
+          axisLabel: {
+            fill: trace?.color ?? styles.colors?.[variant],
+          },
         },
-        grid: {
-          display: 'none',
-        },
-        tickLabels: {
-          padding: 4,
-        },
-        axisLabel: {
-          fill: theme.colors[variant],
-        },
-      },
+        styles.dependentAxis,
+      ),
     },
     line: {
-      style: {
-        data: {
-          stroke: theme.colors[variant],
-          strokeWidth: 2,
+      style: merge(
+        {
+          data: {
+            stroke: trace?.color ?? styles.colors?.[variant],
+          },
         },
-      },
+        styles.line,
+      ),
     },
     scatter: {
-      style: {
-        data: {
-          fill: theme.colors[variant],
+      style: merge(
+        {
+          data: {
+            fill: trace?.color ?? styles.colors?.[variant],
+          },
         },
-      },
+        styles.scatter,
+      ),
     },
   };
 };


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds the ability to specify chart styles using style overrides
  - Makes the independent axis labels use the trace color
  - Adds the ability to set a color on the trace

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
![image](https://github.com/lifeomic/react-native-sdk/assets/2295908/7fb65f50-9e6c-446c-9166-fdbaf91187d2)
