### PR TITLE
fix: Fix My Data Query for Large Date Ranges

### DIFF
--- a/src/components/MyData/LineChart/useChartData.test.ts
+++ b/src/components/MyData/LineChart/useChartData.test.ts
@@ -58,7 +58,7 @@ describe('useChartData', () => {
       resourceType: 'Observation',
       coding: [{ code: 'code', system: 'system' }],
       dateRange: [new Date(0), new Date(0)],
-      pageSize: 10,
+      pageSize: 200,
     });
     expect(useSearchResourcesQuery).toHaveBeenNthCalledWith(
       2,
@@ -143,7 +143,7 @@ describe('useChartData', () => {
         resourceType: 'Observation',
         coding: [{ code: 'code2', system: 'system2' }],
         dateRange: [new Date(0), new Date(0)],
-        pageSize: 10,
+        pageSize: 200,
       }),
     );
 
@@ -177,27 +177,21 @@ describe('useChartData', () => {
     const trace1: Trace = {
       label: 'Label',
       type: 'Observation',
-      coding: [
-        { code: 'code', system: 'system' },
-        { code: 'code2', system: 'system' },
-      ],
+      coding: [{ code: 'code', system: 'system' }],
     };
 
     renderHook(() =>
       useChartData({
-        dateRange: [new Date(0), addDays(new Date(0), 16)],
+        dateRange: [new Date(0), addDays(new Date(0), 500)],
         trace1,
       }),
     );
 
     expect(useSearchResourcesQuery).toHaveBeenNthCalledWith(1, {
       resourceType: 'Observation',
-      coding: [
-        { code: 'code', system: 'system' },
-        { code: 'code2', system: 'system' },
-      ],
-      dateRange: [new Date(0), addDays(new Date(0), 16)],
-      pageSize: 32, // 16 days * 2 codes
+      coding: [{ code: 'code', system: 'system' }],
+      dateRange: [new Date(0), addDays(new Date(0), 500)],
+      pageSize: 500,
     });
   });
 });

--- a/src/components/MyData/LineChart/useChartData.ts
+++ b/src/components/MyData/LineChart/useChartData.ts
@@ -1,7 +1,7 @@
 import { sortBy } from 'lodash';
 import { useFhirClient } from '../../../hooks';
 import { Trace } from './TraceLine';
-import { startOfDay } from 'date-fns';
+import { startOfDay, differenceInDays } from 'date-fns';
 
 type Props = {
   trace1: Trace;
@@ -13,10 +13,13 @@ export const useChartData = (props: Props) => {
   const { trace1, trace2, dateRange } = props;
   const { useSearchResourcesQuery } = useFhirClient();
 
+  const days = Math.abs(differenceInDays(...dateRange));
+
   const trace1Res = useSearchResourcesQuery({
     resourceType: trace1.type,
     coding: trace1.coding,
     dateRange,
+    pageSize: Math.max(days * trace1.coding.length, 10),
   });
 
   const trace2Res = useSearchResourcesQuery({
@@ -24,6 +27,7 @@ export const useChartData = (props: Props) => {
     coding: trace2?.coding ?? [],
     dateRange,
     enabled: !!trace2,
+    pageSize: Math.max(days * (trace2?.coding?.length ?? 1), 10),
   });
 
   const trace1Data = sortBy(extractPointData(trace1Res, trace1), 'x');

--- a/src/components/MyData/LineChart/useChartData.ts
+++ b/src/components/MyData/LineChart/useChartData.ts
@@ -19,7 +19,7 @@ export const useChartData = (props: Props) => {
     resourceType: trace1.type,
     coding: trace1.coding,
     dateRange,
-    pageSize: Math.max(days * trace1.coding.length, 10),
+    pageSize: Math.max(200, days),
   });
 
   const trace2Res = useSearchResourcesQuery({
@@ -27,7 +27,7 @@ export const useChartData = (props: Props) => {
     coding: trace2?.coding ?? [],
     dateRange,
     enabled: !!trace2,
-    pageSize: Math.max(days * (trace2?.coding?.length ?? 1), 10),
+    pageSize: Math.max(200, days),
   });
 
   const trace1Data = sortBy(extractPointData(trace1Res, trace1), 'x');


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Default query uses 10 as the page size. This changes the query to query for more data based on days in the interval and the number of codes.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->