### PR TITLE
chore: useUnreadMessages tracks read receipts

### DIFF
--- a/src/components/MessagesTile/MessagesTile.tsx
+++ b/src/components/MessagesTile/MessagesTile.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Tile } from '../tiles/Tile';
 import { HomeStackScreenProps } from '../../navigators';
 import { useIcons } from '../BrandConfigProvider';
 import { tID } from '../TrackTile/common/testID';
 import { useUnreadMessages } from '../../hooks/useUnreadMessages';
-import { useFocusEffect } from '@react-navigation/native';
-import { useNotificationManager } from '../../hooks/useNotificationManager';
 
 interface Props extends Pick<HomeStackScreenProps<'Home'>, 'navigation'> {
   id: string;
@@ -21,16 +19,6 @@ export function MessagesTile({
 }: Props) {
   const { MessageCircle } = useIcons();
   const { unreadMessagesUserIds } = useUnreadMessages();
-  const { setNotificationsRead } = useNotificationManager();
-
-  // TODO: This works for tracking new unread messages now but a refactor
-  // to track the privatePosts separately from general notifications will
-  // be required once the notifications tab is setup to show a badge
-  useFocusEffect(
-    useCallback(() => {
-      return () => setNotificationsRead();
-    }, [setNotificationsRead]),
-  );
 
   return (
     <Tile

--- a/src/hooks/useNotificationManager.tsx
+++ b/src/hooks/useNotificationManager.tsx
@@ -7,10 +7,9 @@ import React, {
   useState,
 } from 'react';
 import { AppState, AppStateStatus, Platform } from 'react-native';
-import { useNotifications, FeedNotification } from './useNotifications';
+import { useNotifications } from './useNotifications';
 import { useAsyncStorage } from './useAsyncStorage';
 import { onNotificationReceived } from '../common/Notifications';
-import { compact } from 'lodash';
 
 export interface NotificationsManagerContextType {
   unreadCount: number | undefined;
@@ -21,13 +20,11 @@ export interface NotificationsManagerContextType {
    * Date - async storage has loaded and key was set
    */
   lastReadAt: Date | null | undefined;
-  privatePostsUserIds: string[] | undefined;
 }
 
 export const NotificationsManagerContext =
   createContext<NotificationsManagerContextType>({
     unreadCount: 0,
-    privatePostsUserIds: [],
     setNotificationsRead: () => {},
     lastReadAt: undefined,
   });
@@ -121,33 +118,20 @@ export const NotificationsManagerProvider = ({
   }, [updateLastReadAt]);
 
   let unreadCount: number | undefined;
-  let privatePostsUserIds: string[] | undefined;
-
-  const notificationsToAuthorId = (_notifications: FeedNotification[]) =>
-    compact(
-      _notifications.map((n) => {
-        if (n.__typename === 'PrivatePostNotification') {
-          return n.post.authorId;
-        }
-      }),
-    );
 
   if (lastReadAt === null) {
     unreadCount = notifications.length;
-    privatePostsUserIds = notificationsToAuthorId(notifications);
   } else if (lastReadAt instanceof Date) {
     const newNotifications = notifications?.filter(
       (notification) => new Date(notification.time) > lastReadAt,
     );
     unreadCount = newNotifications.length;
-    privatePostsUserIds = notificationsToAuthorId(newNotifications);
   }
 
   return (
     <NotificationsManagerContext.Provider
       value={{
         unreadCount,
-        privatePostsUserIds,
         setNotificationsRead,
         lastReadAt,
       }}

--- a/src/screens/DirectMessagesScreen.tsx
+++ b/src/screens/DirectMessagesScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { Bubble, GiftedChat, IMessage } from 'react-native-gifted-chat';
 import {
   useInfinitePrivatePosts,
@@ -23,10 +23,14 @@ export function DirectMessagesScreen({
   const { recipientUserId, displayName } = route.params;
   const { styles } = useStyles(defaultStyles);
   const { markMessageRead } = useUnreadMessages();
+  const userId = useRef<string>();
 
   useEffect(() => {
-    markMessageRead?.(recipientUserId);
-  }, [markMessageRead, recipientUserId]);
+    if (userId.current !== recipientUserId) {
+      userId.current = recipientUserId;
+      markMessageRead?.(recipientUserId);
+    }
+  });
 
   useLayoutEffect(() => {
     navigation.setOptions({


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - useUnreadMessages now tracks read receipts when the user opens the DM screen; the read receipt is used to compare notification timestamps to determine new unread messages
  - NotificationManager is can now strictly be used for the NotificationTab badges/tracking new notifications
  - Fixed the order of unread messages on the message screen so the newest unread message will always appear at the top

## Screenshots
<!-- include screen recordings, if relevant to your changes -->