### PR TITLE
Assign defaultStyles for notification screen components

### DIFF
--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -3,7 +3,7 @@ import { t } from 'i18next';
 import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
 import { useNotifications } from '../hooks/useNotifications';
 import { Divider, List } from 'react-native-paper';
-import { SafeAreaView, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import formatRelative from 'date-fns/formatRelative';
 import { createStyles, useIcons } from '../components/BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
@@ -37,12 +37,11 @@ export const NotificationsScreen = () => {
   const notificationEntries = data?.notificationsForUser.edges.map(
     (edge, index) => {
       return (
-        <View key={edge.node.id}>
+        <View key={edge.node.id} style={styles.listItemView}>
           <List.Item
             title={edge.node.fullText}
             titleNumberOfLines={4}
             style={styles.listItem}
-            // TODO: switch to i18next formatter when available
             description={formatRelative(new Date(edge.node.time), new Date())}
             left={() => surveyIcon}
             testID={tID(`notification-${index}`)}
@@ -72,15 +71,16 @@ export const NotificationsScreen = () => {
 
   return (
     <View testID="notifications-screen">
-      <SafeAreaView>
+      <ScrollView>
         <Divider />
         {notificationsAreaContent}
-      </SafeAreaView>
+      </ScrollView>
     </View>
   );
 };
 
 const defaultStyles = createStyles('NotificationsScreen', () => ({
+  listItemView: {},
   listItem: {},
   icon: { paddingLeft: 16 },
 }));

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -15,12 +15,12 @@ export const NotificationsScreen = () => {
   const { styles } = useStyles(defaultStyles);
 
   const surveyIcon = useMemo(
-    () => <List.Icon style={styles.icon} icon={Bell} />,
-    [styles.icon, Bell],
+    () => <List.Icon style={styles.iconView} icon={Bell} />,
+    [styles.iconView, Bell],
   );
   const noNotificationsIcon = useMemo(
-    () => <List.Icon style={styles.icon} icon={BellOff} />,
-    [styles.icon, BellOff],
+    () => <List.Icon style={styles.iconView} icon={BellOff} />,
+    [styles.iconView, BellOff],
   );
 
   if (isLoading) {
@@ -41,12 +41,12 @@ export const NotificationsScreen = () => {
           <List.Item
             title={edge.node.fullText}
             titleNumberOfLines={4}
-            style={styles.listItem}
+            style={styles.listItemContentsView}
             description={formatRelative(new Date(edge.node.time), new Date())}
             left={() => surveyIcon}
             testID={tID(`notification-${index}`)}
           />
-          <Divider />
+          <Divider style={styles.dividerView} />
         </View>
       );
     },
@@ -59,7 +59,7 @@ export const NotificationsScreen = () => {
         'You have no notifications to display!',
       )}
       testID={tID('no-notifications-message')}
-      style={styles.listItem}
+      style={styles.listItemContentsView}
       left={() => noNotificationsIcon}
     />
   );
@@ -70,7 +70,7 @@ export const NotificationsScreen = () => {
       : noNotifications;
 
   return (
-    <View testID="notifications-screen" style={styles.rootView}>
+    <View testID="notifications-screen" style={styles.view}>
       <ScrollView style={styles.scrollView}>
         <Divider style={styles.dividerView} />
         {notificationsAreaContent}
@@ -80,12 +80,12 @@ export const NotificationsScreen = () => {
 };
 
 const defaultStyles = createStyles('NotificationsScreen', () => ({
-  rootView: {},
+  view: {},
   scrollView: {},
   listItemView: {},
-  listItem: {},
+  listItemContentsView: {},
   dividerView: {},
-  icon: { paddingLeft: 16 },
+  iconView: { paddingLeft: 16 },
 }));
 
 declare module '@styles' {

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -79,13 +79,13 @@ export const NotificationsScreen = () => {
   );
 };
 
-const defaultStyles = createStyles('NotificationsScreen', () => ({
+const defaultStyles = createStyles('NotificationsScreen', (theme) => ({
   view: {},
   scrollView: {},
   listItemView: {},
   listItemContentsView: {},
   dividerView: {},
-  iconView: { paddingLeft: 16 },
+  iconView: { paddingLeft: theme.spacing.medium },
 }));
 
 declare module '@styles' {

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -70,9 +70,9 @@ export const NotificationsScreen = () => {
       : noNotifications;
 
   return (
-    <View testID="notifications-screen">
-      <ScrollView>
-        <Divider />
+    <View testID="notifications-screen" style={styles.rootView}>
+      <ScrollView style={styles.scrollView}>
+        <Divider style={styles.dividerView} />
         {notificationsAreaContent}
       </ScrollView>
     </View>
@@ -80,8 +80,11 @@ export const NotificationsScreen = () => {
 };
 
 const defaultStyles = createStyles('NotificationsScreen', () => ({
+  rootView: {},
+  scrollView: {},
   listItemView: {},
   listItem: {},
+  dividerView: {},
   icon: { paddingLeft: 16 },
 }));
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - NotificationScreen now uses a ScrollView to handle notification overflow
  - Assigns defaultStyles to every component to allow for tweaking these styles in consuming apps
  
## Screenshots
<!-- include screen recordings, if relevant to your changes -->