### PR TITLE
Fix: Make AdvancedTrackerDetails history chart default to same style as TrackerDetails

### DIFF
--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.test.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.test.tsx
@@ -8,7 +8,7 @@ import {
   TRACKER_CODE_SYSTEM,
   Tracker,
 } from '../../services/TrackTileService';
-import { add, addDays, endOfWeek, format, startOfWeek } from 'date-fns';
+import { add, addDays, format } from 'date-fns';
 import { useRecentCodedValues } from '../../hooks/useRecentCodedValues';
 import { notifier } from '../../services/EmitterService';
 
@@ -324,7 +324,7 @@ describe('Tracker Advanced Details', () => {
     );
 
     await findByText('Friday, March 17');
-    await findByText('Mar 13-Mar 19');
+    await findByText('Mar 11-Mar 17');
   });
 
   it('should NOT render from referenceDate in the future', async () => {
@@ -359,10 +359,7 @@ describe('Tracker Advanced Details', () => {
 
     await findByText("Today's Servings");
     await findByText(
-      `${format(startOfWeek(now, { weekStartsOn: 1 }), 'MMM d')}-${format(
-        endOfWeek(now, { weekStartsOn: 1 }),
-        'MMM d',
-      )}`,
+      `${format(add(now, { days: -6 }), 'MMM d')}-${format(now, 'MMM d')}`,
     );
   });
 

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerDetails/AdvancedTrackerDetails.tsx
@@ -418,17 +418,12 @@ export const AdvancedTrackerDetails = (props: AdvancedTrackerDetailsProps) => {
       </View>
       <View style={styles.chartContainer}>
         <TrackerHistoryChart
-          variant="flat"
-          stepperPosition="bottom"
-          color={tracker.color}
           metricId={metricId}
           target={targetAmount}
           unit={selectedUnit.display}
           tracker={tracker}
           valuesContext={valuesContext}
-          dateRangeType="calendarWeek"
           referenceDate={dateRange.start}
-          chartStyles={styles.chart}
         />
       </View>
     </ScrollView>
@@ -438,11 +433,6 @@ export const AdvancedTrackerDetails = (props: AdvancedTrackerDetailsProps) => {
 const defaultStyles = createStyles('AdvancedTrackerDetails', (theme) => ({
   container: {
     backgroundColor: theme.colors.elevation.level1,
-  },
-  chart: {
-    labelsContainer: {
-      flexBasis: 20,
-    },
   },
   dayPickerContainer: {
     alignItems: 'center',
@@ -487,7 +477,9 @@ const defaultStyles = createStyles('AdvancedTrackerDetails', (theme) => ({
     marginTop: 35,
   },
   chartContainer: {
-    marginTop: 10,
+    width: '100%',
+    paddingHorizontal: 8,
+    flex: 1,
   },
   recentHistoryContainer: {
     paddingHorizontal: 35,

--- a/src/components/TrackTile/hooks/test/useTrackerValues.test.ts
+++ b/src/components/TrackTile/hooks/test/useTrackerValues.test.ts
@@ -354,17 +354,17 @@ describe('useTrackerValues', () => {
       fetchOntology,
     } as any);
 
-    const valuesContext: TrackerValuesContext = {
+    const customValuesContext: TrackerValuesContext = {
       system: TRACKER_CODE_SYSTEM,
       codeBelow: TRACKER_CODE,
       shouldUseOntology: true,
     };
     const { result, waitFor } = renderHook(() =>
-      useTrackerValues(valuesContext),
+      useTrackerValues(customValuesContext),
     );
 
     await waitFor(() => {
-      expect(fetchTrackerValues).toHaveBeenCalledWith(valuesContext, {
+      expect(fetchTrackerValues).toHaveBeenCalledWith(customValuesContext, {
         start: startOfToday(),
         end: endOfToday(),
       });


### PR DESCRIPTION
Can anyone think of a reason not to default these to the same styling?  I think they just accidentally evolved/diverged over time.

## Screenshots
Before:
![Simulator Screen Shot - iPhone 14 Pro - 2023-08-04 at 14 16 22](https://github.com/lifeomic/react-native-sdk/assets/1445395/86f5fdf6-d4ba-4c94-8be8-228d5955d900)


![Simulator Screen Shot - iPhone 14 Pro - 2023-08-04 at 14 16 33](https://github.com/lifeomic/react-native-sdk/assets/1445395/62e86f25-8f13-4d4d-9f64-b71ba95c78c4)

After:
![Simulator Screen Shot - iPhone 14 Pro - 2023-08-04 at 14 41 58](https://github.com/lifeomic/react-native-sdk/assets/1445395/c62ef3e7-342a-45c0-ba76-900a0618f6a1)

