### PR TITLE
feat: Enable smaller sized settings icon w/o Title

### DIFF
--- a/example/storybook/stories/TrackTile/TrackTiles.stories.tsx
+++ b/example/storybook/stories/TrackTile/TrackTiles.stories.tsx
@@ -8,6 +8,7 @@ import { CenterView } from '../../helpers/CenterView';
 import { getTrackers } from './util/trackerData';
 import { boolean } from '@storybook/addon-knobs';
 import { PillarsTile } from '../../../../src/components/TrackTile/PillarsTile/PillarsTile';
+import { DeveloperConfigProvider } from '../../../../src/components/DeveloperConfigProvider';
 
 const trackers = [...getTrackers(), ...getTrackers({ pillars: true })];
 
@@ -28,7 +29,18 @@ storiesOf('TrackTile/TrackTiles', module)
     </CenterView>
   ))
   .add('In context with Pillars', () => (
-    <>
+    <DeveloperConfigProvider
+      developerConfig={{
+        componentProps: {
+          TrackTile: {
+            hideSettingsButton: boolean(
+              'Hide Settings Button from DeveloperConfig',
+              false,
+            ),
+          },
+        },
+      }}
+    >
       <PillarsTile
         onOpenDetails={action('onOpenDetails')}
         onSaveNewValueOverride={action('onSaveNewValueOverride')}
@@ -37,9 +49,8 @@ storiesOf('TrackTile/TrackTiles', module)
         onOpenSettings={action('onOpenSettings')}
         onOpenTracker={action('onOpenTracker')}
         title={boolean('Title', true) ? 'TrackTile Title' : undefined}
-        hideSettingsButton={boolean('Hide Settings Button', false)}
       />
-    </>
+    </DeveloperConfigProvider>
   ))
   .add('Custom style', () => {
     const styles = {

--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -88,6 +88,9 @@ export type DeveloperConfig = {
       showLabels?: boolean;
       tabs?: NavigationTab[];
     };
+    TrackTile?: {
+      hideSettingsButton?: boolean;
+    };
     TrackerDetails?: {
       showSimpleTargetMessage?: boolean;
       dayPickerShowTodaysUnits?: boolean;

--- a/src/components/TrackTile/OpenSettingsButton.tsx
+++ b/src/components/TrackTile/OpenSettingsButton.tsx
@@ -1,11 +1,13 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { t } from '../../../lib/i18n';
 import { TouchableOpacity, TouchableOpacityProps } from 'react-native';
 import { tID } from './common/testID';
 import { createStyles, useIcons } from '../BrandConfigProvider';
 import { useStyles } from '../../hooks';
 
-const OpenSettingsButton: FC<TouchableOpacityProps> = (props) => {
+type Props = TouchableOpacityProps & { size: number };
+
+const OpenSettingsButton = (props: Props) => {
   const { Settings } = useIcons();
   const { styles } = useStyles(defaultStyles);
 
@@ -21,7 +23,11 @@ const OpenSettingsButton: FC<TouchableOpacityProps> = (props) => {
       hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
       {...props}
     >
-      <Settings stroke={styles.iconImage?.overlayColor} />
+      <Settings
+        stroke={styles.iconImage?.overlayColor}
+        width={styles.iconImage?.width || props.size}
+        height={styles.iconImage?.height || props.size}
+      />
     </TouchableOpacity>
   );
 };

--- a/src/components/TrackTile/TrackTile.tsx
+++ b/src/components/TrackTile/TrackTile.tsx
@@ -12,6 +12,7 @@ import { useTrackerValues } from './hooks/useTrackerValues';
 import { createStyles } from '../BrandConfigProvider';
 import { useStyles } from '../../hooks/useStyles';
 import { Card } from 'react-native-paper';
+import { useDeveloperConfig } from '../../hooks/useDeveloperConfig';
 
 export type TrackTileProps = {
   title?: string;
@@ -25,12 +26,17 @@ export type TrackTileProps = {
 export function TrackTile({
   onOpenSettings,
   onOpenTracker,
-  hideSettingsButton = false,
+  hideSettingsButton,
   title = '',
   styles: instanceStyles,
   shouldUseOntology,
 }: TrackTileProps) {
   const { styles } = useStyles(defaultStyles, instanceStyles);
+  const { componentProps } = useDeveloperConfig() || {};
+  if (hideSettingsButton === undefined) {
+    hideSettingsButton = componentProps?.TrackTile?.hideSettingsButton;
+  }
+
   const valuesContext: TrackerValuesContext = {
     system: TRACKER_CODE_SYSTEM,
     codeBelow: TRACKER_CODE,
@@ -44,6 +50,10 @@ export function TrackTile({
   const settingsButton = (props: { size: number }) => {
     if (hideSettingsButton) {
       return null;
+    }
+    if (!title) {
+      // The `size` prop defaults to 24 from React Native Paper
+      props.size = 18;
     }
     return (
       <OpenSettingsButton
@@ -63,7 +73,7 @@ export function TrackTile({
           titleStyle={styles.titleText}
           right={settingsButton}
           rightStyle={styles.settingsButton}
-          style={styles.titleView}
+          style={title ? styles.titleView : styles.titleViewWithoutTitle}
         />
       )}
       <TrackerRow
@@ -79,6 +89,9 @@ export function TrackTile({
 const defaultStyles = createStyles('TrackTile', (theme) => ({
   titleView: {
     marginVertical: -8,
+  },
+  titleViewWithoutTitle: {
+    marginVertical: -24,
   },
   titleText: {},
   cardView: {


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Add `hideSettingsButton` flag to DeveloperConfig
  - Enable smaller sized icon and margin when TrackTile has no Title

## Screenshots
<!-- include screen recordings, if relevant to your changes -->


https://github.com/lifeomic/react-native-sdk/assets/220893/900d93f3-ce49-4fd3-8b5b-82db2364fb79


