### PR TITLE
Hide background sync toggle if onToggleBackgroundSync is not provided

### DIFF
--- a/src/components/Wearables/SyncTypeSelectionView.tsx
+++ b/src/components/Wearables/SyncTypeSelectionView.tsx
@@ -163,6 +163,8 @@ export const getDisplayValueForSyncType = (
       return t('blood-pressure', 'Blood Pressure');
     case WearableStateSyncType.BodyMass:
       return t('weight', 'Weight');
+    case WearableStateSyncType.BodyMassIndex:
+      return t('body-mass-infex', 'BMI');
     case WearableStateSyncType.BreathKetones:
       return t('breath-ketones', 'Breath Ketones');
     case WearableStateSyncType.Immunization:

--- a/src/components/Wearables/WearableRow.tsx
+++ b/src/components/Wearables/WearableRow.tsx
@@ -347,6 +347,10 @@ export const WearableRow: FC<WearableRowProps> = (props) => {
     (enabledWearable: WearableIntegration) => {
       const backgroundSyncEnabled = _isBackgroundSyncEnabled(enabledWearable);
 
+      if (!onToggleBackgroundSync) {
+        return null;
+      }
+
       return (
         <WearableRowDetailSection
           icon={<Info />}
@@ -392,6 +396,7 @@ export const WearableRow: FC<WearableRowProps> = (props) => {
       styles.backgroundSyncDescription,
       switchProps,
       toggleBackgroundSync,
+      onToggleBackgroundSync,
       wearableProp,
     ],
   );


### PR DESCRIPTION
This hides background sync if it can't be enabled, and also provides a translation value for BMI.

https://github.com/lifeomic/react-native-sdk/assets/1445395/3674f13d-0464-4886-8a09-ddadce4b1d68

