### PR TITLE
fix: PHC-4969 Add My Data Screen to Tiles List

### DIFF
--- a/example/storybook/stories/MyData/MyData.stories.tsx
+++ b/example/storybook/stories/MyData/MyData.stories.tsx
@@ -88,10 +88,7 @@ storiesOf('MyDataScreen', module)
           dates = chunk(dates, 12).map((d) => d[0]);
         }
 
-        return [
-          200,
-          buildSampleDate(data.coding.map((c: any) => c.code).join(','), dates),
-        ];
+        return [200, buildSampleDate(data.code, dates)];
       });
     }),
   )

--- a/src/components/BrandConfigProvider/icons/IconProvider.tsx
+++ b/src/components/BrandConfigProvider/icons/IconProvider.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext } from 'react';
 import * as Chromicons from '@lifeomic/chromicons-native';
 import { TriangleFilled } from './TriangleFilled';
 
+export type ChromiconName = keyof typeof Chromicons;
+
 export type Icons = typeof Chromicons &
   Record<string, React.ComponentType> & {
     TriangleFilled: typeof TriangleFilled;

--- a/src/components/MyData/LineChart/TraceLine.tsx
+++ b/src/components/MyData/LineChart/TraceLine.tsx
@@ -25,10 +25,6 @@ export const TraceLine = (props: Props) => {
   const common = useCommonChartProps();
   const theme = useVictoryTheme(trace, variant);
 
-  if (!data?.length) {
-    return null;
-  }
-
   const domainMax = Math.max(...data.map((v) => v.y));
   const domainMin = Math.min(...data.map((v) => v.y));
 
@@ -46,20 +42,24 @@ export const TraceLine = (props: Props) => {
         tickFormat={(value) => round(value, 1)}
         orientation={isTrace1 ? 'left' : 'right'}
       />
-      <VictoryLine
-        {...common}
-        domain={{ x: xDomain }}
-        standalone={false}
-        data={data}
-        theme={theme}
-      />
-      <VictoryScatter
-        {...common}
-        domain={{ x: xDomain }}
-        standalone={false}
-        data={data}
-        theme={theme}
-      />
+      {!!data?.length && (
+        <>
+          <VictoryLine
+            {...common}
+            domain={{ x: xDomain }}
+            standalone={false}
+            data={data}
+            theme={theme}
+          />
+          <VictoryScatter
+            {...common}
+            domain={{ x: xDomain }}
+            standalone={false}
+            data={data}
+            theme={theme}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/components/MyData/LineChart/index.test.tsx
+++ b/src/components/MyData/LineChart/index.test.tsx
@@ -105,7 +105,7 @@ describe('LineChart', () => {
       trace2Data: [],
     });
 
-    const { findByText } = render(
+    const { findAllByText } = render(
       <LineChart
         dateRange={[mockDate, mockDate]}
         title="Test Title"
@@ -122,7 +122,7 @@ describe('LineChart', () => {
       />,
     );
 
-    expect(await findByText('Trace1Label')).toBeDefined(); // Legend Only
+    expect(await findAllByText('Trace1Label')).toHaveLength(2); // Legend & Axis
   });
 
   it('should allow selecting the data to see details', async () => {

--- a/src/components/tiles/TilesList.tsx
+++ b/src/components/tiles/TilesList.tsx
@@ -6,10 +6,11 @@ import { Tile, TileStyles } from './Tile';
 import { TrackTile } from '../TrackTile';
 import { useStyles, useDeveloperConfig } from '../../hooks';
 import { getCustomAppTileComponent } from '../../common/DeveloperConfig';
-import { createStyles, useIcons } from '../BrandConfigProvider';
+import { ChromiconName, createStyles, useIcons } from '../BrandConfigProvider';
 import { SvgUri } from 'react-native-svg';
 import { PillarsTile } from '../TrackTile/PillarsTile/PillarsTile';
 import { HomeStackScreenProps } from '../../navigators/types';
+import { t } from '../../../lib/i18n';
 
 interface Props extends HomeStackScreenProps<'Home'> {
   styles?: TilesListStyles;
@@ -25,6 +26,7 @@ export function TilesList({ navigation, styles: instanceStyles }: Props) {
   const trackTileEnabled = data?.homeTab?.tiles?.includes?.('trackTile');
   const trackTileTitle = data?.homeTab?.trackTileSettings?.title;
   const todayTileEnabled = data?.homeTab?.tiles?.includes?.('todayTile');
+  const myDataTileEnabled = data?.homeTab?.tiles?.includes?.('myDataTile');
   const todayTile = data?.homeTab?.todayTile;
 
   const onCircleTilePress = useCallback(
@@ -93,8 +95,17 @@ export function TilesList({ navigation, styles: instanceStyles }: Props) {
             id={todayTile.id}
             key={todayTile.id}
             title={todayTile.title}
-            Icon={TodayIcon}
+            Icon={tileIcon('HeartCheck', 'today')}
             onPress={onTodayTilePress}
+          />
+        )}
+        {myDataTileEnabled && (
+          <Tile
+            id={'my-data-tile'}
+            key={'my-data-tile'}
+            title={t('My Data')}
+            Icon={tileIcon('Scatter', 'my-data-tile-icon')}
+            onPress={() => navigation.navigate('Home/MyData')}
           />
         )}
         {data?.homeTab?.appTiles?.map((appTile: AppTile) => (
@@ -112,7 +123,7 @@ export function TilesList({ navigation, styles: instanceStyles }: Props) {
             key={circleTile.circleId}
             title={circleTile.buttonText ?? circleTile.circleName}
             onPress={onCircleTilePress(circleTile)}
-            Icon={circleIcon(circleTile.circleId)}
+            Icon={tileIcon('HeartCircle', circleTile.circleId)}
           />
         ))}
       </View>
@@ -136,28 +147,18 @@ const appTileIcon = (id: string, uri?: string, styles?: ImageStyle) =>
     return null;
   };
 
-const circleIcon = (circleId: string) =>
-  function CircleIcon() {
-    const { HeartCircle, [circleId]: CustomCircleIcon } = useIcons();
+const tileIcon = (defaultIconName: ChromiconName, customIdentifier: string) =>
+  function TileIcon() {
+    const { [defaultIconName]: DefaultIcon, [customIdentifier]: CustomIcon } =
+      useIcons();
     const { styles } = useStyles(defaultStyles);
 
-    if (CustomCircleIcon) {
-      return <CustomCircleIcon />;
+    if (CustomIcon) {
+      return <CustomIcon />;
     }
 
-    return <HeartCircle stroke={styles.circleIconImage?.overlayColor} />;
+    return <DefaultIcon stroke={styles.tileIconImage?.overlayColor} />;
   };
-
-const TodayIcon = () => {
-  const { HeartCheck, today: CustomTodayIcon } = useIcons();
-  const { styles } = useStyles(defaultStyles);
-
-  if (CustomTodayIcon) {
-    return <CustomTodayIcon />;
-  }
-
-  return <HeartCheck stroke={styles.todayIconImage?.overlayColor} />;
-};
 
 const defaultStyles = createStyles('TilesList', (theme) => ({
   view: {},
@@ -170,7 +171,7 @@ const defaultStyles = createStyles('TilesList', (theme) => ({
     height: 30,
     marginRight: theme.spacing.small,
   },
-  circleIconImage: {
+  tileIconImage: {
     overlayColor: theme.colors.primarySource,
   },
   todayIconImage: {

--- a/src/hooks/useAppConfig.ts
+++ b/src/hooks/useAppConfig.ts
@@ -23,7 +23,7 @@ export interface CircleTile {
   isMember: boolean;
 }
 
-type Tile = 'todayTile' | 'trackTile' | 'pillarsTile';
+type Tile = 'todayTile' | 'trackTile' | 'pillarsTile' | 'myDataTile';
 
 export interface AppConfig {
   homeTab?: {

--- a/src/navigators/HomeStack.tsx
+++ b/src/navigators/HomeStack.tsx
@@ -20,6 +20,7 @@ import { AuthedAppTileScreen } from '../screens/AuthedAppTileScreen';
 import { HomeStackParamList } from './types';
 import { CircleDiscussionScreen } from '../screens/CircleDiscussionScreen';
 import { useDeveloperConfig } from '../hooks';
+import { MyDataScreen } from '../screens/MyDataScreen';
 
 const Stack = createNativeStackNavigator<HomeStackParamList>();
 
@@ -52,6 +53,11 @@ export function HomeStack() {
         options={() => ({
           headerRight: SaveEditorButton,
         })}
+      />
+      <Stack.Screen
+        name="Home/MyData"
+        component={MyDataScreen}
+        options={{ title: t('My Data') }}
       />
       {getAdditionalHomeScreens?.(Stack)}
     </Stack.Navigator>

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -75,6 +75,7 @@ export type HomeStackParamList = {
     trackerValue: TrackerValue;
     valuesContext: TrackerValuesContext;
   };
+  'Home/MyData': undefined;
 };
 
 export type NotificationsStackParamList = {


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds a tile for the native My Data Screens
  - Fixes a bug where the chart axis wasn't displayed if there was no data on the chart

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

https://github.com/lifeomic/react-native-sdk/assets/2295908/89c84d06-73ff-4b8e-8eb9-35ca9f36d751

