### PR TITLE
fix: PHC-4968 Fix Chart Label Render Issues

### DIFF
--- a/src/components/MyData/LineChart/DataSelector.tsx
+++ b/src/components/MyData/LineChart/DataSelector.tsx
@@ -60,8 +60,10 @@ export const DataSelector = (props: Props) => {
         domain: trace1Domain,
       };
 
-      const trace1Percent = point1?.y / trace1Domain[1];
-      const trace2Percent = point2?.y / trace2Domain[1];
+      const trace1Percent =
+        (point1?.y - trace1Domain[0]) / (trace1Domain[1] - trace1Domain[0]);
+      const trace2Percent =
+        (point2?.y - trace2Domain[0]) / (trace2Domain[1] - trace2Domain[0]);
 
       if (!point1 || trace2Percent > trace1Percent) {
         highestPointMeta = {
@@ -209,8 +211,13 @@ const CustomLabel = ({ selection, x = 0, y = 0 }: CustomLabelProps) => {
             textAnchor="middle"
             alignmentBaseline="middle"
             fill={styles.dataSelectionTooltip?.bubble1TextColor}
+            fontSize={
+              Math.round(selection.point1.y).toString().length > 2
+                ? 8
+                : undefined
+            }
           >
-            {Math.round(selection.point1?.y)}
+            {Math.round(selection.point1.y)}
           </Text>
         </>
       )}
@@ -227,9 +234,14 @@ const CustomLabel = ({ selection, x = 0, y = 0 }: CustomLabelProps) => {
             y={-4}
             textAnchor="middle"
             alignmentBaseline="middle"
+            fontSize={
+              Math.round(selection.point2.y).toString().length > 2
+                ? 8
+                : undefined
+            }
             fill={styles.dataSelectionTooltip?.bubble2TextColor}
           >
-            {Math.round(selection.point2?.y)}
+            {Math.round(selection.point2.y)}
           </Text>
         </>
       )}


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes an issue where the label was displayed below the highest point if the lower points scale was narrow
  - Fixes an issue where 3+ digit numbers were too large for the bubble. We will likly need to address this again at some point for 4+ character strings.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<img width="186" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/98b4d760-bd21-4314-b58e-02d0028966cc">
<img width="132" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/f74fc6bb-a8dc-403b-b695-093674b4d257">
