### PR TITLE
fix: Clear caches on logout

### DIFF
--- a/src/components/TrackTile/hooks/test/useAxiosTrackTileService.test.ts
+++ b/src/components/TrackTile/hooks/test/useAxiosTrackTileService.test.ts
@@ -71,6 +71,12 @@ jest.mock('../../../../hooks/useActiveProject', () => ({
   }),
 }));
 
+jest.mock('../../../../hooks/useUser', () => ({
+  useUser: () => ({
+    data: { id: 'mockUser' },
+  }),
+}));
+
 describe('useAxiosTrackTileService', () => {
   it('should return the same values for accountSettings', () => {
     const { result } = renderHook(() => useAxiosTrackTileService());

--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -28,7 +28,7 @@ import { pick, merge, pickBy, omit, fromPairs } from 'lodash';
 import { useHttpClient } from '../../../hooks/useHttpClient';
 import { useActiveAccount } from './../../../hooks/useActiveAccount';
 import { useActiveProject } from './../../../hooks/useActiveProject';
-import { useUser } from '../../../hooks';
+import { useUser } from '../../../hooks/useUser';
 
 const axiosConfig = (obj: { account: string }): AxiosRequestConfig => ({
   headers: {

--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -42,7 +42,8 @@ export const useAxiosTrackTileService = (): TrackTileService => {
   const { activeSubjectId: patientId, activeProject } = useActiveProject();
   const { account } = useActiveAccount();
   const { data: userData } = useUser();
-  const [userId, setUserId] = useState(userData?.id);
+  const userId = userData?.id;
+  const [previousUserId, setPreviousUserId] = useState(userId);
 
   const accountId = account?.id || '';
   const projectId = activeProject?.id || '';
@@ -56,13 +57,13 @@ export const useAxiosTrackTileService = (): TrackTileService => {
   // Clear cached trackers when
   // we've detected that the userId has changed
   useEffect(() => {
-    if (userId !== userData?.id) {
+    if (userId !== previousUserId) {
       cache.trackers = undefined;
       cache.trackerValues = {};
       cache.ontologies = {};
-      setUserId(userData?.id);
+      setPreviousUserId(userId);
     }
-  }, [userId, userData?.id, cache]);
+  }, [userId, cache, previousUserId]);
 
   const updateSettingsInCache = (settings: BulkInstalledMetricSettings) => {
     const tracker = cache.trackers?.find(

--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -41,8 +41,8 @@ export const useAxiosTrackTileService = (): TrackTileService => {
   const { httpClient } = useHttpClient();
   const { activeSubjectId: patientId, activeProject } = useActiveProject();
   const { account } = useActiveAccount();
-  const { data } = useUser();
-  const [userId, setUserId] = useState(data?.id);
+  const { data: userData } = useUser();
+  const [userId, setUserId] = useState(userData?.id);
 
   const accountId = account?.id || '';
   const projectId = activeProject?.id || '';
@@ -56,13 +56,13 @@ export const useAxiosTrackTileService = (): TrackTileService => {
   // Clear cached trackers when
   // we've detected that the userId has changed
   useEffect(() => {
-    if (userId !== data?.id) {
+    if (userId !== userData?.id) {
       cache.trackers = undefined;
       cache.trackerValues = {};
       cache.ontologies = {};
-      setUserId(data?.id);
+      setUserId(userData?.id);
     }
-  }, [userId, data?.id, cache]);
+  }, [userId, userData?.id, cache]);
 
   const updateSettingsInCache = (settings: BulkInstalledMetricSettings) => {
     const tracker = cache.trackers?.find(
@@ -98,7 +98,6 @@ export const useAxiosTrackTileService = (): TrackTileService => {
 
     fetchTrackers: async () => {
       if (cache.trackers) {
-        console.log('Returning cached trackers!!!');
         return cache.trackers;
       }
 

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -63,9 +63,11 @@ export const ActiveAccountContextProvider = ({
   const accountsWithProduct = filterNonLRAccounts(accountsResult.data);
   const [activeAccount, setActiveAccount] = useState<ActiveAccountProps>({});
   const { data } = useUser();
-  const [userId, setUserId] = useState(data?.id);
+  const { data: userData } = useUser();
+  const userId = userData?.id;
+  const [previousUserId, setPreviousUserId] = useState(userId);
   const [storedAccountIdResult, setStoredAccountId] = useAsyncStorage(
-    `${selectedAccountIdKey}:${data?.id}`,
+    `${selectedAccountIdKey}:${userId}`,
   );
 
   /**
@@ -109,11 +111,11 @@ export const ActiveAccountContextProvider = ({
   // Clear selected account when
   // we've detected that the userId has changed
   useEffect(() => {
-    if (data?.id !== userId) {
+    if (userId !== previousUserId) {
       setActiveAccount({});
-      setUserId(data?.id);
+      setPreviousUserId(userId);
     }
-  }, [data?.id, userId]);
+  }, [previousUserId, userId]);
 
   const setActiveAccountId = useCallback(
     async (accountId: string) => {

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -62,7 +62,6 @@ export const ActiveAccountContextProvider = ({
   const accountsResult = useAccounts();
   const accountsWithProduct = filterNonLRAccounts(accountsResult.data);
   const [activeAccount, setActiveAccount] = useState<ActiveAccountProps>({});
-  const { data } = useUser();
   const { data: userData } = useUser();
   const userId = userData?.id;
   const [previousUserId, setPreviousUserId] = useState(userId);
@@ -75,7 +74,7 @@ export const ActiveAccountContextProvider = ({
    */
   useEffect(() => {
     if (
-      !data?.id || // require user id before reading/writing to storage
+      !userId || // require user id before reading/writing to storage
       storedAccountIdResult.isLoading || // wait for async storage result
       activeAccount?.account?.id || // activeAccount already set
       accountsWithProduct.length < 1 // no valid accounts found server side
@@ -105,7 +104,7 @@ export const ActiveAccountContextProvider = ({
     setStoredAccountId,
     storedAccountIdResult.data,
     storedAccountIdResult.isLoading,
-    data?.id,
+    userId,
   ]);
 
   // Clear selected account when

--- a/src/hooks/useActiveProject.test.tsx
+++ b/src/hooks/useActiveProject.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useSubjectProjects } from './useSubjectProjects';
 import { useMe } from './useMe';
+import { useUser } from './useUser';
 import {
   ActiveProjectContextProvider,
   useActiveProject,
@@ -18,9 +19,13 @@ jest.mock('./useSubjectProjects', () => ({
 jest.mock('./useMe', () => ({
   useMe: jest.fn(),
 }));
+jest.mock('./useUser', () => ({
+  useUser: jest.fn(),
+}));
 
 const useSubjectProjectsMock = useSubjectProjects as jest.Mock;
 const useMeMock = useMe as jest.Mock;
+const useUserMock = useUser as jest.Mock;
 let useAsyncStorageSpy = jest.spyOn(useAsyncStorage, 'useAsyncStorage');
 
 const mockSubjectProjects = [
@@ -64,6 +69,9 @@ beforeEach(() => {
     data: mockMe,
     isLoading: false,
     isFetched: true,
+  });
+  useUserMock.mockReturnValue({
+    data: { id: 'mockUser' },
   });
 
   useAsyncStorageSpy.mockReturnValue([
@@ -172,7 +180,7 @@ test('uses projectId from async storage', async () => {
   const { result, rerender } = await renderHookInContext();
   await waitFor(() => result.current.isLoading === false);
   rerender({});
-  expect(AsyncStorage.getItem).toBeCalledWith('selectedProjectIdKey');
+  expect(AsyncStorage.getItem).toBeCalledWith('selectedProjectIdKey:mockUser');
   expect(result.current).toMatchObject({
     activeProject: mockSubjectProjects[0],
     activeSubjectId: mockMe[0].subjectId,

--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -71,11 +71,12 @@ export const ActiveProjectContextProvider = ({
   const [hookReturnValue, setHookReturnValue] = useState<ActiveProjectProps>(
     {},
   );
-  const { data } = useUser();
-  const [userId, setUserId] = useState(data?.id);
+  const { data: userData } = useUser();
+  const userId = userData?.id;
+  const [previousUserId, setPreviousUserId] = useState(userId);
   const [isFetched, setIsFetched] = useState<boolean>(false);
   const [storedProjectIdResult, setStoredProjectId] = useAsyncStorage(
-    `${selectedProjectIdKey}:${data?.id}`,
+    `${selectedProjectIdKey}:${userId}`,
   );
 
   /**
@@ -83,7 +84,7 @@ export const ActiveProjectContextProvider = ({
    */
   useEffect(() => {
     if (
-      !data?.id || // wait for user id before reading and writing to storage
+      !userId || // wait for user id before reading and writing to storage
       hookReturnValue.activeProject?.id || // active project already set
       projectLoading || // wait for projects endpoint
       useMeLoading || // wait for subjects endpoint
@@ -116,17 +117,17 @@ export const ActiveProjectContextProvider = ({
     setStoredProjectId,
     projectLoading,
     useMeLoading,
-    data?.id,
+    userId,
   ]);
 
   // Clear selected project when
   // we've detected that the userId has changed
   useEffect(() => {
-    if (data?.id !== userId) {
+    if (userId !== previousUserId) {
       setHookReturnValue({});
-      setUserId(data?.id);
+      setPreviousUserId(userId);
     }
-  }, [data?.id, userId]);
+  }, [previousUserId, userId]);
 
   const setActiveProjectId = useCallback(
     async (projectId: string) => {

--- a/src/hooks/useOAuthFlow.test.tsx
+++ b/src/hooks/useOAuthFlow.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react-native';
 import { authorize, refresh, revoke } from 'react-native-app-auth';
 import { OAuthContextProvider, useOAuthFlow } from './useOAuthFlow';
 import { AuthResult, useAuth } from './useAuth';
+import { QueryClientProvider, QueryClient } from 'react-query';
 
 jest.mock('react-native-app-auth', () => ({
   authorize: jest.fn(),
@@ -44,9 +45,11 @@ const authResult: AuthResult = {
 const renderHookInContext = async () => {
   return renderHook(() => useOAuthFlow(), {
     wrapper: ({ children }) => (
-      <OAuthContextProvider authConfig={authConfig}>
-        {children}
-      </OAuthContextProvider>
+      <QueryClientProvider client={new QueryClient()}>
+        <OAuthContextProvider authConfig={authConfig}>
+          {children}
+        </OAuthContextProvider>
+      </QueryClientProvider>
     ),
   });
 };
@@ -81,9 +84,11 @@ test('overrides usePKCE to true', async () => {
   };
   const { result } = await renderHook(() => useOAuthFlow(), {
     wrapper: ({ children }) => (
-      <OAuthContextProvider authConfig={newAuthConfig}>
-        {children}
-      </OAuthContextProvider>
+      <QueryClientProvider client={new QueryClient()}>
+        <OAuthContextProvider authConfig={newAuthConfig}>
+          {children}
+        </OAuthContextProvider>
+      </QueryClientProvider>
     ),
   });
   expect(result.current.authConfig).toEqual(authConfig);

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -8,10 +8,12 @@ import { t } from 'i18next';
 import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
 import { createStyles } from '../components/BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
+import { useActiveProject } from '../hooks';
 
 export const ProfileScreen = () => {
   const { styles } = useStyles(defaultStyles);
   const { isLoading, data } = useUser();
+  const { activeProject } = useActiveProject();
 
   const userProfile = data?.profile;
 
@@ -44,6 +46,9 @@ export const ProfileScreen = () => {
           value={userProfile.familyName}
         />
         <Field label={t('profile-email', 'Email')} value={userProfile.email} />
+        {__DEV__ && (
+          <Field label="Active Project" value={activeProject?.name} />
+        )}
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
To support logout and user switching:
- Clear selected account when the user id changes
- Clear selected project when the user id changes
- Clear cached trackers when the user id changes
- Clear queryClient cache on logout

Also added a _DEV_ only field to the profile screen to show the current project name.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
N/A