### PR TITLE
feat: Inject Brand from App Config

### DIFF
--- a/example/storybook/stories/BrandConfigProvider/BrandConfigProvider.stories.tsx
+++ b/example/storybook/stories/BrandConfigProvider/BrandConfigProvider.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { storiesOf } from '@storybook/react-native';
 import { object } from '@storybook/addon-knobs';
-import { BrandConfigProvider, useIcons } from '../../../../src';
+import { AppConfig, BrandConfigProvider, useIcons } from '../../../../src';
 import { ThemeExampleScreen } from './ThemeExampleScreen';
 import * as baseTheme from '../../../../src/components/BrandConfigProvider/theme/base';
 import { ExampleBox, ExampleBoxStyles } from './ExampleBox';
@@ -10,7 +10,8 @@ import { BrandConfigProviderStyles } from '../../../../src/components/BrandConfi
 import { CenterView } from '../../helpers/CenterView';
 import Svg, { Path } from 'react-native-svg';
 import { List } from 'react-native-paper';
-import { Apple } from '@lifeomic/chromicons-native';
+import { Apple, Disguise } from '@lifeomic/chromicons-native';
+import { appConfigNotifier } from '../../../../src/common/AppConfigNotifier';
 
 storiesOf('BrandConfigProvider', module)
   .addDecorator((story) => <CenterView>{story()}</CenterView>)
@@ -98,6 +99,85 @@ storiesOf('BrandConfigProvider', module)
             left={() => <IconExample name="Custom" />}
           />
         </List.Section>
+      </BrandConfigProvider>
+    );
+  })
+
+  .add('Brand Injection', () => {
+    function IconExample({ name }: { name: string }) {
+      const { [name]: Icon } = useIcons();
+      return Icon && <Icon />;
+    }
+
+    function MockAppConfigProvider(props: {
+      config: AppConfig;
+      children: React.ReactElement;
+    }) {
+      React.useEffect(() => {
+        appConfigNotifier.emit(props.config);
+      }, [props.config]);
+
+      return props.children;
+    }
+
+    return (
+      <BrandConfigProvider>
+        <MockAppConfigProvider
+          config={{
+            brand: {
+              iconAliases: {
+                // Create an icon alias called Alias. Any reference to "Alias" should use the "Disguise" icon.
+                Alias: 'Disguise',
+              },
+              icons: {
+                // Override the icon for apple
+                Apple: () => (
+                  <Svg
+                    fill="slategray"
+                    height="24"
+                    width="24"
+                    viewBox="0 0 16 16"
+                  >
+                    <Path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282z" />
+                    <Path d="M11.182.008C11.148-.03 9.923.023 8.857 1.18c-1.066 1.156-.902 2.482-.878 2.516.024.034 1.52.087 2.475-1.258.955-1.345.762-2.391.728-2.43zm3.314 11.733c-.048-.096-2.325-1.234-2.113-3.422.212-2.189 1.675-2.789 1.698-2.854.023-.065-.597-.79-1.254-1.157a3.692 3.692 0 0 0-1.563-.434c-.108-.003-.483-.095-1.254.116-.508.139-1.653.589-1.968.607-.316.018-1.256-.522-2.267-.665-.647-.125-1.333.131-1.824.328-.49.196-1.422.754-2.074 2.237-.652 1.482-.311 3.83-.067 4.56.244.729.625 1.924 1.273 2.796.576.984 1.34 1.667 1.659 1.899.319.232 1.219.386 1.843.067.502-.308 1.408-.485 1.766-.472.357.013 1.061.154 1.782.539.571.197 1.111.115 1.652-.105.541-.221 1.324-1.059 2.238-2.758.347-.79.505-1.217.473-1.282z" />
+                  </Svg>
+                ),
+              },
+              theme: {
+                // Provide a new on surface color for the whole theme
+                colors: {
+                  onSurface: 'red',
+                },
+              },
+              styles: {
+                // Provide new styles for the ExampleBox component
+                ExampleBox: {
+                  container: {
+                    borderWidth: 4,
+                  },
+                  text: {
+                    fontWeight: 'bold',
+                  },
+                },
+              },
+            },
+          }}
+        >
+          <List.Section style={{ width: 310 }}>
+            <List.Item
+              title='Overrides the "Apple" Icon →'
+              left={() => <IconExample name="Apple" />}
+              right={() => <Apple />}
+            />
+            <List.Item
+              title='Uses "Alias" to resolve icon →'
+              left={() => <IconExample name="Alias" />}
+              right={() => <Disguise />}
+            />
+
+            <ExampleBox message="Text inside a box" styles={{}} />
+          </List.Section>
+        </MockAppConfigProvider>
       </BrandConfigProvider>
     );
   });

