### PR TITLE
fix: Separate LoggedIn Providers from Root

### DIFF
--- a/src/common/LoggedInProviders.tsx
+++ b/src/common/LoggedInProviders.tsx
@@ -3,17 +3,43 @@ import React from 'react';
 import { ActiveAccountContextProvider } from '../hooks/useActiveAccount';
 import { NotificationsManagerProvider } from '../hooks/useNotificationManager';
 import { UnreadMessagesContextProvider } from '../hooks/useUnreadMessages';
+import { ActiveProjectContextProvider } from '../hooks/useActiveProject';
+import Toast from 'react-native-toast-message';
+import { TrackTileProvider } from '../components/TrackTile/TrackTileProvider';
+import { WearableLifecycleProvider } from '../components/Wearables/WearableLifecycleProvider';
+import { CreateEditPostModal } from '../components/Circles/CreateEditPostModal';
+import { PushNotificationsProvider } from '../hooks/usePushNotifications';
+import { CircleTileContextProvider } from '../hooks/Circles/useActiveCircleTile';
+import { OnboardingCourseContextProvider } from '../hooks/useOnboardingCourse';
+import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
 
 export const LoggedInProviders = ({
   children,
 }: {
   children?: React.ReactNode;
 }) => {
+  const { pushNotificationsConfig } = useDeveloperConfig();
   return (
-    <NotificationsManagerProvider>
-      <UnreadMessagesContextProvider>
-        <ActiveAccountContextProvider>{children}</ActiveAccountContextProvider>
-      </UnreadMessagesContextProvider>
-    </NotificationsManagerProvider>
+    <ActiveAccountContextProvider>
+      <ActiveProjectContextProvider>
+        <TrackTileProvider>
+          <WearableLifecycleProvider>
+            <CircleTileContextProvider>
+              <OnboardingCourseContextProvider>
+                <PushNotificationsProvider config={pushNotificationsConfig}>
+                  <NotificationsManagerProvider>
+                    <UnreadMessagesContextProvider>
+                      {children}
+                    </UnreadMessagesContextProvider>
+                  </NotificationsManagerProvider>
+                </PushNotificationsProvider>
+                <CreateEditPostModal />
+                <Toast />
+              </OnboardingCourseContextProvider>
+            </CircleTileContextProvider>
+          </WearableLifecycleProvider>
+        </TrackTileProvider>
+      </ActiveProjectContextProvider>
+    </ActiveAccountContextProvider>
   );
 };

--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -1,27 +1,17 @@
 import * as React from 'react';
-import { ThemedNavigationContainer } from './ThemedNavigationContainer';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AuthConfiguration } from 'react-native-app-auth';
 import { AuthContextProvider } from '../hooks/useAuth';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ActiveAccountContextProvider } from '../hooks/useActiveAccount';
 import { HttpClientContextProvider } from '../hooks/useHttpClient';
 import { OAuthContextProvider } from '../hooks/useOAuthFlow';
-import { ActiveProjectContextProvider } from '../hooks/useActiveProject';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
-import Toast from 'react-native-toast-message';
-import { NoInternetToastProvider } from '../hooks/NoInternetToastProvider';
-import { BrandConfigProvider } from '../components/BrandConfigProvider';
-import { TrackTileProvider } from '../components/TrackTile/TrackTileProvider';
 import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
