### PR TITLE
PHC-4968 Fix Empty Tick Labels

### DIFF
--- a/src/components/MyData/LineChart/TraceLine.tsx
+++ b/src/components/MyData/LineChart/TraceLine.tsx
@@ -38,6 +38,11 @@ export const TraceLine = (props: Props) => {
         label={trace.label}
         maxDomain={domainMax}
         minDomain={domainMin}
+        style={{
+          tickLabels: {
+            display: !data?.length ? 'none' : undefined,
+          },
+        }}
         tickCount={domainMax === domainMin ? 1 : undefined}
         tickFormat={(value) => round(value, 1)}
         orientation={isTrace1 ? 'left' : 'right'}


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes an issues where tick labels were rendered off the chart when trace doesn't have data

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><b>Before
 <td><b>After
<tr>
 <td><img width="372" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/6754cc82-f483-4cde-ab0a-236f6e1aa0b1">
 <td><img width="389" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/99fecb65-7c0e-4e46-8fe4-31c2b761c2e4">
</table>