### PR TITLE
fix: Account Loading Logic Waits for Selection

### DIFF
--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -61,6 +61,7 @@ export const ActiveAccountContextProvider = ({
 }) => {
   const accountsResult = useAccounts();
   const accountsWithProduct = filterNonLRAccounts(accountsResult.data);
+  const [isSettled, setIsSettled] = useState(false);
   const [activeAccount, setActiveAccount] = useState<ActiveAccountProps>({});
   const { data: userData } = useUser();
   const userId = userData?.id;
@@ -73,6 +74,14 @@ export const ActiveAccountContextProvider = ({
    * Initial setting of activeAccount
    */
   useEffect(() => {
+    if (
+      accountsResult.isFetched &&
+      !accountsResult.isLoading &&
+      accountsWithProduct.length < 1
+    ) {
+      setIsSettled(true);
+    }
+
     if (
       !userId || // require user id before reading/writing to storage
       storedAccountIdResult.isLoading || // wait for async storage result
@@ -97,6 +106,7 @@ export const ActiveAccountContextProvider = ({
       trialExpired: getTrialExpired(selectedAccount),
     });
     setStoredAccountId(selectedAccount.id);
+    setIsSettled(true);
   }, [
     accountsWithProduct,
     activeAccount?.account?.id,
@@ -104,6 +114,8 @@ export const ActiveAccountContextProvider = ({
     setStoredAccountId,
     storedAccountIdResult.data,
     storedAccountIdResult.isLoading,
+    accountsResult.isFetched,
+    accountsResult.isLoading,
     userId,
   ]);
 
@@ -171,7 +183,7 @@ export const ActiveAccountContextProvider = ({
         accountsWithProduct,
         refetch,
         setActiveAccountId,
-        isLoading: accountsResult.isLoading,
+        isLoading: accountsResult.isLoading || !isSettled,
         isFetched: accountsResult.isFetched,
         error: accountsResult.error,
       }}

--- a/src/navigators/RootStack.tsx
+++ b/src/navigators/RootStack.tsx
@@ -37,7 +37,9 @@ export function RootStack() {
 
   const loadingProject = !isFetchedProject || isLoadingProject;
   const loadingAccount = !isFetchedAccount || isLoadingAccount;
-  const loadingAccountOrProject = loadingAccount || loadingProject;
+  const hasAccount = !loadingAccount && !!account?.id;
+  const loadingAccountOrProject =
+    loadingAccount || (hasAccount && loadingProject);
 
   if (!isLoggedIn && loadingAuth) {
     return (


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Restores the Root Loading logic
  - Fixes an issue where `useActiveAccount` could be in a state where `isFetched: true` and `isLoading: false` but not actually have set the active account data if possible
