### PR TITLE
fix: Set User's Real Name on Launch if Missing

### DIFF
--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -16,6 +16,7 @@ const selectedProjectIdKey = 'selectedProjectIdKey';
 export type ActiveProjectProps = {
   activeProject?: Project;
   activeSubjectId?: string;
+  activeSubject?: Subject;
 };
 
 export type ActiveProjectContextProps = ActiveProjectProps & {
@@ -101,6 +102,7 @@ export const ActiveProjectContextProvider = ({
       return {
         activeProject: selectedProject,
         activeSubjectId: selectedSubject.subjectId,
+        activeSubject: selectedSubject,
       };
     }
 

--- a/src/hooks/useMe.ts
+++ b/src/hooks/useMe.ts
@@ -1,24 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
+import { Patient } from 'fhir/r3';
 
 export interface Subject {
   subjectId: string;
   projectId: string;
+  name: Patient['name'];
 }
 
 interface Entry {
-  resource: {
-    id: string;
-    meta: {
-      tag: [
-        {
-          system: string;
-          code: string;
-        },
-      ];
-    };
-  };
+  resource: Patient;
 }
 
 interface MeResponse {
@@ -40,9 +32,10 @@ export function useMe() {
             (entry) =>
               ({
                 subjectId: entry.resource.id,
-                projectId: entry.resource.meta.tag.find(
+                projectId: entry.resource.meta?.tag?.find(
                   (t) => t.system === 'http://lifeomic.com/fhir/dataset',
                 )?.code,
+                name: entry.resource.name,
               } as Subject),
           ),
         ),

--- a/src/hooks/useSetUserProfileEffect.test.ts
+++ b/src/hooks/useSetUserProfileEffect.test.ts
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react-native';
+import { useUser } from './useUser';
+import { useActiveProject } from './useActiveProject';
+import { useSetUserProfileEffect } from './useSetUserProfileEffect';
+
+jest.mock('./useActiveProject', () => ({
+  useActiveProject: jest.fn(),
+}));
+jest.mock('./useUser', () => ({
+  useUser: jest.fn(),
+}));
+
+const useUserMock = useUser as jest.Mock;
+const useActiveProjectMock = useActiveProject as jest.Mock;
+const updateUser = jest.fn();
+
+beforeEach(() => {
+  updateUser.mockReset();
+  useUserMock.mockReturnValue({
+    isLoading: true,
+    updateUser,
+  });
+  useActiveProjectMock.mockReturnValue({});
+});
+
+test('should update the user once all hooks load and the user does not have data', () => {
+  const result = renderHook(() => useSetUserProfileEffect());
+
+  expect(updateUser).not.toHaveBeenCalled();
+
+  useUserMock.mockReturnValue({
+    isLoading: false,
+    isFetched: true,
+    data: { profile: {} },
+    updateUser,
+  });
+
+  result.rerender({});
+
+  expect(updateUser).not.toHaveBeenCalled();
+
+  useActiveProjectMock.mockReturnValue({
+    activeSubject: {
+      name: [
+        {
+          family: 'LastName',
+          given: ['FirstName'],
+        },
+      ],
+    },
+  });
+
+  result.rerender({});
+
+  expect(updateUser).toHaveBeenCalledWith({
+    profile: {
+      givenName: 'FirstName',
+      familyName: 'LastName',
+    },
+  });
+});
+
+test('should use the first official name', () => {
+  useUserMock.mockReturnValue({
+    isLoading: false,
+    isFetched: true,
+    data: { profile: {} },
+    updateUser,
+  });
+  useActiveProjectMock.mockReturnValue({
+    activeSubject: {
+      name: [
+        {
+          use: 'nickname',
+          family: 'nickname-LastName',
+          given: ['nickname-FirstName'],
+        },
+        {
+          use: 'official',
+          family: 'LastName',
+          given: ['FirstName'],
+        },
+      ],
+    },
+  });
+
+  renderHook(() => useSetUserProfileEffect());
+
+  expect(updateUser).toHaveBeenCalledWith({
+    profile: {
+      givenName: 'FirstName',
+      familyName: 'LastName',
+    },
+  });
+});
+
+test('not set the username if it is already set', () => {
+  useUserMock.mockReturnValue({
+    isLoading: false,
+    isFetched: true,
+    data: {
+      profile: {
+        familyName: 'AlreadySet',
+      },
+    },
+    updateUser,
+  });
+  useActiveProjectMock.mockReturnValue({
+    activeSubject: {
+      name: [
+        {
+          family: 'LastName',
+          given: ['FirstName'],
+        },
+      ],
+    },
+  });
+
+  renderHook(() => useSetUserProfileEffect());
+
+  expect(updateUser).not.toHaveBeenCalled();
+});

--- a/src/hooks/useSetUserProfileEffect.ts
+++ b/src/hooks/useSetUserProfileEffect.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useActiveProject } from './useActiveProject';
+import { useUser } from './useUser';
+
+export const useSetUserProfileEffect = () => {
+  const { isLoading, isFetched, data: user, updateUser } = useUser();
+  const { activeSubject } = useActiveProject();
+
+  useEffect(() => {
+    const hasFetchedUser = !isLoading && isFetched;
+    const userHasName = !!user?.profile.givenName || !!user?.profile.familyName;
+    const name =
+      activeSubject?.name?.find((v) => v.use === 'official') ??
+      activeSubject?.name?.[0];
+    const subjectHasName = !!name?.family || !!name?.given?.length;
+
+    if (hasFetchedUser && !userHasName && subjectHasName) {
+      updateUser({
+        profile: {
+          givenName: name.given?.[0],
+          familyName: name.family,
+        },
+      });
+    }
+  }, [isLoading, isFetched, user, activeSubject, updateUser]);
+};

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,27 +1,30 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useHttpClient } from './useHttpClient';
 import { useAuth } from './useAuth';
-
-export interface User {
-  id: string;
-  profile: {
-    email: string;
-    displayName?: string;
-    givenName?: string;
-    familyName?: string;
-    picture?: string;
-  };
-}
+import { useRestMutation } from './rest-api';
+import { User } from '../types';
 
 export function useUser() {
   const { authResult } = useAuth();
+  const client = useQueryClient();
   const { httpClient } = useHttpClient();
 
-  return useQuery(
+  const result = useQuery(
     ['user'],
     () => httpClient.get<User>('/v1/user').then((res) => res.data),
     {
       enabled: !!authResult?.accessToken,
     },
   );
+
+  const { mutateAsync: updateUser } = useRestMutation('PATCH /v1/user', {
+    onSuccess: (updatedUser) => {
+      client.setQueryData(['user'], () => updatedUser);
+    },
+  });
+
+  return {
+    ...result,
+    updateUser,
+  };
 }

--- a/src/navigators/RootStack.tsx
+++ b/src/navigators/RootStack.tsx
@@ -18,6 +18,7 @@ import { ConsentScreen } from '../screens/ConsentScreen';
 import { CircleThreadScreen } from '../screens/CircleThreadScreen';
 import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
 import { OnboardingCourseScreen } from '../screens/OnboardingCourseScreen';
+import { useSetUserProfileEffect } from '../hooks/useSetUserProfileEffect';
 
 export function RootStack() {
   const { isLoggedIn, loading: loadingAuth } = useAuth();
@@ -41,6 +42,8 @@ export function RootStack() {
     isLoading: onboardingCourseIsLoading,
     isFetched: onboardingCourseIsFetched,
   } = useOnboardingCourse();
+
+  useSetUserProfileEffect();
 
   const loadingProject = !isFetchedProject || isLoadingProject;
   const loadingAccount = !isFetchedAccount || isLoadingAccount;

--- a/src/screens/ProfileScreen.test.tsx
+++ b/src/screens/ProfileScreen.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { ProfileScreen } from './ProfileScreen';
-import { useUser, User } from '../hooks/useUser';
+import { useUser } from '../hooks/useUser';
+import { User } from '../types';
 
 jest.mock('../hooks/useUser', () => ({
   useUser: jest.fn(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,14 @@ export interface ProjectInvite {
   expirationTimestamp: string;
   purpose?: string;
 }
+
+export interface User {
+  id: string;
+  profile: {
+    email: string;
+    displayName?: string;
+    givenName?: string;
+    familyName?: string;
+    picture?: string;
+  };
+}

--- a/src/types/rest-types.ts
+++ b/src/types/rest-types.ts
@@ -1,4 +1,4 @@
-import { ProjectInvite } from '../types';
+import { ProjectInvite, User } from '../types';
 
 export interface Account {
   id: string;
@@ -28,5 +28,10 @@ export type RestAPIEndpoints = {
   'PATCH /v1/invitations/:inviteId': {
     Request: { status: 'ACCEPTED' };
     Response: ProjectInvite;
+  };
+
+  'PATCH /v1/user': {
+    Request: { profile: Omit<User['profile'], 'picture' | 'email'> };
+    Response: User;
   };
 };


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds a call for updating a user's profile info
  - Adds an effect hook to set the user's last/first name based on the patient if it has a name already