### PR TITLE
fix: Align Message Notification Badge Vertically

### DIFF
--- a/src/screens/MessageScreen.tsx
+++ b/src/screens/MessageScreen.tsx
@@ -126,7 +126,9 @@ const defaultStyles = createStyles('MessageScreen', (theme) => {
     userIconView: {
       marginLeft: theme.spacing.extraSmall,
     },
-    badgeView: {},
+    badgeView: {
+      alignSelf: 'center',
+    },
     loadMoreButton: {},
     loadMoreText: {},
   };


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes the vertical alignment of the notification badge to be centrally aligned

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
Before
![image](https://github.com/lifeomic/react-native-sdk/assets/2295908/ee5371fb-3b5e-4dc2-9cba-ccfa3d40775f)

After
![image](https://github.com/lifeomic/react-native-sdk/assets/2295908/d1da95df-53de-461f-a4d4-61996d3b1308)
