### PR TITLE
Fix state change on every render

### DIFF
--- a/src/hooks/useUnreadMessages.test.tsx
+++ b/src/hooks/useUnreadMessages.test.tsx
@@ -36,16 +36,21 @@ describe('NotificationsManager', () => {
       privatePostsUserIds: ['some_user'],
     });
 
+    const setUnreadStoredUserIds = jest.fn();
+
     useAsyncStorageMock.mockReturnValue([
       {
         data: JSON.stringify([]),
         isFetchedAfterMount: true,
       },
-      jest.fn(),
+      setUnreadStoredUserIds,
     ]);
 
-    const { result } = await renderHookInContext();
-    expect(result.current.unreadMessagesUserIds).toEqual(['some_user']);
+    await renderHookInContext();
+
+    expect(setUnreadStoredUserIds).toBeCalledWith(
+      JSON.stringify(['some_user']),
+    );
   });
 
   it('fetches prior sessions unreadIds from storage', async () => {


### PR DESCRIPTION
I created a secondary local hook that just deals with `useAsyncStorage` to simplify the logic.  This will allow `useUnreadMessages` to grow with whatever else we will need for new message notification.

Since our AsyncStorage wrapper uses React Query for memory caching, I also removed the `useState` hook which is what was causing it to change on every render.