### PR TITLE
Persist Installed Setting to Tracker Cache

### DIFF
--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -96,7 +96,13 @@ export const useAxiosTrackTileService = (): TrackTileService => {
       return;
     }
 
-    const newSettings = pick(settings, ['order', 'target', 'unit', 'metricId']);
+    const newSettings = pick(settings, [
+      'order',
+      'target',
+      'unit',
+      'metricId',
+      'installed',
+    ]);
     const mergedTracker = merge({}, tracker, newSettings);
 
     cache.trackers = (cache.trackers ?? [])


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes a bug where the new install setting was not persisted to the cache causing the settings screen to be incorrect after updating a tracker install status

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><b>Before
 <td><b>After
<tr>
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/41666219-868f-40c1-b8b6-610e2e2b49ec" />
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/649d54ce-2b7b-4a16-9907-dfdd378f2d5b" />
</table>