### PR TITLE
feat: Configure LogoHeader per-screen at DeveloperConfig

### DIFF
--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -15,6 +15,7 @@ import { t } from 'i18next';
 import { Home, Bell, Settings, Menu } from '@lifeomic/chromicons-native';
 import { HelloWorldScreen } from '../../../src/screens/HelloWorldScreen';
 import { IconButton } from 'react-native-paper';
+import { navigationRef } from '../../../../src/common/ThemedNavigationContainer';
 
 storiesOf('Example App', module)
   .addDecorator(withKnobs)
@@ -147,7 +148,15 @@ storiesOf('Example App', module)
     const alignItemValue = number('Align Item', 85, options);
 
     const visibleValue = boolean('Visible', true);
-    const iconButton = <IconButton icon={Bell} />;
+    const iconButton = (
+      <IconButton
+        icon={Settings}
+        onPress={() => {
+          navigationRef.navigate('app', { screen: 'SettingsTab' });
+        }}
+      />
+    );
+
     const brand = {
       styles: {
         AppNavHeader: {

--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react-native';
-import { authConfig } from '../../helpers/oauthConfig';
+import { authConfig, baseURL } from '../../helpers/oauthConfig';
 import {
   DeveloperConfigProvider,
   RootProviders,
@@ -8,12 +8,13 @@ import {
   LogoHeader,
   BrandConfigProvider,
 } from '../../../../src';
-import { withKnobs, color, boolean } from '@storybook/addon-knobs';
+import { withKnobs, color, boolean, number } from '@storybook/addon-knobs';
 import Color from 'color';
 import logo from './header-logo.png';
 import { t } from 'i18next';
 import { Home, Bell, Settings, Menu } from '@lifeomic/chromicons-native';
 import { HelloWorldScreen } from '../../../src/screens/HelloWorldScreen';
+import { IconButton } from 'react-native-paper';
 
 storiesOf('Example App', module)
   .addDecorator(withKnobs)
@@ -27,6 +28,7 @@ storiesOf('Example App', module)
           simpleTheme: {
             primaryColor,
           },
+          apiBaseURL: baseURL,
         }}
       >
         <RootProviders authConfig={authConfig}>
@@ -55,6 +57,7 @@ storiesOf('Example App', module)
               },
             },
           ],
+          apiBaseURL: baseURL,
         }}
       >
         <RootProviders authConfig={authConfig}>
@@ -119,6 +122,7 @@ storiesOf('Example App', module)
               ],
             },
           },
+          apiBaseURL: baseURL,
         }}
       >
         <RootProviders authConfig={authConfig}>
