### PR TITLE
fix: App Tiles can Register a Go Back Handler Now

### DIFF
--- a/src/components/AppNavHeader.tsx
+++ b/src/components/AppNavHeader.tsx
@@ -13,7 +13,6 @@ import {
 } from 'react-native';
 import { useDeveloperConfig, useTheme } from '../hooks';
 import { RouteColor } from '../common/DeveloperConfig';
-import { HomeStackParamList } from '../navigators';
 
 export function AppNavHeader({
   back,
@@ -40,24 +39,13 @@ export function AppNavHeader({
   const statusBarHeight = config.AppNavHeader?.statusBarHeight;
 
   const backNavigationHandler = useCallback(() => {
-    const routeName = route.name;
-    if (routeName === 'Home/AuthedAppTile') {
-      const { blockBackNavigation, webViewRefGoBack } =
-        route.params as HomeStackParamList['Home/AuthedAppTile'];
-
-      if (blockBackNavigation) {
-        webViewRefGoBack?.();
-        return true;
-      }
-    }
-
     if (navigation.canGoBack()) {
       navigation.goBack();
       return true;
     }
 
     return false;
-  }, [navigation, route]);
+  }, [navigation]);
 
   useEffect(() => {
     const handler = BackHandler.addEventListener(

--- a/src/hooks/useHandleAppTileEvents.test.ts
+++ b/src/hooks/useHandleAppTileEvents.test.ts
@@ -37,6 +37,7 @@ const openURLMock = Linking.openURL as jest.Mock;
 const popMock = jest.fn();
 const canGoBack = jest.fn();
 const pushMock = jest.fn();
+const setParamsMock = jest.fn();
 
 const surveysAppTile = { id: 'surveys', url: 'surveys.com' };
 
@@ -51,6 +52,7 @@ beforeEach(() => {
     canGoBack: canGoBack,
     push: pushMock,
     pop: popMock,
+    setParams: setParamsMock,
   });
 
   useAppConfigMock.mockReturnValue({
@@ -316,5 +318,31 @@ describe('handleAppTileNavigationStateChange', () => {
       event as WebViewNavigation,
     );
     expect(popMock).not.toBeCalled();
+  });
+
+  it('should set the navigation back settings if the webview ref exists', () => {
+    const event = { url: 'www.hello.world', canGoBack: true };
+    const webView: any = { goBack: jest.fn() };
+    const { result } = renderHook(() => useHandleAppTileEvents(webView));
+    result.current.handleAppTileNavigationStateChange(
+      event as WebViewNavigation,
+    );
+    expect(setParamsMock).toHaveBeenCalledWith({
+      blockBackNavigation: true,
+      webViewRefGoBack: webView.goBack,
+    });
+  });
+
+  it('should not block navigation back if webapp canGoBack is false', () => {
+    const event = { url: 'www.hello.world', canGoBack: false };
+    const webView: any = { goBack: jest.fn() };
+    const { result } = renderHook(() => useHandleAppTileEvents(webView));
+    result.current.handleAppTileNavigationStateChange(
+      event as WebViewNavigation,
+    );
+    expect(setParamsMock).toHaveBeenCalledWith({
+      blockBackNavigation: false,
+      webViewRefGoBack: undefined,
+    });
   });
 });

--- a/src/hooks/useHandleAppTileEvents.ts
+++ b/src/hooks/useHandleAppTileEvents.ts
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Linking } from 'react-native';
 import type {
+  WebView,
   WebViewMessageEvent,
   WebViewNavigation,
 } from 'react-native-webview';
@@ -52,7 +53,7 @@ export type OpenUrlAppletMessage = {
 
 export type AppTileMessage = DeepLinkAppletMessage | OpenUrlAppletMessage;
 
-export const useHandleAppTileEvents = () => {
+export const useHandleAppTileEvents = (webView: WebView | null = null) => {
   const { data } = useAppConfig();
   const { pillarTrackers } = useTrackers();
   const { todayTileSettings, tiles } = data?.homeTab || {};
@@ -152,6 +153,13 @@ export const useHandleAppTileEvents = () => {
       if (navigation.canGoBack()) {
         navigation.pop();
       }
+    }
+
+    if (webView) {
+      navigation.setParams({
+        blockBackNavigation: event.canGoBack,
+        webViewRefGoBack: event.canGoBack ? webView?.goBack : undefined,
+      });
     }
   };
 

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -55,8 +55,6 @@ export type HomeStackParamList = {
   'Home/AuthedAppTile': {
     appTile: AppTile;
     searchParams?: { [key: string]: string };
-    blockBackNavigation?: boolean;
-    webViewRefGoBack?: () => void;
   };
   'Home/CustomAppTile': { appTile: AppTile };
   'Home/Circle/Discussion': { circleTile: CircleTile };

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -55,6 +55,8 @@ export type HomeStackParamList = {
   'Home/AuthedAppTile': {
     appTile: AppTile;
     searchParams?: { [key: string]: string };
+    blockBackNavigation?: boolean;
+    webViewRefGoBack?: () => void;
   };
   'Home/CustomAppTile': { appTile: AppTile };
   'Home/Circle/Discussion': { circleTile: CircleTile };

--- a/src/screens/AuthedAppTileScreen.tsx
+++ b/src/screens/AuthedAppTileScreen.tsx
@@ -111,6 +111,7 @@ export const AuthedAppTileScreen = ({
 
   return (
     <WebView
+      key={source.uri}
       geolocationEnabled
       source={source}
       ref={webViewRef}

--- a/src/screens/AuthedAppTileScreen.tsx
+++ b/src/screens/AuthedAppTileScreen.tsx
@@ -18,7 +18,7 @@ export const AuthedAppTileScreen = ({
   const { appTile, searchParams = {} } = route.params;
   const webViewRef = useRef<WebView>(null);
   const { handleAppTileMessage, handleAppTileNavigationStateChange } =
-    useHandleAppTileEvents();
+    useHandleAppTileEvents(webViewRef.current);
 
   useLayoutEffect(() => {
     navigation.setOptions({


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds logic to handle the back arrow or hardware back button

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/498fa7e1-4872-4528-b3c1-cfdac238104b" />
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/05a508a4-61c6-45ab-aea2-7023ad0f3c7b" />
</table>







