### PR TITLE
PHC-5065 Display Splash Screen Behind Login Screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,163 @@ export default function App() {
 }
 ```
 
+### Customizing the Default Login Screen with a Native View
+
+The default login screen adds a long button to a native view with the name
+`RNTLaunchScreen`.
+
+1- To define an iOS launch screen, use an existing Storyboard, or create a new
+one, and then create a module according to the
+[official docs](https://reactnative.dev/docs/native-components-ios) that creates
+an `RNTLaunchScreen` native view.
+
+Example creating the native view for the `LaunchScreen` storyboard:
+
+```objectivec
+#import <React/RCTViewManager.h>
+
+@interface RNTLaunchScreen : RCTViewManager
+@end
+
+@implementation RNTLaunchScreen
+
+RCT_EXPORT_MODULE(RNTLaunchScreen)
+
+- (UIView *)view
+{
+  UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
+  UIViewController *controller = [storyboard instantiateInitialViewController];
+
+  return controller.view;
+}
+
+@end
+```
+
+2- To define an android launch screen, use an existing View, or create a new
+one, and then create a module according to the
+[official docs](https://reactnative.dev/docs/native-components-android) that
+registers an `RNTLaunchScreen` native view with the application.
+
+Example creating a launch screen view from a layout and then registering the
+launch screen `ReactPackage` with the `ReactApplication`:
+
+<details>
+  <summary>Create a layout at <code>res/layout/splash_screen.xml</code></summary>
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:layout_gravity="center_horizontal"
+    android:background="#FFFFFF"
+    android:weightSum="1">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight=".30"
+        android:gravity="bottom|center"
+        android:text="example"
+        android:textColor="#000000"
+        android:textSize="35dp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight=".64"
+        android:gravity="bottom|center"
+        android:textSize="16dp"
+        android:textColor="#000000"
+        android:text="Powered by React Native" />
+</LinearLayout>
+```
+
+</details>
+
+<details>
+  <summary>Create a <code>RNTLaunchScreen</code> class</summary>
+
+```java
+package com.example;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import android.view.View;
+import java.util.Arrays;
+import java.util.List;
+
+public class RNTLaunchScreen extends SimpleViewManager<View> implements ReactPackage {
+    public static final String REACT_CLASS = "RNTLaunchScreen";
+
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    @Override
+    public View createViewInstance(ThemedReactContext context) {
+        return View.inflate(context, R.layout.splash_screen, null);
+    }
+
+    @Overrides
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Arrays.<ViewManager>asList(new RNTLaunchScreen());
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList();
+    }
+}
+```
+
+</details>
+
+<details>
+  <summary>Register the <code>RNTLaunchScreen</code> package with the <code>ReactApplication</code></summary>
+
+```java
+package com.example;
+
+import android.app.Application;
+import com.facebook.react.PackageList;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.defaults.DefaultReactNativeHost;
+import java.util.List;
+import com.example.RNTLaunchScreen;
+
+public class MainApplication extends Application implements ReactApplication {
+
+  private final ReactNativeHost mReactNativeHost =
+      new DefaultReactNativeHost(this) {
+        @Override
+        protected List<ReactPackage> getPackages() {
+          List<ReactPackage> packages = new PackageList(this).getPackages();
+          packages.add(new RNTLaunchScreen());
+          return packages;
+        }
+      };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+}
+```
+
+</details>
+
 ### Peer dependencies
 
 We may have more peer dependencies than is typical. We have run into a number of

--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -9,6 +9,7 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactNativeHost;
 import com.facebook.soloader.SoLoader;
 import java.util.List;
+import com.example.RNTLaunchScreen;
 
 import com.google.firebase.FirebaseApp;
 import com.wix.reactnativenotifications.RNNotificationsPackage;
@@ -24,10 +25,9 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override
         protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
+          packages.add(new RNTLaunchScreen());
           return packages;
         }
 

--- a/example/android/app/src/main/java/com/example/RNTLaunchScreen.java
+++ b/example/android/app/src/main/java/com/example/RNTLaunchScreen.java
@@ -1,0 +1,35 @@
+package com.example;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import android.view.View;
+import java.util.Arrays;
+import java.util.List;
+
+public class RNTLaunchScreen extends SimpleViewManager<View> implements ReactPackage {
+    public static final String REACT_CLASS = "RNTLaunchScreen";
+
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    @Override
+    public View createViewInstance(ThemedReactContext context) {
+        return View.inflate(context, R.layout.splash_screen, null);
+    }
+
+    @Overrides
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Arrays.<ViewManager>asList(new RNTLaunchScreen());
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList();
+    }
+}

