### PR TITLE
feat: Update LogoHeader to be customizable per screen

### DIFF
--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -187,7 +187,7 @@ storiesOf('Example App', module)
       >
         <RootProviders authConfig={authConfig}>
           <BrandConfigProvider {...brand}>
-            <LogoHeader imageSource={logo} />
+            <LogoHeader visible={true} imageSource={logo} />
             <RootStack />
           </BrandConfigProvider>
         </RootProviders>

--- a/src/components/LogoHeader.tsx
+++ b/src/components/LogoHeader.tsx
@@ -1,26 +1,86 @@
-import React from 'react';
-import { View, Image, ImageSourcePropType, Platform } from 'react-native';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
+import {
+  View,
+  Image,
+  Platform,
+  ImageSourcePropType,
+  NativeEventEmitter,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { createStyles } from './BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
+import { useFocusEffect } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 
 type Percentage = `${number}%`;
-
-interface Props {
-  imageSource: ImageSourcePropType;
+type LogoHeaderOptions = {
+  visible?: boolean;
+  imageSource?: ImageSourcePropType;
   item?: JSX.Element;
   alignImage?: Percentage;
   alignItem?: Percentage;
-}
+};
 
-export function LogoHeader({
-  imageSource,
-  item,
-  alignImage,
-  alignItem,
-}: Props) {
+const eventEmitter = new NativeEventEmitter({
+  addListener: () => {},
+  removeListeners: () => {},
+});
+
+const updateLogoOptionsEvent = 'updateLogoOptions';
+const restoreLogoOptionsEvent = 'restoreLogoOptions';
+
+export const emitOptionsChanged = (options: LogoHeaderOptions) =>
+  eventEmitter.emit(updateLogoOptionsEvent, options);
+
+/**
+ * @param newOptions
+ * @returns void
+ * When the current screen comes into focus emit new header options
+ * and restores defaults when a blurScreen event is emitted
+ */
+export const useEmitLogoHeaderOptions = (newOptions: LogoHeaderOptions) => {
+  const navigation = useNavigation();
+  useFocusEffect(() => {
+    emitOptionsChanged(newOptions);
+  });
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('blur', () => {
+      eventEmitter.emit(restoreLogoOptionsEvent);
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+};
+
+export function LogoHeader(defaultOptions: LogoHeaderOptions) {
   const { styles } = useStyles(defaultStyles);
   const androidFix = Platform.OS === 'android' ? { marginTop: 12 } : {};
+  const [options, setOptions] = useState<LogoHeaderOptions>(defaultOptions);
+
+  useLayoutEffect(() => {
+    const subscription = eventEmitter.addListener(
+      updateLogoOptionsEvent,
+      (newOptions) => setOptions({ ...defaultOptions, ...newOptions }),
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [defaultOptions]);
+
+  useLayoutEffect(() => {
+    const subscription = eventEmitter.addListener(restoreLogoOptionsEvent, () =>
+      setOptions(defaultOptions),
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [defaultOptions]);
+
+  if (!options || !options?.visible) {
+    return null;
+  }
 
   return (
     <View style={styles.view}>
@@ -29,16 +89,20 @@ export function LogoHeader({
         style={[androidFix, styles.safeAreaView]}
       >
         <View style={styles.contentView}>
-          <Image
-            source={imageSource}
-            style={[
-              {
-                left: alignImage,
-              },
-              styles.image,
-            ]}
-          />
-          <View style={[{ left: alignItem }, styles.itemView]}>{item}</View>
+          {options.imageSource && (
+            <Image
+              source={options.imageSource}
+              style={[
+                {
+                  left: options.alignImage,
+                },
+                styles.image,
+              ]}
+            />
+          )}
+          <View style={[{ left: options.alignItem }, styles.itemView]}>
+            {options.item}
+          </View>
         </View>
       </SafeAreaView>
     </View>

--- a/src/components/LogoHeader.tsx
+++ b/src/components/LogoHeader.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
-
 import { View, Image, ImageSourcePropType, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { createStyles } from './BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
 
+type Percentage = `${number}%`;
+
 interface Props {
   imageSource: ImageSourcePropType;
+  item?: JSX.Element;
+  alignImage?: Percentage;
+  alignItem?: Percentage;
 }
 
-export function LogoHeader({ imageSource }: Props) {
+export function LogoHeader({
+  imageSource,
+  item,
+  alignImage,
+  alignItem,
+}: Props) {
   const { styles } = useStyles(defaultStyles);
   const androidFix = Platform.OS === 'android' ? { marginTop: 12 } : {};
 
@@ -19,7 +28,18 @@ export function LogoHeader({ imageSource }: Props) {
         edges={['left', 'right', 'top']}
         style={[androidFix, styles.safeAreaView]}
       >
-        <Image source={imageSource} style={styles.image} />
+        <View style={styles.contentView}>
+          <Image
+            source={imageSource}
+            style={[
+              {
+                left: alignImage,
+              },
+              styles.image,
+            ]}
+          />
+          <View style={[{ left: alignItem }, styles.itemView]}>{item}</View>
+        </View>
       </SafeAreaView>
     </View>
   );
@@ -27,8 +47,10 @@ export function LogoHeader({ imageSource }: Props) {
 
 const defaultStyles = createStyles('LogoHeader', () => ({
   view: {},
-  safeAreaView: { alignItems: 'center' },
-  image: {},
+  safeAreaView: {},
+  image: { position: 'absolute' },
+  itemView: { position: 'absolute' },
+  contentView: { alignItems: 'center', minHeight: '20%', overflow: 'visible' },
 }));
 
 declare module '@styles' {


### PR DESCRIPTION
### Changes 
 - Adds ability to pass an Element to the LogoHeader, e.g., Buttons
  - Adds optional parameters to absolutely position image and the item along the horizontal axis
  - Preserves default positioning by aligning items center if alignment props are not specified.
  - Adds new visible prop

### Emitter/Listener system to update LogoHeader per screen
  - Adds new hook useEmitLogoHeaderOptions to customize logo settings per screen
  - Restores defaults (passed as props to LogoHeader) when leaving the screen
  - Merges updated options with defaults so options such as ImageSource only have to specified once

#### Limitations
 - The useEmitLogoHeaderOptions must be placed within the screen which will prevent using the default screens with this effect. It would be a better experience if this was injectable (perhaps via the DeveloperConfig).
  
## Screenshots
<!-- include screen recordings, if relevant to your changes -->

https://github.com/lifeomic/react-native-sdk/assets/76954025/00a00cc2-2b0a-4f33-9c4d-64cee8ef9596


<img width="768" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/76954025/83181d3b-af6e-41e9-95c9-db44610aa3ce">

