### PR TITLE
fix: Cache circles by circleId

### DIFF
--- a/src/components/Circles/CreateEditPostModal.tsx
+++ b/src/components/Circles/CreateEditPostModal.tsx
@@ -29,6 +29,7 @@ const eventEmitter = new NativeEventEmitter({
 const showCreateEditPostModelEvent = 'showCreateEditPostModelEvent';
 
 type EmitEventProps = {
+  circleId?: string;
   parentId?: string;
   parentType?: ParentType;
   onModalClose?: (createdNewPost?: boolean) => void;
@@ -76,7 +77,8 @@ export const CreateEditPostModal = () => {
     return null;
   }
 
-  const { parentId, parentType, postToEdit, onModalClose } = emitProps;
+  const { parentId, parentType, postToEdit, circleId, onModalClose } =
+    emitProps;
 
   return (
     <Provider>
@@ -139,6 +141,7 @@ export const CreateEditPostModal = () => {
                       updatePost.mutate({
                         id: postToEdit.id,
                         newMessage: postText,
+                        circleId: postToEdit.circle?.id,
                       });
                       hideModal(false);
                     } else {
@@ -148,6 +151,9 @@ export const CreateEditPostModal = () => {
                           message: postText,
                           parentId: parentId!,
                           parentType: parentType!,
+                          circle: {
+                            id: circleId!,
+                          },
                         },
                       });
                       hideModal(true);

--- a/src/components/Circles/CreatePostToolbar.tsx
+++ b/src/components/Circles/CreatePostToolbar.tsx
@@ -10,6 +10,7 @@ import uuid from 'react-native-uuid';
 
 type CreatePostToolbarProps = {
   parentId?: string;
+  circleId?: string;
   parentType?: ParentType;
   onSubmit?: ({ shouldScroll }: { shouldScroll: boolean }) => void;
   textInputRef?: Ref<any>;
@@ -19,6 +20,7 @@ type CreatePostToolbarProps = {
 export const CreatePostToolbar = ({
   parentId,
   parentType,
+  circleId,
   onSubmit,
   textInputRef,
   rootPostId,
@@ -74,6 +76,7 @@ export const CreatePostToolbar = ({
                 message: postText,
                 parentId: parentId!,
                 parentType: parentType!,
+                circle: { id: circleId! },
               },
             });
             // only scroll to end when commenting on the root post

--- a/src/components/Circles/PostsList.tsx
+++ b/src/components/Circles/PostsList.tsx
@@ -114,6 +114,7 @@ export const PostsList = ({ circleTile, onOpenPost }: PostsListProps) => {
         style={styles.fabView}
         onPress={() => {
           showCreateEditPostModal({
+            circleId: circleTile.circleId,
             parentType: ParentType.CIRCLE,
             parentId: circleTile.circleId,
           });

--- a/src/components/Circles/ReactionsToolbar.tsx
+++ b/src/components/Circles/ReactionsToolbar.tsx
@@ -35,13 +35,21 @@ export const ReactionsToolbar = ({ post }: ReactionsToolbarProps) => {
 
       // if the reaction type doesn't exist locally
       if (reactionIndex < 0) {
-        createReaction.mutate({ postId: post.id, type: emojiType });
+        createReaction.mutate({
+          postId: post.id,
+          type: emojiType,
+          circleId: post.circle?.id,
+        });
         return;
       }
 
       // reaction exists locally but current user has not reacted
       if (!post.reactionTotals[reactionIndex].userHasReacted) {
-        createReaction.mutate({ postId: post.id, type: emojiType });
+        createReaction.mutate({
+          postId: post.id,
+          type: emojiType,
+          circleId: post.circle?.id,
+        });
         return;
       }
 
@@ -51,11 +59,19 @@ export const ReactionsToolbar = ({ post }: ReactionsToolbarProps) => {
           userId: data.id,
           postId: post.id,
           type: emojiType,
+          circleId: post.circle?.id,
         });
         return;
       }
     },
-    [post.id, post.reactionTotals, data?.id, createReaction, undoReaction],
+    [
+      post.id,
+      post.reactionTotals,
+      post.circle?.id,
+      data?.id,
+      createReaction,
+      undoReaction,
+    ],
   );
 
   return (

--- a/src/components/Circles/ShowPostMenuButton.tsx
+++ b/src/components/Circles/ShowPostMenuButton.tsx
@@ -38,7 +38,7 @@ export const ShowPostMenuButton = ({
             ? t('delete-post', 'Delete Post')
             : t('delete-comment', 'Delete Comment'),
         action: () => {
-          deletePost.mutate({ id: post?.id });
+          deletePost.mutate({ id: post?.id, circleId: post.circle?.id });
         },
       },
       {
@@ -48,6 +48,7 @@ export const ShowPostMenuButton = ({
             : t('edit-comment', 'Edit Comment'),
         action: () =>
           showCreateEditPostModal({
+            circleId: post.circle?.id,
             parentId: post.id,
             parentType: parentType,
             postToEdit: post,

--- a/src/components/Circles/Thread.tsx
+++ b/src/components/Circles/Thread.tsx
@@ -151,6 +151,7 @@ export const Thread = (props: ThreadProps) => {
         parentId={commentPost}
         parentType={ParentType.POST}
         rootPostId={postIn.id}
+        circleId={postIn.circle?.id}
         onSubmit={handleNewReply}
         textInputRef={textInputRef}
       />

--- a/src/hooks/Circles/types.ts
+++ b/src/hooks/Circles/types.ts
@@ -51,6 +51,9 @@ export type Post = {
       hasNextPage?: boolean;
     };
   };
+  circle?: {
+    id: string;
+  };
 };
 
 export const postDetailsFragment = gql`
@@ -76,6 +79,9 @@ export const postDetailsFragment = gql`
         url
         count
         userHasReacted
+      }
+      circle {
+        id
       }
     }
   }

--- a/src/hooks/Circles/useCreatePost.test.tsx
+++ b/src/hooks/Circles/useCreatePost.test.tsx
@@ -66,7 +66,7 @@ describe('useCreatePost', () => {
       }
     } as any;
 
-    queryClient.setQueryData('posts', getDataWithPosts([]));
+    queryClient.setQueryData('posts-someCircleId', getDataWithPosts([]));
     const scope = nock(`${baseURL}/v1/graphql`)
       .post('')
       .times(2)
@@ -94,6 +94,9 @@ describe('useCreatePost', () => {
           picture: '',
         },
       },
+      circle: {
+        id: 'someCircleId',
+      },
     };
 
     const createPostInput = {
@@ -101,6 +104,7 @@ describe('useCreatePost', () => {
       id: '123',
       parentId: '456',
       parentType: ParentType.CIRCLE,
+      circle: { id: 'someCircleId' },
     };
 
     onSuccessMock.mockReset();
@@ -114,7 +118,7 @@ describe('useCreatePost', () => {
       expect(onSuccessMock).toBeCalled();
     });
 
-    expect(queryClient.getQueryData('posts')).toEqual(
+    expect(queryClient.getQueryData('posts-someCircleId')).toEqual(
       getDataWithPosts([{ node: expectedPost }]),
     );
 
@@ -123,6 +127,7 @@ describe('useCreatePost', () => {
       id: '789',
       parentId: createPostInput.id,
       parentType: ParentType.POST,
+      circle: { id: 'someCircleId' },
     };
 
     result.current.mutate(
@@ -151,13 +156,16 @@ describe('useCreatePost', () => {
           picture: '',
         },
       },
+      circle: {
+        id: 'someCircleId',
+      },
     };
 
     expectedPost.replyCount = 1;
     expectedPost.replies.edges.push({
       node: expectedCommentPost,
     });
-    expect(queryClient.getQueryData('posts')).toEqual(
+    expect(queryClient.getQueryData('posts-someCircleId')).toEqual(
       getDataWithPosts([{ node: expectedPost }]),
     );
     global.Date = RealDate;

--- a/src/hooks/Circles/useDeletePost.ts
+++ b/src/hooks/Circles/useDeletePost.ts
@@ -3,15 +3,19 @@ import { useQueryClient, useMutation } from 'react-query';
 import { useActiveAccount } from '../useActiveAccount';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { optimisticallyDeletePosts } from './utils/optimisticallyDeletePosts';
+import omit from 'lodash/omit';
 
 export function useDeletePost() {
   const { graphQLClient } = useGraphQLClient();
   const { accountHeaders } = useActiveAccount();
   const queryClient = useQueryClient();
 
-  const deletePostMutation = async (input: { id: string }) => {
+  const deletePostMutation = async (input: {
+    id: string;
+    circleId?: string;
+  }) => {
     const variables = {
-      input,
+      input: omit(input, 'circleId'),
     };
 
     return graphQLClient.request(
@@ -33,6 +37,7 @@ export function useDeletePost() {
       optimisticallyDeletePosts({
         queryClient,
         postId: deletedPost.id,
+        circleId: deletedPost.circleId,
       });
 
       // Return a context object with the snapshotted value

--- a/src/hooks/Circles/useInfinitePosts.tsx
+++ b/src/hooks/Circles/useInfinitePosts.tsx
@@ -57,7 +57,7 @@ export function useInfinitePosts({ circleId }: useInfinitePostsProps) {
     error: postsError,
     hasNextPage,
     fetchNextPage,
-  } = useInfiniteQuery('posts', queryPosts, {
+  } = useInfiniteQuery(`posts-${circleId}`, queryPosts, {
     enabled: !!accountHeaders?.['LifeOmic-Account'] && !!circleId,
     getNextPageParam: (lastPage) => {
       return lastPage.postsV2.pageInfo.hasNextPage

--- a/src/hooks/Circles/useLoadReplies.ts
+++ b/src/hooks/Circles/useLoadReplies.ts
@@ -14,6 +14,7 @@ export const useLoadReplies = () => {
   const [queryVariables, setQueryVariables] = useState({
     after: undefined as string | undefined,
     id: '',
+    circleId: undefined as string | undefined,
   });
 
   const queryForPostReplies = useCallback(async () => {
@@ -27,7 +28,11 @@ export const useLoadReplies = () => {
   }, [accountHeaders, graphQLClient, queryVariables]);
 
   const repliesRes = useQuery(
-    ['loadReplies', queryVariables.id, queryVariables.after],
+    [
+      `loadReplies-${queryVariables.circleId}`,
+      queryVariables.id,
+      queryVariables.after,
+    ],
     queryForPostReplies,
     {
       enabled: isFetched && !!accountHeaders && !!queryVariables.id,
@@ -39,6 +44,7 @@ export const useLoadReplies = () => {
         optimisticallyUpdatePosts({
           queryClient,
           id: queryVariables.id,
+          circleId: queryVariables.circleId,
           transformFn: (post) => {
             post.replies = post.replies ?? { edges: [] };
             post.replies.edges.push(...data.post.replies.edges);
@@ -55,6 +61,7 @@ export const useLoadReplies = () => {
     setQueryVariables({
       id: post.id,
       after: post.replies?.pageInfo?.endCursor,
+      circleId: post.circle?.id,
     });
   };
 

--- a/src/hooks/Circles/useReactionMutations.test.tsx
+++ b/src/hooks/Circles/useReactionMutations.test.tsx
@@ -75,7 +75,7 @@ const getDataWithCount = ({
 
 test('useCreateReaction mutation', async () => {
   queryClient.setQueryData(
-    'posts',
+    'posts-someCircleId',
     getDataWithCount({ count: 0, userHasReacted: false }),
   );
 
@@ -91,7 +91,7 @@ test('useCreateReaction mutation', async () => {
   const onSuccessMock = jest.fn();
   const { result } = await renderCreateReactionHook();
   result.current.mutate(
-    { postId: 'somePostId', type: '(-_-)' },
+    { postId: 'somePostId', type: '(-_-)', circleId: 'someCircleId' },
     { onSuccess: onSuccessMock },
   );
 
@@ -100,7 +100,7 @@ test('useCreateReaction mutation', async () => {
     expect(onSuccessMock).toBeCalled();
   });
 
-  expect(queryClient.getQueryData('posts')).toEqual(
+  expect(queryClient.getQueryData('posts-someCircleId')).toEqual(
     getDataWithCount({ count: 1, userHasReacted: true }),
   );
 });
@@ -144,7 +144,7 @@ test('useCreateReaction mutation updates postDetails', async () => {
 
 test('useUndoReaction mutation', async () => {
   queryClient.setQueryData(
-    'posts',
+    'posts-someCircleId',
     getDataWithCount({ count: 1, userHasReacted: true }),
   );
 
@@ -160,7 +160,12 @@ test('useUndoReaction mutation', async () => {
   const onSuccessMock = jest.fn();
   const { result } = await renderUndoReactionHook();
   result.current.mutate(
-    { postId: 'somePostId', type: '(-_-)', userId: 'someUser' },
+    {
+      postId: 'somePostId',
+      type: '(-_-)',
+      userId: 'someUser',
+      circleId: 'someCircleId',
+    },
     { onSuccess: onSuccessMock },
   );
 
@@ -169,7 +174,7 @@ test('useUndoReaction mutation', async () => {
     expect(onSuccessMock).toBeCalled();
   });
 
-  expect(queryClient.getQueryData('posts')).toEqual(
+  expect(queryClient.getQueryData('posts-someCircleId')).toEqual(
     getDataWithCount({ count: 0, userHasReacted: false }),
   );
 });

--- a/src/hooks/Circles/useReactionMutations.tsx
+++ b/src/hooks/Circles/useReactionMutations.tsx
@@ -9,6 +9,7 @@ interface CreateReactionMutationProps {
   type: string;
   postId: string;
   parentId?: string;
+  circleId?: string;
 }
 
 interface UndoReactionMutationProps {
@@ -16,6 +17,7 @@ interface UndoReactionMutationProps {
   type: string;
   postId: string;
   parentId?: string;
+  circleId?: string;
 }
 
 export function useCreateReactionMutation() {
@@ -45,15 +47,20 @@ export function useCreateReactionMutation() {
     onMutate: async (newReaction) => {
       // Cancel any outgoing refetches
       // (so they don't overwrite our optimistic update)
-      await queryClient.cancelQueries({ queryKey: ['posts'] });
+      await queryClient.cancelQueries({
+        queryKey: `posts-${newReaction.circleId}`,
+      });
 
       // Snapshot the previous value
-      const previousPosts = queryClient.getQueryData(['posts']);
+      const previousPosts = queryClient.getQueryData([
+        `posts-${newReaction.circleId}`,
+      ]);
 
       // Optimistically update to the new value
       optimisticallyUpdatePosts({
         queryClient,
         id: newReaction.postId,
+        circleId: newReaction.circleId,
         transformFn: (post) => optimisticUpdatePost(post, newReaction)!,
       });
 
@@ -92,15 +99,20 @@ export function useUndoReactionMutation() {
     onMutate: async (newReaction) => {
       // Cancel any outgoing refetches
       // (so they don't overwrite our optimistic update)
-      await queryClient.cancelQueries({ queryKey: ['posts'] });
+      await queryClient.cancelQueries({
+        queryKey: `posts-${newReaction.circleId}`,
+      });
 
       // Snapshot the previous value
-      const previousPosts = queryClient.getQueryData(['posts']);
+      const previousPosts = queryClient.getQueryData([
+        `posts-${newReaction.circleId}`,
+      ]);
 
       // Optimistically update to the new value
       optimisticallyUpdatePosts({
         queryClient,
         id: newReaction.postId,
+        circleId: newReaction.circleId,
         transformFn: (post) => optimisticUpdatePost(post, newReaction, true)!,
       });
 

--- a/src/hooks/Circles/utils/optimisticallyDeletePosts.ts
+++ b/src/hooks/Circles/utils/optimisticallyDeletePosts.ts
@@ -10,26 +10,31 @@ import { cloneDeep } from 'lodash';
 type DeletePostsConfig = {
   queryClient: QueryClient;
   postId: string;
+  circleId?: string;
 };
 
 export const optimisticallyDeletePosts = ({
   queryClient,
   postId,
+  circleId,
 }: DeletePostsConfig) => {
-  queryClient.setQueryData<InfinitePostsData>(['posts'], (currentData) => {
-    if (!currentData) {
-      return currentData!;
-    }
-    const newData = cloneDeep(currentData);
-    for (const page of newData?.pages) {
-      const result = deletePostById(page.postsV2.edges, postId);
-      if (result) {
-        break;
+  queryClient.setQueryData<InfinitePostsData>(
+    `posts-${circleId}`,
+    (currentData) => {
+      if (!currentData) {
+        return currentData!;
       }
-    }
+      const newData = cloneDeep(currentData);
+      for (const page of newData?.pages) {
+        const result = deletePostById(page.postsV2.edges, postId);
+        if (result) {
+          break;
+        }
+      }
 
-    return newData!;
-  });
+      return newData!;
+    },
+  );
 
   queryClient
     .getQueryCache()

--- a/src/hooks/Circles/utils/optimisticallyUpdatePosts.ts
+++ b/src/hooks/Circles/utils/optimisticallyUpdatePosts.ts
@@ -10,21 +10,26 @@ import { cloneDeep } from 'lodash';
 interface OptimisticallyUpdatePosts {
   queryClient: QueryClient;
   id: string;
+  circleId?: string;
   transformFn: (post: Post) => Post;
 }
 
 export const optimisticallyUpdatePosts = ({
   queryClient,
   id,
+  circleId,
   transformFn,
 }: OptimisticallyUpdatePosts) => {
-  queryClient.setQueryData<InfinitePostsData>(['posts'], (currentData) => {
-    const newData = cloneDeep(currentData);
-    forEach(newData?.pages, (page) => {
-      transformEdgesById(page.postsV2?.edges, id, transformFn);
-    });
-    return newData!;
-  });
+  queryClient.setQueryData<InfinitePostsData>(
+    `posts-${circleId}`,
+    (currentData) => {
+      const newData = cloneDeep(currentData);
+      forEach(newData?.pages, (page) => {
+        transformEdgesById(page.postsV2?.edges, id, transformFn);
+      });
+      return newData!;
+    },
+  );
 
   queryClient
     .getQueryCache()


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
Fix caching of circles when multiple circles are loaded by using the circleId in the `posts` queryKey.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->