--- a/example/android/app/src/main/res/layout/splash_screen.xml
+++ b/example/android/app/src/main/res/layout/splash_screen.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:layout_gravity="center_horizontal"
+    android:background="#FFFFFF"
+    android:weightSum="1">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight=".30"
+        android:gravity="bottom|center"
+        android:textSize="35dp"
+        android:textColor="#000000"
+        android:textStyle="bold"
+        android:text="example" />
+
+    <TextView
+        android:id="@+id/subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight=".64"
+        android:gravity="bottom|center"
+        android:textSize="16dp"
+        android:textColor="#000000"
+        android:text="Powered by React Native" />
+</LinearLayout>

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		15C135A12A61D3AF00004D19 /* RNTLaunchScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 15C135A02A61D3AF00004D19 /* RNTLaunchScreen.m */; };
 		7699B88040F8A987B510C191 /* libPods-example-exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-example-exampleTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -36,6 +37,7 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = example/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = example/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = example/main.m; sourceTree = "<group>"; };
+		15C135A02A61D3AF00004D19 /* RNTLaunchScreen.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RNTLaunchScreen.m; path = example/RNTLaunchScreen.m; sourceTree = "<group>"; };
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-example-exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-example-exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.debug.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.debug.xcconfig"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example.release.xcconfig"; path = "Target Support Files/Pods-example/Pods-example.release.xcconfig"; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				15C135A02A61D3AF00004D19 /* RNTLaunchScreen.m */,
 			);
 			name = example;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				15C135A12A61D3AF00004D19 /* RNTLaunchScreen.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);

--- a/example/ios/example/RNTLaunchScreen.m
+++ b/example/ios/example/RNTLaunchScreen.m
@@ -1,0 +1,18 @@
+#import <React/RCTViewManager.h>
+
+@interface RNTLaunchScreen : RCTViewManager
+@end
+
+@implementation RNTLaunchScreen
+
+RCT_EXPORT_MODULE(RNTLaunchScreen)
+
+- (UIView *)view
+{
+  UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
+  UIViewController *controller = [storyboard instantiateInitialViewController];
+  
+  return controller.view;
+}
+
+@end

--- a/src/components/LaunchScreen.ts
+++ b/src/components/LaunchScreen.ts
@@ -1,0 +1,11 @@
+import { View, requireNativeComponent, UIManager } from 'react-native';
+
+const NativeComponentName = 'RNTLaunchScreen';
+
+let Screen = View;
+
+if (UIManager.getViewManagerConfig(NativeComponentName)) {
+  Screen = requireNativeComponent(NativeComponentName) as any;
+}
+
+export default Screen;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,9 +1,10 @@
 import React, { FC, useState } from 'react';
-import { View } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { t } from 'i18next';
 import { OAuthLoginButton } from '../components/OAuthLoginButton';
 import { useStyles, useDeveloperConfig } from '../hooks/';
 import { createStyles, useIcons } from '../components/BrandConfigProvider';
+import LaunchScreen from '../components/LaunchScreen';
 import { Dialog, Portal, Text } from 'react-native-paper';
 
 export const LoginScreen: FC = () => {
@@ -12,6 +13,7 @@ export const LoginScreen: FC = () => {
   const [visible, setVisible] = useState(false);
   const [errorText, setErrorText] = useState('');
   const { AlertTriangle } = useIcons();
+
   const hideDialog = () => {
     setVisible(false);
     setErrorText('');
@@ -41,10 +43,13 @@ export const LoginScreen: FC = () => {
   ) : (
     <>
       <View style={styles.containerView}>
-        <OAuthLoginButton
-          label={t('login-button-title', 'Login')}
-          onFail={onFail}
-        />
+        <LaunchScreen key="launch-screen" style={StyleSheet.absoluteFill} />
+        <View style={styles.buttonContainer}>
+          <OAuthLoginButton
+            label={t('login-button-title', 'Login')}
+            onFail={onFail}
+          />
+        </View>
       </View>
       <Portal>
         <Dialog visible={visible} onDismiss={hideDialog}>
@@ -64,8 +69,13 @@ export const LoginScreen: FC = () => {
 const defaultStyles = createStyles('LoginScreen', () => ({
   containerView: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-end',
     alignItems: 'center',
+  },
+  buttonContainer: {
+    height: '20%',
+    width: '100%',
+    paddingHorizontal: 30,
   },
 }));
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds the ability to provide a native view, registered as `RNTLaunchScreen`, that will be displayed behind the long button if present. 
  - Adds documentation to the README specifying how to configure this view

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<img width="338" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/51483829-f1a6-43eb-b940-7fc963c46c58">
<img width="318" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/80d2438f-24f4-4772-b5f6-f258c95130bf">
