### PR TITLE
fix: Handle errors during parsing the WebView messages

### DIFF
--- a/src/hooks/useHandleAppTileEvents.test.ts
+++ b/src/hooks/useHandleAppTileEvents.test.ts
@@ -416,4 +416,22 @@ describe('handleAppTileNavigationStateChange', () => {
 
     expect(preventDefault).not.toHaveBeenCalled();
   });
+
+  it('should handle events with undefined data', () => {
+    const { result } = renderHook(() => useHandleAppTileEvents());
+    const event = {
+      nativeEvent: {
+        data: undefined,
+        canGoBack: true,
+        canGoForward: false,
+        loading: false,
+        title: 'event',
+        url: 'event.com',
+        lockIdentifier: 1234442,
+      },
+    };
+    expect(() =>
+      result.current.handleAppTileMessage(event as any),
+    ).not.toThrowError();
+  });
 });

--- a/src/hooks/useHandleAppTileEvents.ts
+++ b/src/hooks/useHandleAppTileEvents.ts
@@ -173,16 +173,25 @@ export const useHandleAppTileEvents = (webView: WebView | null = null) => {
   };
 
   const handleAppTileMessage = (event: WebViewMessageEvent) => {
-    const appTileMessage: AppTileMessage = JSON.parse(event.nativeEvent.data);
-    switch (appTileMessage.type) {
-      case AppTileMessageType.deepLink:
-        handleDeepLinkMessage(appTileMessage);
-        break;
-      case AppTileMessageType.openUrl:
-        handleOpenUrlMessage(appTileMessage);
-        break;
+    const eventData = event.nativeEvent.data;
+    if (!eventData) {
+      return;
+    }
 
-      // no default
+    try {
+      const appTileMessage: AppTileMessage = JSON.parse(eventData);
+      switch (appTileMessage.type) {
+        case AppTileMessageType.deepLink:
+          handleDeepLinkMessage(appTileMessage);
+          break;
+        case AppTileMessageType.openUrl:
+          handleOpenUrlMessage(appTileMessage);
+          break;
+
+        // no default
+      }
+    } catch (error) {
+      console.warn('Error parsing app tile message', { eventData, error });
     }
   };
 


### PR DESCRIPTION
When opening a lifeology course via the today tile on Android, the web view sends a message with `data = undefined`. Our message parser tries to parse undefined, and causes the app to crash.

This message is not sent in iOS.