@@ -128,6 +132,22 @@ storiesOf('Example App', module)
     );
   })
   .add('Customized AppNavHeader with LogoHeader', () => {
+    const options = {
+      range: true,
+      min: 0,
+      max: 100,
+      step: 1,
+    };
+
+    const alignImageValue = number(
+      'Align Image (Re-navigate to screen to take effect)',
+      30,
+      options,
+    );
+    const alignItemValue = number('Align Item', 85, options);
+
+    const visibleValue = boolean('Visible', true);
+    const iconButton = <IconButton icon={Bell} />;
     const brand = {
       styles: {
         AppNavHeader: {
@@ -183,6 +203,15 @@ storiesOf('Example App', module)
             ],
             statusBarHeight: 0,
           },
+          logoHeaderConfig: {
+            Home: {
+              alignImage: `${alignImageValue}%`,
+              visible: visibleValue,
+              item: iconButton,
+              alignItem: `${alignItemValue}%`,
+            },
+          },
+          apiBaseURL: baseURL,
         }}
       >
         <RootProviders authConfig={authConfig}>

--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -14,6 +14,8 @@ import {
 } from '@react-navigation/native-stack';
 import { NativeStackNavigatorProps } from '@react-navigation/native-stack/lib/typescript/src/types';
 import { PointBreakdownProps } from '../components/SocialShare/renderers/point-breakdown';
+import { Route } from '../navigators/types';
+import { LogoHeaderOptions } from '../hooks/useLogoHeaderOptions';
 
 /**
  * DeveloperConfig provides a single interface to configure the app at build-time.
@@ -86,7 +88,10 @@ export type DeveloperConfig = {
   sharingRenderers?: {
     pointBreakdown: (props: PointBreakdownProps) => React.JSX.Element;
   };
+  logoHeaderConfig?: LogoHeaderConfig;
 };
+
+export type LogoHeaderConfig = { [key in Route]?: LogoHeaderOptions };
 
 export type AppTileScreens = {
   [key: string]: ComponentType;

--- a/src/common/ThemedNavigationContainer.tsx
+++ b/src/common/ThemedNavigationContainer.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 
 import { NavigationContainer, Theme } from '@react-navigation/native';
 import { useTheme } from 'react-native-paper';
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+export const navigationRef = createNavigationContainerRef();
 
 interface Props {
   children?: React.ReactNode;
@@ -10,5 +13,9 @@ interface Props {
 export function ThemedNavigationContainer({ children }: Props) {
   const theme = useTheme<Theme>();
 
-  return <NavigationContainer theme={theme}>{children}</NavigationContainer>;
+  return (
+    <NavigationContainer theme={theme} ref={navigationRef}>
+      {children}
+    </NavigationContainer>
+  );
 }

--- a/src/common/ThemedNavigationContainer.tsx
+++ b/src/common/ThemedNavigationContainer.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
-import { NavigationContainer, Theme } from '@react-navigation/native';
+import {
+  createNavigationContainerRef,
+  NavigationContainer,
+  Theme,
+} from '@react-navigation/native';
 import { useTheme } from 'react-native-paper';
-import { createNavigationContainerRef } from '@react-navigation/native';
 
 export const navigationRef = createNavigationContainerRef();
 

--- a/src/components/Circles/__tests__/Post.test.tsx
+++ b/src/components/Circles/__tests__/Post.test.tsx
@@ -6,6 +6,7 @@ import {
 import { PostItem } from '../PostItem';
 import { Post as PostType, Priority } from '../../../hooks';
 
+jest.unmock('@react-navigation/native');
 jest.mock('../ReactionsToolbar');
 
 const post: PostType = {

--- a/src/components/Circles/__tests__/PostList.test.tsx
+++ b/src/components/Circles/__tests__/PostList.test.tsx
@@ -8,6 +8,7 @@ import { CircleTile } from '../../../hooks/useAppConfig';
 import { useInfinitePosts, useCreatePost } from '../../../hooks';
 import { CreateEditPostModal } from '../CreateEditPostModal';
 
+jest.unmock('@react-navigation/native');
 jest.mock('../../../hooks/Circles/useInfinitePosts');
 jest.mock('../../../hooks/Circles/useCreatePost');
 jest.mock('../ReactionsToolbar');

--- a/src/components/Circles/__tests__/ReactionsToolbar.test.tsx
+++ b/src/components/Circles/__tests__/ReactionsToolbar.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../hooks';
 import { useUser } from '../../../hooks/useUser';
 
+jest.unmock('@react-navigation/native');
 jest.useFakeTimers();
 jest.mock('../../../hooks/Circles/useReactionMutations', () => ({
   useCreateReactionMutation: jest.fn(),

--- a/src/components/Circles/__tests__/Thread.test.tsx
+++ b/src/components/Circles/__tests__/Thread.test.tsx
@@ -8,6 +8,7 @@ import { Thread } from '../Thread';
 import { usePost, Post, useLoadReplies } from '../../../hooks';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
+jest.unmock('@react-navigation/native');
 jest.mock('../../../hooks/Circles/usePost');
 jest.mock('../../../hooks/Circles/useLoadReplies');
 jest.mock('../ReactionsToolbar');

--- a/src/components/Circles/__tests__/ThreadComment.test.tsx
+++ b/src/components/Circles/__tests__/ThreadComment.test.tsx
@@ -6,6 +6,7 @@ import {
 import { ThreadComment } from '../ThreadComment';
 import { Post } from '../../../hooks';
 
+jest.unmock('@react-navigation/native');
 jest.mock('date-fns', () => ({
   ...jest.requireActual('date-fns'),
   formatDistanceToNow: jest.fn(() => '5 minutes'),

--- a/src/components/LogoHeader.tsx
+++ b/src/components/LogoHeader.tsx
@@ -1,82 +1,20 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react';
-import {
-  View,
-  Image,
-  Platform,
-  ImageSourcePropType,
-  NativeEventEmitter,
-} from 'react-native';
+import React, { useState } from 'react';
+import { View, Image, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { createStyles } from './BrandConfigProvider';
 import { useStyles } from '../hooks/useStyles';
-import { useFocusEffect } from '@react-navigation/native';
-import { useNavigation } from '@react-navigation/native';
-
-type Percentage = `${number}%`;
-type LogoHeaderOptions = {
-  visible?: boolean;
-  imageSource?: ImageSourcePropType;
-  item?: JSX.Element;
-  alignImage?: Percentage;
-  alignItem?: Percentage;
-};
-
-const eventEmitter = new NativeEventEmitter({
-  addListener: () => {},
-  removeListeners: () => {},
-});
-
-const updateLogoOptionsEvent = 'updateLogoOptions';
-const restoreLogoOptionsEvent = 'restoreLogoOptions';
-
-export const emitOptionsChanged = (options: LogoHeaderOptions) =>
-  eventEmitter.emit(updateLogoOptionsEvent, options);
-
-/**
- * @param newOptions
- * @returns void
- * When the current screen comes into focus emit new header options
- * and restores defaults when a blurScreen event is emitted
- */
-export const useEmitLogoHeaderOptions = (newOptions: LogoHeaderOptions) => {
-  const navigation = useNavigation();
-  useFocusEffect(() => {
-    emitOptionsChanged(newOptions);
-  });
-  useEffect(() => {
-    const unsubscribe = navigation.addListener('blur', () => {
-      eventEmitter.emit(restoreLogoOptionsEvent);
-    });
-
-    return unsubscribe;
-  }, [navigation]);
-};
+import {
+  LogoHeaderOptions,
+  useHandleOptionEvents,
+} from '../hooks/useLogoHeaderOptions';
 
 export function LogoHeader(defaultOptions: LogoHeaderOptions) {
   const { styles } = useStyles(defaultStyles);
   const androidFix = Platform.OS === 'android' ? { marginTop: 12 } : {};
   const [options, setOptions] = useState<LogoHeaderOptions>(defaultOptions);
 
-  useLayoutEffect(() => {
-    const subscription = eventEmitter.addListener(
-      updateLogoOptionsEvent,
-      (newOptions) => setOptions({ ...defaultOptions, ...newOptions }),
-    );
-
-    return () => {
-      subscription.remove();
-    };
-  }, [defaultOptions]);
-
-  useLayoutEffect(() => {
-    const subscription = eventEmitter.addListener(restoreLogoOptionsEvent, () =>
-      setOptions(defaultOptions),
-    );
-
-    return () => {
-      subscription.remove();
-    };
-  }, [defaultOptions]);
+  // Subscribe to events to receive option updates
+  useHandleOptionEvents(setOptions, defaultOptions);
 
   if (!options || !options?.visible) {
     return null;

--- a/src/components/MyData/LineChart/index.test.tsx
+++ b/src/components/MyData/LineChart/index.test.tsx
@@ -5,6 +5,7 @@ import { LineChart } from './index';
 import { useChartData } from './useChartData';
 import { addDays, startOfDay, format } from 'date-fns';
 
+jest.unmock('@react-navigation/native');
 jest.mock('./useChartData', () => ({
   useChartData: jest.fn(),
 }));

--- a/src/components/tiles/TilesList.test.tsx
+++ b/src/components/tiles/TilesList.test.tsx
@@ -7,7 +7,10 @@ import { useAppConfig } from '../../hooks/useAppConfig';
 import { useIcons } from '../BrandConfigProvider';
 
 jest.unmock('i18next');
-
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: jest.fn(),
+}));
 jest.mock('../TrackTile', () => ({
   TrackTile: ({ title }: { title: string }) => <Text>{title}</Text>,
 }));

