### PR TITLE
feat: Add invite required screen

### DIFF
--- a/src/hooks/useActiveProject.test.tsx
+++ b/src/hooks/useActiveProject.test.tsx
@@ -57,9 +57,13 @@ const renderHookInContext = async () => {
 beforeEach(() => {
   useSubjectProjectsMock.mockReturnValue({
     data: mockSubjectProjects,
+    isLoading: false,
+    isFetched: true,
   });
   useMeMock.mockReturnValue({
     data: mockMe,
+    isLoading: false,
+    isFetched: true,
   });
 
   useAsyncStorageSpy.mockReturnValue([
@@ -104,7 +108,7 @@ test('exposes some props from useSubjectProjects and useMe', async () => {
     isFetched: true,
   });
   useMeMock.mockReturnValue({
-    isLoading: true,
+    isLoading: false,
     isFetched: true,
     error,
   });
@@ -112,7 +116,7 @@ test('exposes some props from useSubjectProjects and useMe', async () => {
   await rerender({});
 
   expect(result.current).toMatchObject({
-    isLoading: true,
+    isLoading: false,
     isFetched: true,
     error,
   });

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -16,6 +16,7 @@ export const useConsent = () => {
         {
           account,
           projectId: activeProject?.id,
+          accountHeaders,
         },
       ],
       () =>

--- a/src/hooks/useSubjectProjects.test.tsx
+++ b/src/hooks/useSubjectProjects.test.tsx
@@ -61,7 +61,16 @@ test('fetches and returns projects related to useMe', async () => {
   await waitFor(() => expect(result.current.data).toEqual([{}, {}]));
 });
 
-test('does not fetch if useMe has no data', async () => {
+/*
+  This test used to not fetch if useMe
+  returned empty. This would lead to an endless loading
+  state for the useSubjectProjects query for users that
+  do not have subjects, i.e, they were never invited to a project.
+  To control the flow of the app (specifically to navigate to the InviteRequired screen)
+  we need to know when this query has settled even if it failed.
+*/
+
+test('fetches even if useMe returns no data', async () => {
   useMeMock.mockReturnValue({
     isLoading: true,
   });
@@ -80,6 +89,6 @@ test('does not fetch if useMe has no data', async () => {
   await rerender({});
   await waitFor(() => result.current.isSuccess);
 
-  expect(axiosMock.history.get.length).toBe(0);
+  expect(axiosMock.history.get.length).toBe(3);
   expect(result.current.data).toBeUndefined();
 });

--- a/src/hooks/useSubjectProjects.tsx
+++ b/src/hooks/useSubjectProjects.tsx
@@ -18,7 +18,7 @@ export function useSubjectProjects() {
   const { httpClient } = useHttpClient();
 
   return useQuery(
-    `${account?.id}-projects`,
+    [`${account?.id}-projects`, subjects],
     () =>
       httpClient
         .get<ProjectsResponse>(
@@ -27,10 +27,7 @@ export function useSubjectProjects() {
         )
         .then((res) => res.data.items),
     {
-      enabled:
-        !!accountHeaders &&
-        (subjects?.length ?? 0) > 0 &&
-        !!subjects?.every((s) => s.projectId),
+      enabled: !!accountHeaders,
     },
   );
 }

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -24,6 +24,7 @@ export type LoggedInScreenProps<T extends keyof LoggedInRootParamList> =
 export type LoggedInRootParamList = {
   app: NavigatorScreenParams<TabParamList> | undefined;
   'screens/ConsentScreen': undefined;
+  InviteRequired: undefined;
   'Circle/Thread': { post: Post; createNewComment?: boolean };
 };
 

--- a/src/screens/InviteRequiredScreen.test.tsx
+++ b/src/screens/InviteRequiredScreen.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { InviteRequiredScreen } from './InviteRequiredScreen';
+import { useActiveAccount, useActiveProject, useConsent } from '../hooks';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+jest.mock('../hooks/useActiveProject', () => ({
+  useActiveProject: jest.fn(),
+}));
+jest.mock('../hooks/useActiveAccount', () => ({
+  useActiveAccount: jest.fn(),
+}));
+jest.mock('../hooks/useConsent', () => ({
+  useConsent: jest.fn(),
+}));
+
+const useConsentMock = useConsent as jest.Mock;
+const useActiveProjectMock = useActiveProject as jest.Mock;
+const useActiveAccountMock = useActiveAccount as jest.Mock;
+
+useConsentMock.mockReturnValue({
+  useShouldRenderConsentScreen: () => ({
+    shouldRenderConsentScreen: false,
+    isLoading: false,
+  }),
+});
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const mockReplace = jest.fn();
+const mockNavigation = {
+  replace: mockReplace,
+};
+
+const inviteRequiredScreen = (
+  <QueryClientProvider client={queryClient}>
+    <InviteRequiredScreen
+      navigation={mockNavigation as any}
+      route={jest.fn() as any}
+    />
+  </QueryClientProvider>
+);
+
+test('renders loading indicator while either query is loading', async () => {
+  useActiveProjectMock.mockReturnValue({
+    isLoading: true,
+    activeProject: undefined,
+    isFetched: false,
+  });
+  useActiveAccountMock.mockReturnValue({
+    isLoading: true,
+    account: undefined,
+    isFetched: false,
+  });
+
+  const { getByTestId, rerender } = render(inviteRequiredScreen);
+  expect(getByTestId('activity-indicator-view')).toBeDefined();
+
+  useActiveProjectMock.mockReturnValue({
+    isLoading: false,
+    activeProject: undefined,
+    isFetched: true,
+  });
+  useActiveAccountMock.mockReturnValue({
+    isLoading: true,
+    account: undefined,
+    isFetched: false,
+  });
+
+  rerender(inviteRequiredScreen);
+  expect(getByTestId('activity-indicator-view')).toBeDefined();
+});
+
+it('renders invite required text and logout button', () => {
+  useActiveProjectMock.mockReturnValue({
+    isLoading: false,
+    activeProject: undefined,
+    isFetched: true,
+  });
+  useActiveAccountMock.mockReturnValue({
+    isLoading: false,
+    account: undefined,
+    isFetched: true,
+  });
+  const { getByTestId } = render(inviteRequiredScreen);
+  expect(getByTestId('invite-only-text')).toBeDefined();
+});
+
+it('renders loading indicator if pending consent query', () => {
+  useActiveProjectMock.mockReturnValue({
+    isLoading: false,
+    activeProject: { id: 'someProjectId' },
+    isFetched: true,
+  });
+  useActiveAccountMock.mockReturnValue({
+    isLoading: false,
+    account: { id: 'someAccountId' },
+    isFetched: true,
+  });
+  useConsentMock.mockReturnValue({
+    useShouldRenderConsentScreen: () => ({
+      shouldRenderConsentScreen: false,
+      isLoading: true,
+    }),
+  });
+
+  const { getByTestId } = render(inviteRequiredScreen);
+  expect(getByTestId('activity-indicator-view')).toBeDefined();
+});
+
+it('replaces current route with consent screen if consent is required', () => {
+  useActiveProjectMock.mockReturnValue({
+    isLoading: false,
+    activeProject: { id: 'someProjectId' },
+    isFetched: true,
+  });
+  useActiveAccountMock.mockReturnValue({
+    isLoading: false,
+    account: { id: 'someAccountId' },
+    isFetched: true,
+  });
+  useConsentMock.mockReturnValue({
+    useShouldRenderConsentScreen: () => ({
+      shouldRenderConsentScreen: true,
+      isLoading: false,
+    }),
+  });
+
+  render(inviteRequiredScreen);
+  expect(mockReplace).toBeCalledWith('screens/ConsentScreen');
+});
+
+it('replaces current route with app if consent is not required', () => {
+  useActiveProjectMock.mockReturnValue({
+    isLoading: false,
+    activeProject: { id: 'someProjectId' },
+    isFetched: true,
+  });
+  useActiveAccountMock.mockReturnValue({
+    isLoading: false,
+    account: { id: 'someAccountId' },
+    isFetched: true,
+  });
+  useConsentMock.mockReturnValue({
+    useShouldRenderConsentScreen: () => ({
+      shouldRenderConsentScreen: false,
+      isLoading: false,
+    }),
+  });
+
+  render(inviteRequiredScreen);
+  expect(mockReplace).toBeCalledWith('app');
+});

--- a/src/screens/InviteRequiredScreen.tsx
+++ b/src/screens/InviteRequiredScreen.tsx
@@ -1,0 +1,112 @@
+import { t } from 'i18next';
+import React, { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import {
+  ActivityIndicatorView,
+  OAuthLogoutButton,
+  OAuthLogoutButtonStyles,
+  createStyles,
+} from '../components';
+import { tID } from '../common/testID';
+import {
+  useActiveAccount,
+  useActiveProject,
+  useConsent,
+  useStyles,
+} from '../hooks';
+import { LoggedInRootScreenProps } from '../navigators/types';
+
+export const InviteRequiredScreen = ({
+  navigation,
+}: LoggedInRootScreenProps<'InviteRequired'>) => {
+  const {
+    account,
+    isLoading: isLoadingAccount,
+    isFetched: isFetchedAccount,
+  } = useActiveAccount();
+  const {
+    activeProject,
+    isLoading: isLoadingProject,
+    isFetched: isFetchedProject,
+  } = useActiveProject();
+
+  const loadingProject = !isFetchedProject || isLoadingProject;
+  const loadingAccount = !isFetchedAccount || isLoadingAccount;
+  const loadingAccountOrProject = loadingProject || loadingAccount;
+  const hasAccountAndProject = !!(activeProject?.id && account?.id);
+
+  const { useShouldRenderConsentScreen } = useConsent();
+  const { shouldRenderConsentScreen, isLoading: loadingConsents } =
+    useShouldRenderConsentScreen();
+
+  const { styles } = useStyles(defaultStyles);
+
+  useEffect(() => {
+    if (!loadingAccountOrProject && !loadingConsents && hasAccountAndProject) {
+      if (shouldRenderConsentScreen) {
+        navigation.replace('screens/ConsentScreen');
+      } else {
+        navigation.replace('app');
+      }
+    }
+  }, [
+    account,
+    activeProject,
+    navigation,
+    shouldRenderConsentScreen,
+    loadingConsents,
+    loadingAccountOrProject,
+    hasAccountAndProject,
+  ]);
+
+  if (!loadingAccountOrProject && !hasAccountAndProject) {
+    if (__DEV__) {
+      console.info(
+        `Invite required! User is not part of both an account AND project. \n Account: ${account?.id} Project: ${activeProject?.id}`,
+      );
+    }
+    return (
+      <View style={styles.containerView}>
+        <Text style={styles.invitationLabel} testID={tID('invite-only-text')}>
+          {t(
+            'invite-required-text',
+            'This app is only available to use by invitation. Please contact your administrator for access.',
+          )}
+        </Text>
+        <OAuthLogoutButton
+          label={t('settings-logout', 'Logout')}
+          mode="contained"
+          style={styles.oAuthLogout}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <ActivityIndicatorView
+      message={t('root-stack-waiting-for-queries', 'Loading')}
+    />
+  );
+};
+
+const defaultStyles = createStyles('InviteRequiredScreen', (theme) => ({
+  containerView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginHorizontal: theme.spacing.medium,
+  },
+  invitationLabel: {
+    textAlign: 'center',
+  },
+  oAuthLogout: {
+    style: { marginTop: theme.spacing.small },
+  } as OAuthLogoutButtonStyles,
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}
+
+export type InviteRequiredScreenStyles = NamedStylesProp<typeof defaultStyles>;


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
- Adds new screen to the RootStack for a user that does have both an account and project set
- Vigorous debugging of some react queries uncovered some inconsistencies around loading/enabled controls and this PR makes several updates to ensure correct loading behavior.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
![Simulator Screen Shot - iPhone 14 Pro - 2023-06-28 at 13 39 58](https://github.com/lifeomic/react-native-sdk/assets/76954025/2727fc48-f7b5-4445-88ab-adc3f9db265f)