-import { WearableLifecycleProvider } from '../components/Wearables/WearableLifecycleProvider';
-import { CreateEditPostModal } from '../components/Circles/CreateEditPostModal';
-import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { InviteProvider } from '../components/Invitations/InviteProvider';
-import { PushNotificationsProvider } from '../hooks/usePushNotifications';
-import { CircleTileContextProvider } from '../hooks/Circles/useActiveCircleTile';
-import { OnboardingCourseContextProvider } from '../hooks/useOnboardingCourse';
-
+import { BrandConfigProvider } from '../components/BrandConfigProvider';
+import { NoInternetToastProvider } from '../hooks/NoInternetToastProvider';
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { ThemedNavigationContainer } from './ThemedNavigationContainer';
 const queryClient = new QueryClient();
 
 export function RootProviders({
@@ -31,7 +21,7 @@ export function RootProviders({
   authConfig: AuthConfiguration;
   children?: React.ReactNode;
 }) {
-  const { theme, apiBaseURL, pushNotificationsConfig } = useDeveloperConfig();
+  const { apiBaseURL, theme } = useDeveloperConfig();
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -40,35 +30,17 @@ export function RootProviders({
           <GraphQLClientContextProvider baseURL={apiBaseURL}>
             <InviteProvider>
               <OAuthContextProvider authConfig={authConfig}>
-                <ActiveAccountContextProvider>
-                  <ActiveProjectContextProvider>
-                    <TrackTileProvider>
-                      <WearableLifecycleProvider>
-                        <CircleTileContextProvider>
-                          <BrandConfigProvider theme={theme}>
-                            <OnboardingCourseContextProvider>
-                              <NoInternetToastProvider>
-                                <ActionSheetProvider>
-                                  <SafeAreaProvider>
-                                    <ThemedNavigationContainer>
-                                      <PushNotificationsProvider
-                                        config={pushNotificationsConfig}
-                                      >
-                                        {children}
-                                      </PushNotificationsProvider>
-                                    </ThemedNavigationContainer>
-                                    <CreateEditPostModal />
-                                    <Toast />
-                                  </SafeAreaProvider>
-                                </ActionSheetProvider>
-                              </NoInternetToastProvider>
-                            </OnboardingCourseContextProvider>
-                          </BrandConfigProvider>
-                        </CircleTileContextProvider>
-                      </WearableLifecycleProvider>
-                    </TrackTileProvider>
-                  </ActiveProjectContextProvider>
-                </ActiveAccountContextProvider>
+                <BrandConfigProvider theme={theme}>
+                  <NoInternetToastProvider>
+                    <ActionSheetProvider>
+                      <SafeAreaProvider>
+                        <ThemedNavigationContainer>
+                          {children}
+                        </ThemedNavigationContainer>
+                      </SafeAreaProvider>
+                    </ActionSheetProvider>
+                  </NoInternetToastProvider>
+                </BrandConfigProvider>
               </OAuthContextProvider>
             </InviteProvider>
           </GraphQLClientContextProvider>

--- a/src/navigators/LoggedInStack.tsx
+++ b/src/navigators/LoggedInStack.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { TabNavigator } from './TabNavigator';
+import { ConsentScreen } from '../screens/ConsentScreen';
+import { CircleThreadScreen } from '../screens/CircleThreadScreen';
+import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
+import { OnboardingCourseScreen } from '../screens/OnboardingCourseScreen';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { LoggedInRootParamList } from './types';
+import { useConsent } from '../hooks/useConsent';
+import { useActiveAccount } from '../hooks/useActiveAccount';
+import { useActiveProject } from '../hooks/useActiveProject';
+import { useOnboardingCourse } from '../hooks/useOnboardingCourse';
+import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
+import { t } from 'i18next';
+import { usePendingInvite } from '../hooks/usePendingInvite';
+import { useSetUserProfileEffect } from '../hooks/useSetUserProfileEffect';
+
+export function LoggedInStack() {
+  const Stack = createNativeStackNavigator<LoggedInRootParamList>();
+  const { inviteParams } = usePendingInvite();
+  useSetUserProfileEffect();
+  const {
+    account,
+    isLoading: isLoadingAccount,
+    isFetched: isFetchedAccount,
+  } = useActiveAccount();
+  const {
+    activeProject,
+    isLoading: isLoadingProject,
+    isFetched: isFetchedProject,
+  } = useActiveProject();
+  const { useShouldRenderConsentScreen } = useConsent();
+  const { shouldRenderConsentScreen, isLoading: loadingConsents } =
+    useShouldRenderConsentScreen();
+  const {
+    shouldLaunchOnboardingCourse,
+    isLoading: onboardingCourseIsLoading,
+    isFetched: onboardingCourseIsFetched,
+  } = useOnboardingCourse();
+
+  const loadingProject = !isFetchedProject || isLoadingProject;
+  const loadingAccount = !isFetchedAccount || isLoadingAccount;
+  const hasAccount = !loadingAccount && !!account?.id;
+  const loadingAccountOrProject =
+    loadingAccount || (hasAccount && loadingProject);
+  const loadingOnboardingCourse =
+    !onboardingCourseIsFetched || onboardingCourseIsLoading;
+
+  const hasAccountAndProject = !!(activeProject?.id && account?.id);
+  const initialRoute = !hasAccountAndProject
+    ? 'InviteRequired'
+    : shouldRenderConsentScreen
+    ? 'screens/ConsentScreen'
+    : shouldLaunchOnboardingCourse
+    ? 'screens/OnboardingCourseScreen'
+    : 'app';
+
+  if (loadingAccountOrProject) {
+    return (
+      <ActivityIndicatorView
+        message={t(
+          'root-stack-waiting-for-account-and-project',
+          'Loading account',
+        )}
+      />
+    );
+  }
+
+  if (hasAccountAndProject && loadingConsents) {
+    return (
+      <ActivityIndicatorView
+        message={t('root-stack-waiting-for-consents', 'Loading consents')}
+      />
+    );
+  }
+
+  if (hasAccountAndProject && loadingOnboardingCourse) {
+    return (
+      <ActivityIndicatorView
+        message={t(
+          'root-stack-waiting-for-app-config',
+          'Loading onboarding course data',
+        )}
+      />
+    );
+  }
+
+  if (inviteParams?.inviteId) {
+    return (
+      <ActivityIndicatorView
+        message={t('root-stack-accepting-invitation', 'Accepting invitation')}
+      />
+    );
+  }
+
+  return (
+    <Stack.Navigator initialRouteName={initialRoute}>
+      <Stack.Screen
+        name="InviteRequired"
+        component={InviteRequiredScreen}
+        options={{
+          presentation: 'fullScreenModal',
+          title: t('invite-required', 'Invitation Required'),
+        }}
+      />
+      <Stack.Screen
+        name="app"
+        component={TabNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="screens/ConsentScreen"
+        component={ConsentScreen}
+        options={{
+          presentation: 'fullScreenModal',
+          title: t('consent', 'Consent'),
+        }}
+      />
+      <Stack.Screen
+        name="screens/OnboardingCourseScreen"
+        component={OnboardingCourseScreen}
+        options={{
+          presentation: 'fullScreenModal',
+        }}
+      />
+      <Stack.Screen name="Circle/Thread" component={CircleThreadScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigators/RootStack.tsx
+++ b/src/navigators/RootStack.tsx
@@ -1,58 +1,15 @@
 import React from 'react';
 import { t } from 'i18next';
 import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
-import {
-  useActiveAccount,
-  useActiveProject,
-  useAuth,
-  useConsent,
-  useOnboardingCourse,
-  usePendingInvite,
-} from '../hooks';
+import { useAuth } from '../hooks';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { LoggedInProviders } from '../common/LoggedInProviders';
 import { LoginScreen } from '../screens/LoginScreen';
-import { TabNavigator } from './TabNavigator';
-import { LoggedInRootParamList, NotLoggedInRootParamList } from './types';
-import { ConsentScreen } from '../screens/ConsentScreen';
-import { CircleThreadScreen } from '../screens/CircleThreadScreen';
-import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
-import { OnboardingCourseScreen } from '../screens/OnboardingCourseScreen';
-import { useSetUserProfileEffect } from '../hooks/useSetUserProfileEffect';
+import { NotLoggedInRootParamList } from './types';
+import { LoggedInStack } from './LoggedInStack';
 
 export function RootStack() {
   const { isLoggedIn, loading: loadingAuth } = useAuth();
-  const {
-    account,
-    isLoading: isLoadingAccount,
-    isFetched: isFetchedAccount,
-  } = useActiveAccount();
-  const {
-    activeProject,
-    isLoading: isLoadingProject,
-    isFetched: isFetchedProject,
-  } = useActiveProject();
-  const { inviteParams } = usePendingInvite();
-
-  const { useShouldRenderConsentScreen } = useConsent();
-  const { shouldRenderConsentScreen, isLoading: loadingConsents } =
-    useShouldRenderConsentScreen();
-  const {
-    shouldLaunchOnboardingCourse,
-    isLoading: onboardingCourseIsLoading,
-    isFetched: onboardingCourseIsFetched,
-  } = useOnboardingCourse();
-
-  useSetUserProfileEffect();
-
-  const loadingProject = !isFetchedProject || isLoadingProject;
-  const loadingAccount = !isFetchedAccount || isLoadingAccount;
-  const hasAccount = !loadingAccount && !!account?.id;
-  const loadingAccountOrProject =
-    loadingAccount || (hasAccount && loadingProject);
-  const loadingOnboardingCourse =
-    !onboardingCourseIsFetched || onboardingCourseIsLoading;
-
   if (!isLoggedIn && loadingAuth) {
     return (
       <ActivityIndicatorView
@@ -62,88 +19,9 @@ export function RootStack() {
   }
 
   if (isLoggedIn) {
-    const Stack = createNativeStackNavigator<LoggedInRootParamList>();
-    const hasAccountAndProject = !!(activeProject?.id && account?.id);
-
-    if (loadingAccountOrProject) {
-      return (
-        <ActivityIndicatorView
-          message={t(
-            'root-stack-waiting-for-account-and-project',
-            'Loading account',
-          )}
-        />
-      );
-    }
-
-    if (hasAccountAndProject && loadingConsents) {
-      return (
-        <ActivityIndicatorView
-          message={t('root-stack-waiting-for-consents', 'Loading consents')}
-        />
-      );
-    }
-
-    if (hasAccountAndProject && loadingOnboardingCourse) {
-      return (
-        <ActivityIndicatorView
-          message={t(
-            'root-stack-waiting-for-app-config',
-            'Loading onboarding course data',
-          )}
-        />
-      );
-    }
-
-    if (inviteParams?.inviteId) {
-      return (
-        <ActivityIndicatorView
-          message={t('root-stack-waiting-for-consents', 'Accepting invitation')}
-        />
-      );
-    }
-
-    const initialRoute = !hasAccountAndProject
-      ? 'InviteRequired'
-      : shouldRenderConsentScreen
-      ? 'screens/ConsentScreen'
-      : shouldLaunchOnboardingCourse
-      ? 'screens/OnboardingCourseScreen'
-      : 'app';
-
     return (
       <LoggedInProviders>
-        <Stack.Navigator initialRouteName={initialRoute}>
-          <Stack.Screen
-            name="InviteRequired"
-            component={InviteRequiredScreen}
-            options={{
-              presentation: 'fullScreenModal',
-              title: t('invite-required', 'Invitation Required'),
-            }}
-          />
-          <Stack.Screen
-            name="app"
-            component={TabNavigator}
-            options={{ headerShown: false }}
-          />
-          <Stack.Screen
-            name="screens/ConsentScreen"
-            component={ConsentScreen}
-            options={{
-              presentation: 'fullScreenModal',
-              title: t('consent', 'Consent'),
-            }}
-          />
-          <Stack.Screen
-            name="screens/OnboardingCourseScreen"
-            component={OnboardingCourseScreen}
-            options={{
-              presentation: 'fullScreenModal',
-            }}
-          />
-          <Stack.Screen name="Circle/Thread" component={CircleThreadScreen} />
-        </Stack.Navigator>
+        <LoggedInStack />
       </LoggedInProviders>
     );
   }

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -73,22 +73,6 @@ beforeEach(() => {
   });
 });
 
-test('renders loading indicator while account fetching', async () => {
-  useActiveAccountMock.mockReturnValue({
-    isLoading: true,
-  });
-  const { getByTestId } = render(homeScreen);
-  expect(getByTestId('activity-indicator-view')).toBeDefined();
-});
-
-test('renders loading indicator while app config fetching', async () => {
-  useAppConfigMock.mockReturnValue({
-    isInitialLoading: true,
-  });
-  const { getByTestId } = render(homeScreen);
-  expect(getByTestId('activity-indicator-view')).toBeDefined();
-});
-
 test('sets the custom header title', async () => {
   render(homeScreen);
   await waitFor(() => {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,24 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { t } from 'i18next';
-import { useActiveAccount } from '../hooks/useActiveAccount';
 import { useAppConfig } from '../hooks/useAppConfig';
-import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
 import { TilesList } from '../components/tiles/TilesList';
 import { ScreenSurface } from '../components/ScreenSurface';
 import { HomeStackScreenProps } from '../navigators/types';
-import { useJoinCircles } from '../hooks';
 import { refreshNotifier } from '../common/RefreshNotifier';
 import { HeaderLeftRefreshButton } from '../components/HeaderLeftRefreshButton';
 
 export const HomeScreen = (navProps: HomeStackScreenProps<'Home'>) => {
-  const { isLoading: loadingAccount } = useActiveAccount();
-  const { isInitialLoading: loadingAppConfig, data: appConfig } =
-    useAppConfig();
-  const { isInitialLoading: loadingJoinCircles } = useJoinCircles();
+  const { data } = useAppConfig();
   const [refreshing, setRefreshing] = useState(false);
   const { navigation } = navProps;
-  const customHeaderTitle = appConfig?.homeTab?.screenHeader?.title;
-  const headerRefreshEnabled = appConfig?.homeTab?.screenHeader?.enableRefresh;
+  const customHeaderTitle = data?.homeTab?.screenHeader?.title;
+  const headerRefreshEnabled = data?.homeTab?.screenHeader?.enableRefresh;
 
   const refresh = useCallback(async () => {
     if (refreshing) {
@@ -49,33 +42,6 @@ export const HomeScreen = (navProps: HomeStackScreenProps<'Home'>) => {
       });
     }
   }, [navigation, refreshing, refresh, headerRefreshEnabled]);
-
-  if (loadingAccount) {
-    return (
-      <ActivityIndicatorView
-        message={t(
-          'home-screen-loading-account',
-          'Loading account information',
-        )}
-      />
-    );
-  }
-
-  if (loadingAppConfig) {
-    return (
-      <ActivityIndicatorView
-        message={t('home-screen-loading-config', 'Loading app config')}
-      />
-    );
-  }
-
-  if (loadingJoinCircles) {
-    return (
-      <ActivityIndicatorView
-        message={t('home-screen-joining-circles', 'Joining available circles')}
-      />
-    );
-  }
 
   return (
     <ScreenSurface testID="home-screen">


### PR DESCRIPTION
## About

The example app has been exhibiting some inefficient behavior which is addressed by this PR:
- Race condition in async-storage reads; with no built-in wait mechanism for useAsyncStorage reads would sometimes occur with the key containing `undefined`, .e.g, a key of `${user?.id}-myData` would result in `undefined-myData` and thus fail to fetch the stored data at times.
- API calls occurring before prerequisite auth/account headers ready. Sometimes this is the result of calling refetch() which bypasses the enabled conditions, other times I'm speculating that the async-storage bugs mentioned above can lead to this.
- Duplicate loading indicators on the home page could lead to excessive loading indicators; these required conditions were already being handled by the RootStack Provider.
- Multiple calls to app-config

## Changes
<!-- list your changes here -->
  - useAsyncStorage no longer wraps async-storage with react-query and instead uses async-storage directly which improves overall performance when reading from storage. 
  - Providers that require authentication have been removed from RootProviders and placed into LoggedInProviders. This prevents any Providers that require authentication from firing too early.
 - Extracted project/account/consent loading logic and screens from RootStack to a new stack `LoggedInStack` which ensures that the required Providers for the project/account/consent hooks have already initialized. 
 - Converted useAppConfig to a Provider which only fetches the app-config once depending on if the appConfig state value has been set or not.
