### PR TITLE
chore: Extract MessageScreen logic to hook

### DIFF
--- a/src/components/MessagesTile/MessagesTile.test.tsx
+++ b/src/components/MessagesTile/MessagesTile.test.tsx
@@ -60,13 +60,13 @@ test('calls navigate with params', async () => {
   expect(queryAllByTestId('tile-badge')).toHaveLength(0);
   fireEvent.press(messageTile);
   expect(navigateMock.navigate).toBeCalledWith('Home/Messages', {
-    recipientsUserIds: ['doctorId'],
+    tileId: 'some-messages-tile',
   });
 });
 
 test('renders badge if unread messages are available', async () => {
   useUnreadMessagesMock.mockReturnValue({
-    unreadMessagesUserIds: ['doctorId'],
+    unreadIds: ['doctorId'],
   });
 
   const { getByTestId } = render(directMessageScreen);

--- a/src/components/MessagesTile/MessagesTile.tsx
+++ b/src/components/MessagesTile/MessagesTile.tsx
@@ -11,14 +11,9 @@ interface Props extends Pick<HomeStackScreenProps<'Home'>, 'navigation'> {
   recipientsUserIds: string[];
 }
 
-export function MessagesTile({
-  navigation,
-  title,
-  id,
-  recipientsUserIds,
-}: Props) {
+export function MessagesTile({ navigation, title, id }: Props) {
   const { MessageCircle } = useIcons();
-  const { unreadMessagesUserIds } = useUnreadMessages();
+  const { unreadIds } = useUnreadMessages();
 
   return (
     <Tile
@@ -27,10 +22,10 @@ export function MessagesTile({
       title={title}
       testID={tID('message-tile')}
       Icon={MessageCircle}
-      showBadge={unreadMessagesUserIds && unreadMessagesUserIds.length > 0}
+      showBadge={unreadIds && unreadIds.length > 0}
       onPress={() => {
         navigation.navigate('Home/Messages', {
-          recipientsUserIds: recipientsUserIds,
+          tileId: id,
         });
       }}
     />

--- a/src/hooks/Circles/usePrivatePosts.ts
+++ b/src/hooks/Circles/usePrivatePosts.ts
@@ -157,7 +157,7 @@ export function usePollPageInfoForUsers(
 }
 
 export const useLookupUsers = (
-  userList: { userId: string; enabled: boolean }[],
+  userList?: { userId: string; enabled: boolean }[],
 ) => {
   const { graphQLClient } = useGraphQLClient();
   const { accountHeaders } = useActiveAccount();

--- a/src/hooks/useMyMessages.tsx
+++ b/src/hooks/useMyMessages.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useAppConfig } from './useAppConfig';
+import { useUnreadMessages } from './useUnreadMessages';
+import { useUser } from './useUser';
+import { chunk, compact, find, uniq } from 'lodash';
+import { useLookupUsers } from './Circles/usePrivatePosts';
+
+export const useMyMessages = (tileId: string) => {
+  const [pageIndex, setPageIndex] = useState(0);
+  const appConfig = useAppConfig();
+  const { data: userData } = useUser();
+  const { unreadIds } = useUnreadMessages();
+  const messageTile = find(
+    appConfig.data?.homeTab?.messageTiles,
+    (tile) => tile.id === tileId,
+  );
+  const recipientsUserIds = messageTile?.userIds.filter(
+    (id) => id !== userData?.id,
+  );
+
+  // If unread isn't in the receipt list do not use it
+  const permittedUnreadIds = unreadIds?.filter((id) =>
+    recipientsUserIds?.includes(id),
+  );
+
+  // Unread messages always show on the top of the list
+  const sortedList =
+    permittedUnreadIds && recipientsUserIds
+      ? uniq([...permittedUnreadIds, ...recipientsUserIds])
+      : recipientsUserIds;
+
+  // Break-down list of users into smaller chunks
+  const recipientsListChunked = chunk(sortedList, 10);
+
+  // Use current scroll-index to expand the list of users
+  // in view up to the maximum
+  const usersInView = compact(
+    recipientsListChunked.flatMap((users, index) => {
+      if (index <= pageIndex) {
+        return users;
+      }
+    }),
+  );
+
+  // Construct object to identify which user
+  // queries should be enabled
+  const userQueryList = sortedList?.map((userId) => ({
+    userId,
+    enabled: usersInView.includes(userId),
+  }));
+
+  // Get user details (picture/displayName) for usersInView
+  const userQueries = useLookupUsers(userQueryList);
+  const userDetailsList = compact(
+    userQueries.map(({ data }) => {
+      if (!data) {
+        return;
+      }
+
+      return {
+        userId: data.user.userId,
+        displayName: data.user.profile.displayName,
+        picture: data.user.profile.picture,
+        isUnread: unreadIds?.includes(data.user.userId) ?? false,
+      };
+    }),
+  );
+
+  const isLoading = userQueries.some(
+    ({ isInitialLoading }) => isInitialLoading,
+  );
+
+  const fetchNextPage = () => {
+    if (recipientsListChunked.length - 1 > pageIndex) {
+      // Expand list of users in view
+      setPageIndex((currentIndex) => currentIndex + 1);
+    }
+  };
+
+  console.log(recipientsListChunked.length, pageIndex);
+  const hasNextPage = recipientsListChunked.length - 1 > pageIndex;
+  return { userDetailsList, isLoading, fetchNextPage, hasNextPage };
+};

--- a/src/hooks/useMyMessages.tsx
+++ b/src/hooks/useMyMessages.tsx
@@ -77,7 +77,6 @@ export const useMyMessages = (tileId: string) => {
     }
   };
 
-  console.log(recipientsListChunked.length, pageIndex);
   const hasNextPage = recipientsListChunked.length - 1 > pageIndex;
   return { userDetailsList, isLoading, fetchNextPage, hasNextPage };
 };

--- a/src/hooks/useUnreadMessages.test.tsx
+++ b/src/hooks/useUnreadMessages.test.tsx
@@ -72,7 +72,7 @@ describe('NotificationsManager', () => {
 
     const { result } = await renderHookInContext();
 
-    expect(result.current.unreadMessagesUserIds).toEqual(['someAuthor']);
+    expect(result.current.unreadIds).toEqual(['someAuthor']);
   });
 
   it('stored read receipts filter notifications and hook result', async () => {
@@ -95,7 +95,7 @@ describe('NotificationsManager', () => {
     ]);
 
     const { result } = await renderHookInContext();
-    expect(result.current.unreadMessagesUserIds).toEqual([]);
+    expect(result.current.unreadIds).toEqual([]);
   });
 
   it('markMessage removes user from unreadIds and storage', async () => {

--- a/src/hooks/useUnreadMessages.tsx
+++ b/src/hooks/useUnreadMessages.tsx
@@ -61,6 +61,9 @@ const useMessageReadReceipts = () => {
         [
           {
             id: userId,
+            // TODO: Using the local time is brittle
+            // We could use the current system time of our
+            // graphql server to make this more robust
             time: new Date().toISOString(),
           },
           ...messageReadReceipts,

--- a/src/hooks/useUnreadMessages.tsx
+++ b/src/hooks/useUnreadMessages.tsx
@@ -12,7 +12,7 @@ type ReadReceipt = {
 };
 
 type UnreadMessageContextProps = {
-  unreadMessagesUserIds?: string[];
+  unreadIds?: string[];
   markMessageRead?: (userId: string) => void;
 };
 
@@ -26,14 +26,14 @@ export const UnreadMessagesContextProvider = ({
   const { messageReadReceipts, updateReadReceiptForUser } =
     useMessageReadReceipts();
   const { data } = useNotifications();
-  const unreadMessagesUserIds = useMemo(() => {
+  const unreadIds = useMemo(() => {
     return extractUnreadIdsFromNotifications(data, messageReadReceipts);
   }, [data, messageReadReceipts]);
 
   return (
     <UnreadMessagesContext.Provider
       value={{
-        unreadMessagesUserIds,
+        unreadIds,
         markMessageRead: updateReadReceiptForUser,
       }}
     >

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -80,11 +80,11 @@ export type HomeStackParamList = {
   'Home/MyData': undefined;
   'Home/YoutubePlayer': { youtubeVideoId: string; videoName?: string };
   'Home/Messages': {
-    recipientsUserIds: string[];
+    tileId: string;
   };
   'Home/DirectMessage': {
     recipientUserId: string;
-    displayName: string;
+    displayName?: string;
   };
 };
 

--- a/src/screens/MessageScreen.test.tsx
+++ b/src/screens/MessageScreen.test.tsx
@@ -10,7 +10,6 @@ jest.mock('../hooks/Circles/usePrivatePosts', () => {
   return {
     ...jest.requireActual('../hooks/Circles/usePrivatePosts'),
     useLookupUsers: jest.fn(),
-    usePollPageInfoForUsers: jest.fn(),
   };
 });
 jest.mock('../hooks/useUnreadMessages');
@@ -65,7 +64,7 @@ beforeEach(() => {
     },
   ]);
   useUnreadMessagesMock.mockReturnValue({
-    unreadMessageUserIds: [],
+    unreadIds: [],
   });
 });
 
@@ -74,7 +73,9 @@ test('renders loading indicator while lookup queries are fetching', async () => 
     {
       isInitialLoading: false,
     },
-    { isInitialLoading: true },
+    {
+      isInitialLoading: true,
+    },
   ]);
   const { getByTestId } = render(directMessageScreen);
   expect(getByTestId('activity-indicator-view')).toBeDefined();
@@ -127,7 +128,7 @@ test('renders badge if unread messages are available and sorts list', async () =
   ]);
 
   useUnreadMessagesMock.mockReturnValue({
-    unreadMessagesUserIds: ['other_user'],
+    unreadIds: ['other_user'],
   });
 
   const { queryAllByTestId } = render(directMessageScreen);

--- a/src/screens/MessageScreen.tsx
+++ b/src/screens/MessageScreen.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useLayoutEffect } from 'react';
 import { useStyles } from '../hooks/useStyles';
 import { Badge, Divider, List, Button } from 'react-native-paper';
 import { TouchableOpacity, ScrollView, View, ViewStyle } from 'react-native';
-import { createStyles, useIcons } from '../components/BrandConfigProvider';
+import { createStyles } from '../components/BrandConfigProvider';
 import { GiftedAvatar, User as GiftedUser } from 'react-native-gifted-chat';
 import { HomeStackScreenProps } from '../navigators/types';
 import { t } from 'i18next';
@@ -24,7 +24,6 @@ export function MessageScreen({
   }, [navigation]);
 
   const { styles } = useStyles(defaultStyles);
-  const { User } = useIcons();
   const { userDetailsList, fetchNextPage, hasNextPage, isLoading } =
     useMyMessages(tileId);
 
@@ -50,8 +49,8 @@ export function MessageScreen({
   );
 
   const renderRight = useCallback(
-    (user: User) =>
-      unreadUserIds?.includes(user.id) && (
+    (isUnread: boolean) =>
+      isUnread && (
         <Badge
           size={12}
           style={styles.badgeView}
@@ -69,15 +68,22 @@ export function MessageScreen({
       >
         {userDetailsList?.map((user) => (
           <TouchableOpacity
-            key={`message-${user.id}`}
-            onPress={handlePostTapped(user.id, user.name)}
+            key={`message-${user.userId}`}
+            onPress={handlePostTapped(user.userId, user.displayName)}
             activeOpacity={0.6}
           >
             <List.Item
               testID={tID('user-list-item')}
               titleStyle={styles.listItemText}
               style={styles.listItemView}
-              left={() => renderLeft(user.picture)}
+              left={(props) =>
+                renderLeft(props, {
+                  _id: user.userId,
+                  id: user.userId,
+                  name: user.displayName,
+                  avatar: user.picture,
+                })
+              }
               title={user.displayName}
               right={() => renderRight(user.isUnread)}
             />

--- a/src/screens/MessageScreen.tsx
+++ b/src/screens/MessageScreen.tsx
@@ -61,8 +61,6 @@ export function MessageScreen({
     [styles.badgeView],
   );
 
-  console.log(userDetailsList);
-
   return (
     <View style={styles.rootView}>
       <ScrollView


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
This PR is mostly a refactor with very little functional change. The MessageScreen has been simplified by extracting all the unread message/user list logic to a new hook, useMyMessages. 

There is one change to the UX on the MessageScreen, instead of relying on scrolling beyond the content height the user must tap the "Load More" button. This will accommodate changes in screen size. See video below.

#### NOTE: For the below video I've modified the chunk size to 5 in order to demonstrate paging via the "Load More" button. The usual size is 10 which typically consumes the entire height of the device.

https://github.com/lifeomic/react-native-sdk/assets/76954025/71fc005f-d42d-4d7c-8118-eca938ccb74a