--- a/src/common/AppConfigNotifier.tsx
+++ b/src/common/AppConfigNotifier.tsx
@@ -1,0 +1,22 @@
+import { EventEmitter } from 'events';
+import { AppConfig } from '../hooks';
+
+export const appConfigChangeEventType = 'appConfigChanged';
+export type AppConfigChangeHandler = (config: AppConfig | undefined) => void;
+export class AppConfigNotifier {
+  private emitter = new EventEmitter();
+
+  public addListener(listener: AppConfigChangeHandler) {
+    return this.emitter.addListener(appConfigChangeEventType, listener);
+  }
+
+  public removeListener(listener: AppConfigChangeHandler) {
+    return this.emitter.removeListener(appConfigChangeEventType, listener);
+  }
+
+  public emit(config: AppConfig | undefined) {
+    return this.emitter.emit(appConfigChangeEventType, config);
+  }
+}
+
+export const appConfigNotifier = new AppConfigNotifier();

--- a/src/components/BrandConfigProvider/icons/IconProvider.tsx
+++ b/src/components/BrandConfigProvider/icons/IconProvider.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import * as Chromicons from '@lifeomic/chromicons-native';
 import { TriangleFilled } from './TriangleFilled';
+import mapValues from 'lodash/mapValues';
 
 export type ChromiconName = keyof typeof Chromicons;
 
@@ -9,14 +10,27 @@ export type Icons = typeof Chromicons &
     TriangleFilled: typeof TriangleFilled;
   };
 
-const IconContext = createContext<Icons>({ ...Chromicons, TriangleFilled });
+const DefaultIcons = { ...Chromicons, TriangleFilled };
+
+const IconContext = createContext<Icons>(DefaultIcons);
 
 export const useIcons = () => useContext(IconContext);
 
-type Props = { children: React.ReactNode; icons?: Partial<Icons> };
+type Props = {
+  children: React.ReactNode;
+  icons?: Partial<Icons>;
+  iconAliases?: Record<string, string>;
+};
 
-export const IconProvider = ({ children, icons }: Props) => (
-  <IconContext.Provider value={{ ...Chromicons, ...icons, TriangleFilled }}>
-    {children}
-  </IconContext.Provider>
-);
+export const IconProvider = ({ children, icons, iconAliases = {} }: Props) => {
+  const value = useMemo(() => {
+    const baseIcons: Icons = { ...DefaultIcons, ...icons };
+
+    return {
+      ...baseIcons,
+      ...mapValues(iconAliases, (mapTo) => baseIcons[mapTo]),
+    };
+  }, [iconAliases, icons]);
+
+  return <IconContext.Provider value={value}>{children}</IconContext.Provider>;
+};

--- a/src/hooks/useAppConfig.tsx
+++ b/src/hooks/useAppConfig.tsx
@@ -3,6 +3,7 @@ import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { Trace } from '../components/MyData/LineChart/TraceLine';
 import { useHttpClient } from './useHttpClient';
+import { appConfigNotifier } from '../common/AppConfigNotifier';
 
 export interface AppTile {
   id: string;
@@ -67,6 +68,7 @@ export interface AppConfig {
     url: string;
     title?: string;
   };
+  brand?: Record<string, any>;
 }
 
 type AppConfigContextProps = {
@@ -108,11 +110,13 @@ export const AppConfigContextProvider = ({
         isLoading.current = false;
         error.current = undefined;
         setAppConfig(res.data);
+        appConfigNotifier.emit(res.data);
       })
       .catch((err) => {
         isLoading.current = false;
         error.current = err;
         setAppConfig(undefined);
+        appConfigNotifier.emit(undefined);
       });
   }
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds the ability to inject the brand, defined within the App Config, once it is loaded.
  - Some amount of compile time config will still be needed for unauthenticated screens but this allows us to update styles post an app store release
  - Adds the ability to provide icon aliases to change icons at runtime. This is particularly useful for app tiles and circle tiles that allow icon injection based on their `id` if a customer wants to change to a new or different app tile, they can update the iconAliases to include the correct mapping for the new icon outside of an app store release. This would also allow a customer to load all their custom icons (similar to Chromicons) and then pick and choose them from the API at a later date. 

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
![image](https://github.com/lifeomic/react-native-sdk/assets/2295908/0ccd2fbc-8ccf-42ed-b598-88677380bbeb)
