### PR TITLE
Fix couple invite flow quirks

### DIFF
--- a/src/components/Invitations/InviteProvider.test.tsx
+++ b/src/components/Invitations/InviteProvider.test.tsx
@@ -118,15 +118,14 @@ describe('accepting invite', () => {
         params: { inviteId: mockInviteParams.inviteId },
       }),
     );
+    expect(result.current.inviteParams).toEqual({});
     expect(refreshForInviteAccept).toHaveBeenCalled();
     expect(acceptListener).toHaveBeenCalled();
-    expect(result.current.inviteParams?.inviteId).toBeDefined();
 
     await act(async () => {
       inviteNotifier.emit('inviteAccountSettled');
       await rerender({});
     });
-    expect(result.current.inviteParams).toEqual({});
 
     inviteNotifier.removeListener('inviteAccepted', acceptListener);
   });

--- a/src/components/Invitations/InviteProvider.tsx
+++ b/src/components/Invitations/InviteProvider.tsx
@@ -51,6 +51,8 @@ export const InviteProvider = ({ children }: ProviderProps) => {
         // Before notifying others, refresh the auth token so that the new
         // auth token used has context of the accepted invite.
         await refreshForInviteAccept();
+        clearPendingInvite();
+        reset();
         inviteNotifier.emit('inviteAccepted', acceptedInvite);
       } catch (error) {
         if (

--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -134,20 +134,6 @@ test('setActiveAccountId saves accountId', async () => {
   );
 });
 
-test('setActiveAccountId ignores invalid accountId', async () => {
-  const { result } = await renderHookInContext();
-
-  await act(async () => {
-    result.current.setActiveAccountId('invalid account');
-  });
-
-  await waitFor(() =>
-    expect(result.current).toMatchObject({
-      account: mockAccounts[0],
-    }),
-  );
-});
-
 test('indicates expired trial', async () => {
   const expiredTrialAccount = {
     id: 'acct',

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -127,28 +127,9 @@ export const ActiveAccountContextProvider = ({
     }
   }, [previousUserId, userId, accountsResult]);
 
-  const setActiveAccountId = useCallback(
-    async (accountId: string) => {
-      try {
-        const selectedAccount = getValidAccount(accountsWithProduct, accountId);
-        if (!selectedAccount) {
-          if (process.env.NODE_ENV !== 'test') {
-            console.warn(
-              'Ignoring attempt to set invalid accountId',
-              accountId,
-            );
-          }
-          return;
-        }
-        setSelectedId(selectedAccount.id);
-      } catch (error) {
-        if (process.env.NODE_ENV !== 'test') {
-          console.warn('Unable to set active account', error);
-        }
-      }
-    },
-    [accountsWithProduct],
-  );
+  const setActiveAccountId = useCallback(async (accountId: string) => {
+    setSelectedId(accountId);
+  }, []);
 
   const refetch = useCallback(async () => {
     return accountsResult.refetch();


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
- Clear the pending invite status as soon as we've accepted the invite to prevent repeated attempts at accepting the invite. I've seen this manifest when setActiveAccountId fails to set the new account.
- Remove the check that only allows accounts returned from the API to be set from setActiveAccountId. We are hitting a race condition here and this check is resulting in quite a bit of pain. The risk of allowing the setting of an invalid account is low to begin with and any inappropriate account headers sent will be rejected by the API.
