### PR TITLE
Support substituting an authorize implementation in

### DIFF
--- a/src/common/SecureStore.ts
+++ b/src/common/SecureStore.ts
@@ -36,6 +36,7 @@ export class SecureStore<Stored> {
    * @param object
    */
   async setObject(object: Stored) {
+    console.log('Expo app Throws'); // [TypeError: Cannot read property 'resetGenericPasswordForOptions' of null]
     return Keychain.setGenericPassword(
       unusedUsername,
       JSON.stringify(object),


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
Getting a rough poc working before PTO for allowing a consumer to replace the `authorize` `react-native-app-auth` implementation. We plan to continue to support that implementation as the default 

This gets us up to the point where we attempt to securely store the tokens, where we will need another place to tie in and allow for changing that implementation

Things to do:

- We can definitely re-consider names of types/variables 
- Define a more robust `ProvidedAuthorizeResult`, maybe something like https://lifeomic.slack.com/archives/C05KMKQNTAR/p1692289334198989?thread_ts=1692288197.696699&cid=C05KMKQNTAR
- We likely also need to sub in implementations for `revoke` and `refresh` and create the interfaces that a consumer can conform to

Tested with https://github.com/lifeomic/fountain-life-member-app/pull/36 after running

```
yarn copyToProject fountain-life-member-app    
```

## Screenshots

https://github.com/lifeomic/react-native-sdk/assets/19804196/fa30f10a-e286-4239-a6c3-ef433955882a