--- a/src/hooks/useLogoHeaderOptions.tsx
+++ b/src/hooks/useLogoHeaderOptions.tsx
@@ -59,7 +59,6 @@ export const navigationScreenListeners = (
   focus: (e: any) => {
     // Coerce unique route event target to route name
     const routeName = e.target?.split('-')?.[0] as Route | undefined;
-    console.log('Found routeName', routeName);
     if (typeof routeName === 'undefined') {
       return;
     }

--- a/src/hooks/useLogoHeaderOptions.tsx
+++ b/src/hooks/useLogoHeaderOptions.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useLayoutEffect } from 'react';
+import { ImageSourcePropType, NativeEventEmitter } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
+import get from 'lodash/get';
+import { Route } from '../navigators/types';
+import { LogoHeaderConfig } from '../common/DeveloperConfig';
+
+const eventEmitter = new NativeEventEmitter({
+  addListener: () => {},
+  removeListeners: () => {},
+});
+
+const updateLogoOptionsEvent = 'updateLogoOptions';
+const restoreLogoOptionsEvent = 'restoreLogoOptions';
+
+export const emitOptionsChanged = (options: LogoHeaderOptions) =>
+  eventEmitter.emit(updateLogoOptionsEvent, options);
+
+export const emitRestoreDefaults = () =>
+  eventEmitter.emit(restoreLogoOptionsEvent);
+
+export const useHandleOptionEvents = (
+  setOptions: (args: LogoHeaderOptions) => void,
+  defaultOptions: LogoHeaderOptions,
+) => {
+  useLayoutEffect(() => {
+    const subscription = eventEmitter.addListener(
+      updateLogoOptionsEvent,
+      (newOptions) => setOptions({ ...defaultOptions, ...newOptions }),
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [defaultOptions, setOptions]);
+
+  useLayoutEffect(() => {
+    const subscription = eventEmitter.addListener(restoreLogoOptionsEvent, () =>
+      setOptions(defaultOptions),
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [defaultOptions, setOptions]);
+};
+
+/**
+ * Listens to react-navigation events and in turn emits LogoHeader events
+ * to set the header options per screen at the developerConfig level.
+ *
+ * Pass into screenListeners prop for a <Stack.Navigator/>
+ */
+
+export const navigationScreenListeners = (
+  headerOptions?: LogoHeaderConfig,
+) => ({
+  focus: (e: any) => {
+    // Coerce unique route event target to route name
+    const routeName = e.target?.split('-')?.[0] as Route | undefined;
+    console.log('Found routeName', routeName);
+    if (typeof routeName === 'undefined') {
+      return;
+    }
+    const options = get(headerOptions, routeName);
+    if (options) {
+      emitOptionsChanged(options);
+    }
+  },
+  blur: () => {
+    // Make this a no-op if per screen
+    // settings have not been specified
+    if (headerOptions) {
+      emitRestoreDefaults();
+    }
+  },
+});
+
+/**
+ * Setup LogoHeader emitters on a single screen to pass in custom options.
+ * Most the time a combination of navigationScreenListeners and developConfig
+ * should be sufficient but this is probably useful in advanced cases where the
+ * developerConfig does not have enough context.
+ */
+export const useEmitLogoHeaderOptions = (newOptions: LogoHeaderOptions) => {
+  const navigation = useNavigation();
+  useFocusEffect(() => {
+    emitOptionsChanged(newOptions);
+  });
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('blur', () => {
+      eventEmitter.emit(restoreLogoOptionsEvent);
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+};
+
+export type LogoHeaderOptions = {
+  visible?: boolean;
+  imageSource?: ImageSourcePropType;
+  item?: JSX.Element;
+  alignImage?: `${number}%`;
+  alignItem?: `${number}%`;
+};

--- a/src/hooks/useWearableBackfill.test.tsx
+++ b/src/hooks/useWearableBackfill.test.tsx
@@ -9,6 +9,7 @@ import { useHttpClient } from './useHttpClient';
 import { WearablesSyncState } from '../components';
 import { useFeature } from './useFeature';
 
+jest.unmock('@react-navigation/native');
 jest.mock('./useActiveAccount', () => ({
   useActiveAccount: jest.fn(() => ({ isFetched: true, accountHeaders: {} })),
 }));

--- a/src/navigators/HomeStack.tsx
+++ b/src/navigators/HomeStack.tsx
@@ -15,14 +15,18 @@ import { CircleDiscussionScreen } from '../screens/CircleDiscussionScreen';
 import { useDeveloperConfig } from '../hooks';
 import { MyDataScreen } from '../screens/MyDataScreen';
 import { YoutubePlayerScreen } from '../screens/YoutubePlayerScreen';
+import { navigationScreenListeners } from '../hooks/useLogoHeaderOptions';
 
 const Stack = createNativeStackNavigator<HomeStackParamList>();
 
 export function HomeStack() {
-  const { getAdditionalHomeScreens } = useDeveloperConfig();
+  const { getAdditionalHomeScreens, logoHeaderConfig } = useDeveloperConfig();
 
   return (
-    <Stack.Navigator screenOptions={{ header: AppNavHeader }}>
+    <Stack.Navigator
+      screenOptions={{ header: AppNavHeader }}
+      screenListeners={navigationScreenListeners(logoHeaderConfig)}
+    >
       <Stack.Screen name="Home" component={HomeScreen} />
       <Stack.Screen name="Home/AppTile" component={AppTileScreen} />
       <Stack.Screen name="Home/AuthedAppTile" component={AuthedAppTileScreen} />

--- a/src/navigators/NotificationsStack.tsx
+++ b/src/navigators/NotificationsStack.tsx
@@ -3,12 +3,18 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { AppNavHeader } from '../components/AppNavHeader';
 import { NotificationsScreen } from '../screens/NotificationsScreen';
 import { NotificationsStackParamList } from './types';
+import { navigationScreenListeners } from '../hooks/useLogoHeaderOptions';
+import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
 
 const Stack = createNativeStackNavigator<NotificationsStackParamList>();
 
 export function NotificationsStack() {
+  const { logoHeaderConfig } = useDeveloperConfig();
   return (
-    <Stack.Navigator screenOptions={{ header: AppNavHeader }}>
+    <Stack.Navigator
+      screenOptions={{ header: AppNavHeader }}
+      screenListeners={navigationScreenListeners(logoHeaderConfig)}
+    >
       <Stack.Screen name="Notifications" component={NotificationsScreen} />
     </Stack.Navigator>
   );

--- a/src/navigators/SettingsStack.tsx
+++ b/src/navigators/SettingsStack.tsx
@@ -7,12 +7,18 @@ import { AccountSelectionScreen } from '../screens/AccountSelectionScreen';
 import { AppNavHeader } from '../components/AppNavHeader';
 import WearablesScreen from '../screens/WearablesScreen';
 import { SettingsStackParamList } from './types';
+import { navigationScreenListeners } from '../hooks/useLogoHeaderOptions';
+import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
 
 const Stack = createNativeStackNavigator<SettingsStackParamList>();
 
 export function SettingsStack() {
+  const { logoHeaderConfig } = useDeveloperConfig();
   return (
-    <Stack.Navigator screenOptions={{ header: AppNavHeader }}>
+    <Stack.Navigator
+      screenOptions={{ header: AppNavHeader }}
+      screenListeners={navigationScreenListeners(logoHeaderConfig)}
+    >
       <Stack.Screen name="Settings" component={SettingsScreen} />
       <Stack.Screen
         name="Settings/Profile"

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -98,6 +98,12 @@ export type SettingsStackParamList = {
   'Settings/Wearables': undefined;
 };
 
+export type Route =
+  | keyof LoggedInRootParamList
+  | keyof SettingsStackParamList
+  | keyof NotificationsStackParamList
+  | keyof HomeStackParamList;
+
 declare global {
   namespace ReactNavigation {
     interface RootParamList extends RootStackParamList {}

--- a/src/screens/AccountSelectionScreen.test.tsx
+++ b/src/screens/AccountSelectionScreen.test.tsx
@@ -11,15 +11,16 @@ jest.mock('../hooks/useActiveAccount', () => ({
 const useActiveAccountMock = useActiveAccount as jest.Mock;
 
 const setActiveAccountId = jest.fn();
-const useNavigationMock = useNavigation as jest.Mock;
 const goBackMock = jest.fn();
-
-beforeEach(() => {
-  useNavigationMock.mockReturnValue({
-    canGoBack: () => true,
-    goBack: goBackMock,
-  });
+const useNavigationMock = jest.fn().mockReturnValue({
+  canGoBack: () => true,
+  goBack: goBackMock,
 });
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => useNavigationMock(),
+}));
 
 test('renders buttons to select account', async () => {
   useActiveAccountMock.mockReturnValue({

--- a/src/screens/ConsentScreen.test.tsx
+++ b/src/screens/ConsentScreen.test.tsx
@@ -5,7 +5,7 @@ import { useOAuthFlow, useConsent, useOnboardingCourse } from '../hooks';
 import { ConsentScreen } from './ConsentScreen';
 
 jest.unmock('i18next');
-
+jest.unmock('@react-navigation/native');
 jest.mock('../hooks/useOAuthFlow', () => ({
   useOAuthFlow: jest.fn(),
 }));

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
 
 jest.unmock('i18next');
-
+jest.unmock('@react-navigation/native');
 jest.mock('../hooks/useActiveAccount', () => ({
   useActiveAccount: jest.fn(),
 }));

--- a/src/screens/InviteRequiredScreen.test.tsx
+++ b/src/screens/InviteRequiredScreen.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react-native';
 import { InviteRequiredScreen } from './InviteRequiredScreen';
 
 const inviteRequiredScreen = <InviteRequiredScreen />;
+jest.unmock('@react-navigation/native');
 
 it('renders invite required text and logout button', () => {
   const { getByTestId } = render(inviteRequiredScreen);

--- a/src/screens/MyDataScreen.test.tsx
+++ b/src/screens/MyDataScreen.test.tsx
@@ -15,6 +15,7 @@ import { MyDataScreen } from './MyDataScreen';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
 
+jest.unmock('@react-navigation/native');
 jest.unmock('i18next');
 
 jest.mock('../hooks/useAppConfig', () => ({

--- a/src/screens/NotificationsScreen.test.tsx
+++ b/src/screens/NotificationsScreen.test.tsx
@@ -7,6 +7,7 @@ import { NotificationsScreen } from './NotificationsScreen';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
 
+jest.unmock('@react-navigation/native');
 jest.mock('../hooks/useActiveAccount', () => ({
   useActiveAccount: jest.fn(),
 }));


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds stack navigation listeners to sync LogoHeader with options specified in DeveloperConfig

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

https://github.com/lifeomic/react-native-sdk/assets/76954025/f006f11d-d934-4ac1-9319-bb9b0d7046e1

https://github.com/lifeomic/react-native-sdk/assets/76954025/364cad91-6697-4819-a57c-6a5c6f1fca28

