### PR TITLE
feat: Onboarding course

### DIFF
--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "onboarding-course.done": "Done",
   "track-tile.go-to-tracker": "Go to tracker",
   "track-tile.my-target": "My Target",
   "track-tile.plus-symbol": "+",
@@ -10,6 +11,7 @@
   "track-tile.previous-weeks-data": "Previous week's data",
   "track-tile.problem-occurred-while-reordering-items": "A problem occurred while reordering the items",
   "track-tile.your-active-items": "Your active items",
+  "track-tile.save": "Save",
   "track-tile.save-tracker-order": "Save tracker order",
   "track-tile.open-tracker-settings": "Open Tracker Settings",
   "track-tile.track-it": "Track It!",

--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -20,6 +20,7 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { InviteProvider } from '../components/Invitations/InviteProvider';
 import { PushNotificationsProvider } from '../hooks/usePushNotifications';
 import { CircleTileContextProvider } from '../hooks/Circles/useActiveCircleTile';
+import { OnboardingCourseContextProvider } from '../hooks/useOnboardingCourse';
 
 const queryClient = new QueryClient();
 
@@ -45,21 +46,23 @@ export function RootProviders({
                       <WearableLifecycleProvider>
                         <CircleTileContextProvider>
                           <BrandConfigProvider theme={theme}>
-                            <NoInternetToastProvider>
-                              <ActionSheetProvider>
-                                <SafeAreaProvider>
-                                  <ThemedNavigationContainer>
-                                    <PushNotificationsProvider
-                                      config={pushNotificationsConfig}
-                                    >
-                                      {children}
-                                    </PushNotificationsProvider>
-                                  </ThemedNavigationContainer>
-                                  <CreateEditPostModal />
-                                  <Toast />
-                                </SafeAreaProvider>
-                              </ActionSheetProvider>
-                            </NoInternetToastProvider>
+                            <OnboardingCourseContextProvider>
+                              <NoInternetToastProvider>
+                                <ActionSheetProvider>
+                                  <SafeAreaProvider>
+                                    <ThemedNavigationContainer>
+                                      <PushNotificationsProvider
+                                        config={pushNotificationsConfig}
+                                      >
+                                        {children}
+                                      </PushNotificationsProvider>
+                                    </ThemedNavigationContainer>
+                                    <CreateEditPostModal />
+                                    <Toast />
+                                  </SafeAreaProvider>
+                                </ActionSheetProvider>
+                              </NoInternetToastProvider>
+                            </OnboardingCourseContextProvider>
                           </BrandConfigProvider>
                         </CircleTileContextProvider>
                       </WearableLifecycleProvider>

--- a/src/components/HeaderButton.tsx
+++ b/src/components/HeaderButton.tsx
@@ -4,12 +4,13 @@ import { HeaderButtonComponent } from './HeaderButtonComponent';
 
 interface Props {
   onPress: () => void;
+  title: string;
 }
 
-export const HeaderSaveButton = ({ onPress }: Props) => {
+export const HeaderButton = ({ onPress, title }: Props) => {
   return (
     <HeaderButtons HeaderButtonComponent={HeaderButtonComponent}>
-      <Item title="Save" onPress={onPress} />
+      <Item title={title} onPress={onPress} />
     </HeaderButtons>
   );
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -15,6 +15,7 @@ export * from './useHttpClient';
 export * from './useMe';
 export * from './useNotifications';
 export * from './useOAuthFlow';
+export * from './useOnboardingCourse';
 export * from './usePendingInvite';
 export * from './Circles';
 export * from './useStyles';

--- a/src/hooks/useAppConfig.ts
+++ b/src/hooks/useAppConfig.ts
@@ -46,6 +46,10 @@ export interface AppConfig {
       surveysTile: AppTile;
     };
   };
+  onboardingCourse?: {
+    url: string;
+    title?: string;
+  };
 }
 
 export function useAppConfig() {

--- a/src/hooks/useOnboardingCourse.test.tsx
+++ b/src/hooks/useOnboardingCourse.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  OnboardingCourseContextProvider,
+  useOnboardingCourse,
+} from './useOnboardingCourse';
+import * as useAsyncStorage from './useAsyncStorage';
+import { mockDeep } from 'jest-mock-extended';
+import { UseQueryResult } from 'react-query';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('./useAppConfig', () => ({
+  useAppConfig: () => ({
+    data: {
+      onboardingCourse: { url: 'http://example.com', title: 'Example Title' },
+    },
+    isLoading: false,
+    isFetched: true,
+    error: null,
+  }),
+}));
+
+jest.mock('./useActiveProject', () => ({
+  useActiveProject: () => ({ activeProject: { id: 'project-123' } }),
+}));
+
+let useAsyncStorageSpy = jest.spyOn(useAsyncStorage, 'useAsyncStorage');
+
+beforeEach(() => {
+  useAsyncStorageSpy.mockReturnValue([
+    {
+      ...mockDeep<UseQueryResult<string | null>>({
+        isLoading: false,
+        isFetched: true,
+      }),
+    },
+    (value: string) => AsyncStorage.setItem('selectedProjectIdKey', value),
+  ]);
+});
+
+const renderHookInContext = async () => {
+  return renderHook(() => useOnboardingCourse(), {
+    wrapper: ({ children }) => (
+      <OnboardingCourseContextProvider>
+        {children}
+      </OnboardingCourseContextProvider>
+    ),
+  });
+};
+
+describe('useOnboardingCourse', () => {
+  test('should return the correct context values', async () => {
+    const { result } = await renderHookInContext();
+
+    expect(result.current.shouldLaunchOnboardingCourse).toBe(true);
+    expect(result.current.onboardingCourseUrl).toBe('http://example.com');
+    expect(result.current.onboardingCourseTitle).toBe('Example Title');
+    expect(typeof result.current.onOnboardingCourseOpen).toBe('function');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetched).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('should set didLaunchCourse to true when calling onOnboardingCourseOpen', async () => {
+    const { result } = await renderHookInContext();
+
+    act(() => {
+      result.current.onOnboardingCourseOpen();
+    });
+
+    await waitFor(() => result.current.shouldLaunchOnboardingCourse === false);
+  });
+});

--- a/src/hooks/useOnboardingCourse.tsx
+++ b/src/hooks/useOnboardingCourse.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useCallback, useEffect, useState } from 'react';
+import { useAppConfig } from './useAppConfig';
+import { useActiveProject } from './useActiveProject';
+import { useAsyncStorage } from './useAsyncStorage';
+
+export type OnboardingCourseContextProps = {
+  shouldLaunchOnboardingCourse: boolean;
+  onboardingCourseUrl?: string;
+  onboardingCourseTitle?: string;
+  onOnboardingCourseOpen: () => void;
+  isLoading: boolean;
+  isFetched: boolean;
+  error?: any;
+};
+
+export const OnboardingCourseContext = createContext({
+  shouldLaunchOnboardingCourse: false,
+  onboardingCourseUrl: undefined,
+  onOnboardingCourseOpen: () => {},
+} as OnboardingCourseContextProps);
+
+export const OnboardingCourseContextProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { data, isLoading, isFetched, error } = useAppConfig();
+  const onboardingCourseUrl = data?.onboardingCourse?.url;
+  const onboardingCourseTitle = data?.onboardingCourse?.title;
+  const { activeProject } = useActiveProject();
+
+  const [storedDidLaunchResult, storeDidLaunch] = useAsyncStorage(
+    `${activeProject?.id}-didLaunchOnboardingCourse`,
+  );
+  const [didLaunchCourse, setDidLaunchCourse] = useState(false);
+
+  useEffect(() => {
+    if (storedDidLaunchResult.isFetched && activeProject?.id) {
+      setDidLaunchCourse(storedDidLaunchResult.data === 'true');
+    }
+  }, [storedDidLaunchResult, activeProject?.id]);
+
+  /* Render the onboarding course if the following conditions are met:
+    1. The onboarding course url is defined
+    3. The onboarding course has not been launched
+  */
+  const shouldLaunchOnboardingCourse =
+    !!onboardingCourseUrl && !didLaunchCourse;
+
+  const onOnboardingCourseOpen = useCallback(() => {
+    setDidLaunchCourse(true);
+    storeDidLaunch('true');
+  }, [storeDidLaunch]);
+
+  return (
+    <OnboardingCourseContext.Provider
+      value={{
+        shouldLaunchOnboardingCourse,
+        onboardingCourseUrl,
+        onboardingCourseTitle,
+        onOnboardingCourseOpen,
+        isLoading,
+        isFetched,
+        error,
+      }}
+    >
+      {children}
+    </OnboardingCourseContext.Provider>
+  );
+};
+
+export const useOnboardingCourse = () =>
+  React.useContext(OnboardingCourseContext);

--- a/src/hooks/useOnboardingCourse.tsx
+++ b/src/hooks/useOnboardingCourse.tsx
@@ -42,7 +42,7 @@ export const OnboardingCourseContextProvider = ({
 
   /* Render the onboarding course if the following conditions are met:
     1. The onboarding course url is defined
-    3. The onboarding course has not been launched
+    2. The onboarding course has not been launched
   */
   const shouldLaunchOnboardingCourse =
     !!onboardingCourseUrl && !didLaunchCourse;

--- a/src/hooks/useOnboardingCourse.tsx
+++ b/src/hooks/useOnboardingCourse.tsx
@@ -24,7 +24,12 @@ export const OnboardingCourseContextProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { data, isLoading, isFetched, error } = useAppConfig();
+  const {
+    data,
+    isLoading: isAppConfigLoading,
+    isFetched: isAppConfigFetched,
+    error,
+  } = useAppConfig();
   const onboardingCourseUrl = data?.onboardingCourse?.url;
   const onboardingCourseTitle = data?.onboardingCourse?.title;
   const { activeProject } = useActiveProject();
@@ -32,7 +37,12 @@ export const OnboardingCourseContextProvider = ({
   const [storedDidLaunchResult, storeDidLaunch] = useAsyncStorage(
     `${activeProject?.id}-didLaunchOnboardingCourse`,
   );
-  const [didLaunchCourse, setDidLaunchCourse] = useState(false);
+  const [didLaunchCourse, setDidLaunchCourse] = useState<boolean | undefined>(
+    undefined,
+  );
+
+  const isLoading = isAppConfigLoading || storedDidLaunchResult.isLoading;
+  const isFetched = isAppConfigFetched && storedDidLaunchResult.isFetched;
 
   useEffect(() => {
     if (storedDidLaunchResult.isFetched && activeProject?.id) {
@@ -41,11 +51,12 @@ export const OnboardingCourseContextProvider = ({
   }, [storedDidLaunchResult, activeProject?.id]);
 
   /* Render the onboarding course if the following conditions are met:
-    1. The onboarding course url is defined
-    2. The onboarding course has not been launched
+    1. The app config and the async storage value have been fetched
+    2. The onboarding course url is defined
+    3. The onboarding course has not been launched
   */
   const shouldLaunchOnboardingCourse =
-    !!onboardingCourseUrl && !didLaunchCourse;
+    isFetched && !!onboardingCourseUrl && !didLaunchCourse;
 
   const onOnboardingCourseOpen = useCallback(() => {
     setDidLaunchCourse(true);

--- a/src/navigators/RootStack.tsx
+++ b/src/navigators/RootStack.tsx
@@ -6,6 +6,7 @@ import {
   useActiveProject,
   useAuth,
   useConsent,
+  useOnboardingCourse,
   usePendingInvite,
 } from '../hooks';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -16,6 +17,7 @@ import { LoggedInRootParamList, NotLoggedInRootParamList } from './types';
 import { ConsentScreen } from '../screens/ConsentScreen';
 import { CircleThreadScreen } from '../screens/CircleThreadScreen';
 import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
+import { OnboardingCourseScreen } from '../screens/OnboardingCourseScreen';
 
 export function RootStack() {
   const { isLoggedIn, loading: loadingAuth } = useAuth();
@@ -34,12 +36,19 @@ export function RootStack() {
   const { useShouldRenderConsentScreen } = useConsent();
   const { shouldRenderConsentScreen, isLoading: loadingConsents } =
     useShouldRenderConsentScreen();
+  const {
+    shouldLaunchOnboardingCourse,
+    isLoading: onboardingCourseIsLoading,
+    isFetched: onboardingCourseIsFetched,
+  } = useOnboardingCourse();
 
   const loadingProject = !isFetchedProject || isLoadingProject;
   const loadingAccount = !isFetchedAccount || isLoadingAccount;
   const hasAccount = !loadingAccount && !!account?.id;
   const loadingAccountOrProject =
     loadingAccount || (hasAccount && loadingProject);
+  const loadingOnboardingCourse =
+    !onboardingCourseIsFetched || onboardingCourseIsLoading;
 
   if (!isLoggedIn && loadingAuth) {
     return (
@@ -72,6 +81,17 @@ export function RootStack() {
       );
     }
 
+    if (hasAccountAndProject && loadingOnboardingCourse) {
+      return (
+        <ActivityIndicatorView
+          message={t(
+            'root-stack-waiting-for-app-config',
+            'Loading onboarding course data',
+          )}
+        />
+      );
+    }
+
     if (inviteParams?.inviteId) {
       return (
         <ActivityIndicatorView
@@ -84,6 +104,8 @@ export function RootStack() {
       ? 'InviteRequired'
       : shouldRenderConsentScreen
       ? 'screens/ConsentScreen'
+      : shouldLaunchOnboardingCourse
+      ? 'screens/OnboardingCourseScreen'
       : 'app';
 
     return (
@@ -108,6 +130,13 @@ export function RootStack() {
             options={{
               presentation: 'fullScreenModal',
               title: t('consent', 'Consent'),
+            }}
+          />
+          <Stack.Screen
+            name="screens/OnboardingCourseScreen"
+            component={OnboardingCourseScreen}
+            options={{
+              presentation: 'fullScreenModal',
             }}
           />
           <Stack.Screen name="Circle/Thread" component={CircleThreadScreen} />

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -26,6 +26,7 @@ export type LoggedInRootParamList = {
   'screens/ConsentScreen': undefined;
   InviteRequired: undefined;
   'Circle/Thread': { post: Post; createNewComment?: boolean };
+  'screens/OnboardingCourseScreen': undefined;
 };
 
 export type LoggedInRootScreenProps<T extends keyof LoggedInRootParamList> =

--- a/src/screens/ConsentScreen.tsx
+++ b/src/screens/ConsentScreen.tsx
@@ -4,7 +4,12 @@ import { t } from 'i18next';
 import Markdown from 'react-native-markdown-display';
 import { Button } from 'react-native-paper';
 import { ActivityIndicatorView, createStyles } from '../components';
-import { useStyles, useConsent, useOAuthFlow } from '../hooks';
+import {
+  useStyles,
+  useConsent,
+  useOAuthFlow,
+  useOnboardingCourse,
+} from '../hooks';
 import { LoggedInRootScreenProps } from '../navigators/types';
 
 export const ConsentScreen = ({
@@ -17,6 +22,7 @@ export const ConsentScreen = ({
     useShouldRenderConsentScreen();
   const updateConsentDirectiveMutation = useUpdateProjectConsentDirective();
   const { logout } = useOAuthFlow();
+  const { shouldLaunchOnboardingCourse } = useOnboardingCourse();
 
   // TODO: If needed, allow for accepting multiple consents in a row.
   const consentToPresent = useMemo(
@@ -39,8 +45,11 @@ export const ConsentScreen = ({
 
   const acceptConsent = useCallback(async () => {
     await updateConsentDirective(true);
-    navigation.replace('app');
-  }, [updateConsentDirective, navigation]);
+    const route = shouldLaunchOnboardingCourse
+      ? 'screens/OnboardingCourseScreen'
+      : 'app';
+    navigation.replace(route);
+  }, [updateConsentDirective, navigation, shouldLaunchOnboardingCourse]);
 
   const declineConsent = useCallback(() => {
     Alert.alert(

--- a/src/screens/OnboardingCourseScreen.test.tsx
+++ b/src/screens/OnboardingCourseScreen.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Button } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { OnboardingCourseScreen } from './OnboardingCourseScreen';
+import { useOnboardingCourse } from '../hooks/useOnboardingCourse';
+
+jest.mock('../hooks/useOnboardingCourse', () => ({
+  useOnboardingCourse: jest.fn(),
+}));
+
+jest.mock('../components/HeaderButton', () => Button);
+
+const useOnboardingCourseMock = useOnboardingCourse as jest.Mock;
+
+const navigateMock = {
+  replace: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+const onboardingCourseScreen = (
+  <OnboardingCourseScreen navigation={navigateMock as any} route={{} as any} />
+);
+
+const courseURL = 'http://unit-test/onboarding-course';
+const onboardingCourseTitle = 'Onboarding Course Title';
+const onOnboardingCourseOpenMock = jest.fn();
+
+beforeEach(() => {
+  useOnboardingCourseMock.mockReturnValue({
+    onboardingCourseUrl: courseURL,
+    onOnboardingCourseOpen: onOnboardingCourseOpenMock,
+    onboardingCourseTitle,
+  });
+});
+
+test('should render the course ', async () => {
+  const { getByTestId } = render(onboardingCourseScreen);
+  expect(getByTestId('onboarding-course-web-view')).toBeDefined();
+});

--- a/src/screens/OnboardingCourseScreen.tsx
+++ b/src/screens/OnboardingCourseScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import WebView from 'react-native-webview';
-import { useOnboardingCourse } from '../hooks/useOnboardingCourse';
+import { t } from '../../lib/i18n';
+import { useStyles, useOnboardingCourse } from '../hooks';
 import {
   LoggedInRootParamList,
   LoggedInRootScreenProps,
@@ -9,6 +10,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { HeaderButton } from '../components/HeaderButton';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { createStyles } from '../components/BrandConfigProvider';
 
 type Props = LoggedInRootScreenProps<'screens/OnboardingCourseScreen'>;
 
@@ -23,7 +25,7 @@ export const DoneHeaderButton = () => {
 
   return (
     <HeaderButton
-      title="Done"
+      title={t('onboarding-course.done', 'Done')}
       onPress={() => {
         navigation.replace('app');
       }}
@@ -32,6 +34,7 @@ export const DoneHeaderButton = () => {
 };
 
 export const OnboardingCourseScreen = ({ navigation }: Props) => {
+  const { styles } = useStyles(defaultStyles);
   const { onboardingCourseUrl, onOnboardingCourseOpen, onboardingCourseTitle } =
     useOnboardingCourse();
 
@@ -62,9 +65,18 @@ export const OnboardingCourseScreen = ({ navigation }: Props) => {
   );
 };
 
-const styles = StyleSheet.create({
+const defaultStyles = createStyles('OnboardingCourseScreen', () => ({
   container: {
     flex: 1,
     margin: 0,
   },
-});
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}
+
+export type OnboardingCourseScreenStyles = NamedStylesProp<
+  typeof defaultStyles
+>;

--- a/src/screens/OnboardingCourseScreen.tsx
+++ b/src/screens/OnboardingCourseScreen.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import WebView from 'react-native-webview';
+import { useOnboardingCourse } from '../hooks/useOnboardingCourse';
+import {
+  LoggedInRootParamList,
+  LoggedInRootScreenProps,
+} from '../navigators/types';
+import { useNavigation } from '@react-navigation/native';
+import { HeaderButton } from '../components/HeaderButton';
+import { StackNavigationProp } from '@react-navigation/stack';
+
+type Props = LoggedInRootScreenProps<'screens/OnboardingCourseScreen'>;
+
+export const DoneHeaderButton = () => {
+  const navigation =
+    useNavigation<
+      StackNavigationProp<
+        LoggedInRootParamList,
+        'screens/OnboardingCourseScreen'
+      >
+    >();
+
+  return (
+    <HeaderButton
+      title="Done"
+      onPress={() => {
+        navigation.replace('app');
+      }}
+    />
+  );
+};
+
+export const OnboardingCourseScreen = ({ navigation }: Props) => {
+  const { onboardingCourseUrl, onOnboardingCourseOpen, onboardingCourseTitle } =
+    useOnboardingCourse();
+
+  useEffect(() => {
+    onOnboardingCourseOpen();
+  }, [onOnboardingCourseOpen]);
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: DoneHeaderButton,
+      title: onboardingCourseTitle || ' ',
+    });
+  }, [navigation, onboardingCourseTitle]);
+
+  if (!onboardingCourseUrl) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <WebView
+        source={{
+          uri: onboardingCourseUrl,
+        }}
+        testID="onboarding-course-web-view"
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    margin: 0,
+  },
+});

--- a/src/screens/TrackTileAdvancedEditorScreen.tsx
+++ b/src/screens/TrackTileAdvancedEditorScreen.tsx
@@ -34,7 +34,7 @@ export const SaveEditorButton = () => {
   const navigation = useNavigation();
   return (
     <HeaderButton
-      title="Save"
+      title={t('track-tile.save', 'Save')}
       onPress={async () => {
         navigation.goBack();
         await new Promise(notifySaveEditTrackerValue);

--- a/src/screens/TrackTileAdvancedEditorScreen.tsx
+++ b/src/screens/TrackTileAdvancedEditorScreen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { t } from '../../lib/i18n';
 import { AdvancedTrackerEditor } from '../components/TrackTile/TrackerDetails/AdvancedTrackerEditor/AdvancedTrackerEditor';
 import { HomeStackScreenProps } from '../navigators/types';
-import { HeaderSaveButton } from '../components/HeaderSaveButton';
+import { HeaderButton } from '../components/HeaderButton';
 import { useNavigation } from '@react-navigation/native';
 import { notifySaveEditTrackerValue } from '../components/TrackTile/services/EmitterService';
 
@@ -33,7 +33,8 @@ export const AdvancedTrackerEditorScreen = ({
 export const SaveEditorButton = () => {
   const navigation = useNavigation();
   return (
-    <HeaderSaveButton
+    <HeaderButton
+      title="Save"
       onPress={async () => {
         navigation.goBack();
         await new Promise(notifySaveEditTrackerValue);


### PR DESCRIPTION
This PR adds an onboarding course screen. This screen is rendered either after accepting the consent if it exists, or after accepting the invitation. When a course is launched, a key is saved in `AsyncStorage` so we don't launch it a second time.

https://github.com/lifeomic/react-native-sdk/assets/19395435/1dca127b-5b41-485b-8077-41456dbb8bfa

