### PR TITLE
Use Memo for Account/Project Selection

### DIFF
--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -59,7 +59,7 @@ beforeEach(() => {
   });
   useAsyncStorageSpy.mockReturnValue([
     {
-      ...mockDeep<UseQueryResult<string | null>>(),
+      ...mockDeep<UseQueryResult<string | null>>({ isFetched: true }),
     },
     (value: string) =>
       AsyncStorage.setItem('selectedAccountId:mockUser', value),

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useContext,
   useCallback,
+  useMemo,
 } from 'react';
 import { Account, useAccounts } from './useAccounts';
 import { QueryObserverResult } from 'react-query';
@@ -61,10 +62,9 @@ export const ActiveAccountContextProvider = ({
 }) => {
   const accountsResult = useAccounts();
   const accountsWithProduct = filterNonLRAccounts(accountsResult.data);
-  const [isSettled, setIsSettled] = useState(false);
-  const [activeAccount, setActiveAccount] = useState<ActiveAccountProps>({});
   const { data: userData } = useUser();
   const userId = userData?.id;
+  const [selectedId, setSelectedId] = useState(accountIdToSelect);
   const [previousUserId, setPreviousUserId] = useState(userId);
   const [storedAccountIdResult, setStoredAccountId] = useAsyncStorage(
     `${selectedAccountIdKey}:${userId}`,
@@ -73,60 +73,51 @@ export const ActiveAccountContextProvider = ({
   /**
    * Initial setting of activeAccount
    */
-  useEffect(() => {
-    if (
-      accountsResult.isFetched &&
-      !accountsResult.isLoading &&
-      accountsWithProduct.length < 1
-    ) {
-      setIsSettled(true);
-    }
-
+  const activeAccount = useMemo<ActiveAccountProps>(() => {
     if (
       !userId || // require user id before reading/writing to storage
       storedAccountIdResult.isLoading || // wait for async storage result
-      activeAccount?.account?.id || // activeAccount already set
       accountsWithProduct.length < 1 // no valid accounts found server side
     ) {
-      return;
+      return {};
     }
 
     const accountToSelect =
-      accountIdToSelect ?? storedAccountIdResult.data ?? undefined;
+      selectedId ?? storedAccountIdResult.data ?? undefined;
 
     const selectedAccount =
       getValidAccount(accountsWithProduct, accountToSelect) ??
       accountsWithProduct[0];
 
-    setActiveAccount({
+    return {
       account: selectedAccount,
       accountHeaders: {
         'LifeOmic-Account': selectedAccount.id,
       },
       trialExpired: getTrialExpired(selectedAccount),
-    });
-    setStoredAccountId(selectedAccount.id);
-    setIsSettled(true);
+    };
   }, [
     accountsWithProduct,
-    activeAccount?.account?.id,
-    accountIdToSelect,
-    setStoredAccountId,
+    selectedId,
     storedAccountIdResult.data,
     storedAccountIdResult.isLoading,
-    accountsResult.isFetched,
-    accountsResult.isLoading,
     userId,
   ]);
+
+  useEffect(() => {
+    if (activeAccount?.account?.id) {
+      setStoredAccountId(activeAccount.account.id);
+    }
+  }, [activeAccount, setStoredAccountId]);
 
   // Clear selected account when
   // we've detected that the userId has changed
   useEffect(() => {
     if (userId !== previousUserId) {
-      setActiveAccount({});
+      accountsResult.refetch();
       setPreviousUserId(userId);
     }
-  }, [previousUserId, userId]);
+  }, [previousUserId, userId, accountsResult]);
 
   const setActiveAccountId = useCallback(
     async (accountId: string) => {
@@ -142,21 +133,14 @@ export const ActiveAccountContextProvider = ({
           return;
         }
 
-        setActiveAccount({
-          account: selectedAccount,
-          accountHeaders: {
-            'LifeOmic-Account': selectedAccount.id,
-          },
-          trialExpired: getTrialExpired(selectedAccount),
-        });
-        await setStoredAccountId(selectedAccount.id);
+        setSelectedId(selectedAccount.id);
       } catch (error) {
         if (process.env.NODE_ENV !== 'test') {
           console.warn('Unable to set active account', error);
         }
       }
     },
-    [accountsWithProduct, setStoredAccountId],
+    [accountsWithProduct],
   );
 
   const refetch = useCallback(async () => {
@@ -183,8 +167,8 @@ export const ActiveAccountContextProvider = ({
         accountsWithProduct,
         refetch,
         setActiveAccountId,
-        isLoading: accountsResult.isLoading || !isSettled,
-        isFetched: accountsResult.isFetched,
+        isLoading: accountsResult.isLoading || storedAccountIdResult.isLoading,
+        isFetched: accountsResult.isFetched && storedAccountIdResult.isFetched,
         error: accountsResult.error,
       }}
     >

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -108,7 +108,7 @@ export const ActiveAccountContextProvider = ({
     if (activeAccount?.account?.id) {
       setStoredAccountId(activeAccount.account.id);
     }
-  }, [activeAccount, setStoredAccountId]);
+  }, [activeAccount?.account?.id, setStoredAccountId]);
 
   // Clear selected account when
   // we've detected that the userId has changed

--- a/src/hooks/useActiveProject.test.tsx
+++ b/src/hooks/useActiveProject.test.tsx
@@ -76,7 +76,10 @@ beforeEach(() => {
 
   useAsyncStorageSpy.mockReturnValue([
     {
-      ...mockDeep<UseQueryResult<string | null>>(),
+      ...mockDeep<UseQueryResult<string | null>>({
+        isLoading: false,
+        isFetched: true,
+      }),
     },
     (value: string) => AsyncStorage.setItem('selectedProjectIdKey', value),
   ]);
@@ -102,6 +105,11 @@ test('exposes some props from useSubjectProjects and useMe', async () => {
   useSubjectProjectsMock.mockReturnValue({
     isLoading: true,
     isFetched: true,
+    error,
+  });
+  useMeMock.mockReturnValue({
+    isLoading: false,
+    isFetched: false,
     error,
   });
   const { result, rerender } = await renderHookInContext();
@@ -159,10 +167,11 @@ test('setActiveProjectId ignores invalid projectId', async () => {
   });
 
   useMeMock.mockReturnValue({
+    isFetched: true,
     data: [mockMe[0]], // NOTE: mockMe[1] not there - weird edge case
   });
   await rerender({});
-  await act(async () => {
+  act(() => {
     result.current.setActiveProjectId(mockSubjectProjects[1].id);
   });
   expect(result.current).toMatchObject({

--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -121,7 +121,7 @@ export const ActiveProjectContextProvider = ({
     if (hookReturnValue?.activeProject?.id) {
       setStoredProjectId(hookReturnValue?.activeProject?.id);
     }
-  }, [hookReturnValue, setStoredProjectId]);
+  }, [hookReturnValue?.activeProject?.id, setStoredProjectId]);
 
   // Clear selected project when
   // we've detected that the userId has changed

--- a/src/hooks/useSubjectProjects.test.tsx
+++ b/src/hooks/useSubjectProjects.test.tsx
@@ -57,7 +57,7 @@ test('fetches and returns projects related to useMe', async () => {
   axiosMock.onGet().reply(200, projectsResponse);
   const { result } = await renderHookInContext();
   await waitFor(() => result.current.isSuccess);
-  expect(axiosMock.history.get[0].url).toBe('/v1/projects?id=proj1,proj2');
+  expect(axiosMock.history.get[0].url).toBe('/v1/projects?id=proj1&id=proj2');
   await waitFor(() => expect(result.current.data).toEqual([{}, {}]));
 });
 

--- a/src/hooks/useSubjectProjects.tsx
+++ b/src/hooks/useSubjectProjects.tsx
@@ -22,7 +22,7 @@ export function useSubjectProjects() {
     async () => {
       if (subjects?.length) {
         const res = await httpClient.get<ProjectsResponse>(
-          `/v1/projects?id=${subjects?.map((s) => s.projectId).join(',')}`,
+          `/v1/projects?${subjects?.map((s) => `id=${s.projectId}`).join('&')}`,
           { headers: accountHeaders },
         );
         return res.data.items;


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Reverts the `isSettled` changes that did not work
  - Switches from state/effect logic to `useMemo` for account and project selection. The old way allowed for some extra renders where `isLoading: false` and `isFetched: true` but the correct account/project had not actually been selected which caused the `need an invitation` warning to be displayed