### PR TITLE
fix: Improve handling when no subjects exist

### DIFF
--- a/src/hooks/useSubjectProjects.test.tsx
+++ b/src/hooks/useSubjectProjects.test.tsx
@@ -89,6 +89,6 @@ test('fetches even if useMe returns no data', async () => {
   await rerender({});
   await waitFor(() => result.current.isSuccess);
 
-  expect(axiosMock.history.get.length).toBe(3);
+  expect(axiosMock.history.get.length).toBe(1);
   expect(result.current.data).toBeUndefined();
 });

--- a/src/hooks/useSubjectProjects.test.tsx
+++ b/src/hooks/useSubjectProjects.test.tsx
@@ -80,12 +80,15 @@ test('fetches even if useMe returns no data', async () => {
   useMeMock.mockReturnValue({
     data: [],
   });
+
   await rerender({});
   await waitFor(() => result.current.isSuccess);
 
   useMeMock.mockReturnValue({
     data: [{ projectId: 'proj1' }, { noProjectIdEdgeCase: true }],
   });
+
+  axiosMock.onGet().replyOnce(200, { items: [] });
   await rerender({});
   await waitFor(() => result.current.isSuccess);
 

--- a/src/hooks/useSubjectProjects.tsx
+++ b/src/hooks/useSubjectProjects.tsx
@@ -17,15 +17,22 @@ export function useSubjectProjects() {
   const { data: subjects } = useMe();
   const { httpClient } = useHttpClient();
 
-  return useQuery(
+  return useQuery<Project[]>(
     [`${account?.id}-projects`, subjects],
-    () =>
-      httpClient
-        .get<ProjectsResponse>(
+    async () => {
+      if (subjects?.length) {
+        const res = await httpClient.get<ProjectsResponse>(
           `/v1/projects?id=${subjects?.map((s) => s.projectId).join(',')}`,
           { headers: accountHeaders },
-        )
-        .then((res) => res.data.items),
+        );
+        return res.data.items;
+      } else {
+        // Having no subjects is a supported state.
+        // Instead of disabling the query to wait for subjects we are
+        // returning a mock response to keep downstream queries moving
+        return new Promise((resolve) => resolve([]));
+      }
+    },
     {
       enabled: !!accountHeaders,
     },

--- a/src/hooks/useSubjectProjects.tsx
+++ b/src/hooks/useSubjectProjects.tsx
@@ -30,7 +30,7 @@ export function useSubjectProjects() {
         // Having no subjects is a supported state.
         // Instead of disabling the query to wait for subjects we are
         // returning a mock response to keep downstream queries moving
-        return new Promise((resolve) => resolve([]));
+        return [];
       }
     },
     {


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
Instead of performing a GET on an invalid URL return an empty array when subjects is not populated

## Screenshots
<!-- include screen recordings, if relevant to your changes -->