### PR TITLE
Add an Invalidate Today Tasks Hook

### DIFF
--- a/src/components/TodayBadge.tsx
+++ b/src/components/TodayBadge.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { Badge } from 'react-native-paper';
 import { isConsentTask, useTodayTasks } from '../hooks/todayTile/useTodayTasks';
 import { t } from 'i18next';
-import { useFocusEffect } from '@react-navigation/native';
 
 const TodayBadge = () => {
-  const { newTasks, incompleteActivitiesCount, refetch } = useTodayTasks();
-  useFocusEffect(refetch);
+  const { newTasks, incompleteActivitiesCount } = useTodayTasks();
 
   const filteredTasks = newTasks.filter((task) => {
     return (

--- a/src/components/tiles/TilesList.tsx
+++ b/src/components/tiles/TilesList.tsx
@@ -57,7 +57,10 @@ export function TilesList({ navigation, styles: instanceStyles }: Props) {
     if (!todayTile) {
       return;
     }
-    navigation.navigate('Home/AuthedAppTile', { appTile: todayTile });
+    navigation.navigate('Home/AuthedAppTile', {
+      appTile: todayTile,
+      refreshTodayCountOnRemove: true,
+    });
   }, [navigation, todayTile]);
 
   return (

--- a/src/hooks/todayTile/useTodayTasks.tsx
+++ b/src/hooks/todayTile/useTodayTasks.tsx
@@ -2,15 +2,36 @@ import { useCallback } from 'react';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { gql } from 'graphql-request';
 import { useActiveAccount } from '../useActiveAccount';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useActiveProject } from '../useActiveProject';
-import { useRestQuery } from '../rest-api';
+import { useRestQuery, useRestCache } from '../rest-api';
 import { ConsentTask, SurveyResponse } from './types';
 
 export type TodayTask = SurveyResponse | ConsentTask;
 export function isConsentTask(value: TodayTask): value is ConsentTask {
   return !!(value as ConsentTask).form;
 }
+
+export const useInvalidateTodayCountCache = () => {
+  const restCache = useRestCache();
+  const queryClient = useQueryClient();
+
+  // We wait 3.5 seconds by default to give the backend a chance to update
+  return useCallback(
+    (delay = 3500) => {
+      setTimeout(() => {
+        console.log('Fetch with delay', delay);
+        restCache.invalidateQueries({
+          'GET /v1/consent/directives/me': 'all',
+          'GET /v1/survey/projects/:projectId/responses': 'all',
+        });
+
+        queryClient.refetchQueries(['getIncompleteActivitiesCount']);
+      }, delay);
+    },
+    [restCache, queryClient],
+  );
+};
 
 const useConsentTasks = () => {
   const { activeProject } = useActiveProject();
@@ -109,6 +130,8 @@ export const useTodayTasks = () => {
     ...inProgressConsentTasks,
     ...inProgressSurveyTasks,
   ] as TodayTask[];
+
+  console.log(newTasks);
 
   return {
     loading: loadingConsents || loadingSurveys || isInitialLoading,

--- a/src/hooks/todayTile/useTodayTasks.tsx
+++ b/src/hooks/todayTile/useTodayTasks.tsx
@@ -20,7 +20,6 @@ export const useInvalidateTodayCountCache = () => {
   return useCallback(
     (delay = 3500) => {
       setTimeout(() => {
-        console.log('Fetch with delay', delay);
         restCache.invalidateQueries({
           'GET /v1/consent/directives/me': 'all',
           'GET /v1/survey/projects/:projectId/responses': 'all',
@@ -130,8 +129,6 @@ export const useTodayTasks = () => {
     ...inProgressConsentTasks,
     ...inProgressSurveyTasks,
   ] as TodayTask[];
-
-  console.log(newTasks);
 
   return {
     loading: loadingConsents || loadingSurveys || isInitialLoading,

--- a/src/navigators/HomeStack.tsx
+++ b/src/navigators/HomeStack.tsx
@@ -18,12 +18,14 @@ import { YoutubePlayerScreen } from '../screens/YoutubePlayerScreen';
 import { navigationScreenListeners } from '../hooks/useLogoHeaderOptions';
 import { DirectMessagesScreen } from '../screens/DirectMessagesScreen';
 import { MessageScreen } from '../screens/MessageScreen';
+import { useInvalidateTodayCountCache } from '../hooks/todayTile/useTodayTasks';
 
 const Stack = createNativeStackNavigator<HomeStackParamList>();
 
 export function HomeStack() {
   const { getAdditionalHomeScreens, logoHeaderConfig, CustomHomeScreen } =
     useDeveloperConfig();
+  const invalidateTodayTasksCache = useInvalidateTodayCountCache();
 
   return (
     <Stack.Navigator
@@ -32,7 +34,17 @@ export function HomeStack() {
     >
       <Stack.Screen name="Home" component={CustomHomeScreen || HomeScreen} />
       <Stack.Screen name="Home/AppTile" component={AppTileScreen} />
-      <Stack.Screen name="Home/AuthedAppTile" component={AuthedAppTileScreen} />
+      <Stack.Screen
+        name="Home/AuthedAppTile"
+        component={AuthedAppTileScreen}
+        listeners={(props) => ({
+          beforeRemove: () => {
+            if (props.route.params.refreshTodayCountOnRemove) {
+              invalidateTodayTasksCache();
+            }
+          },
+        })}
+      />
       <Stack.Screen name="Home/CustomAppTile" component={CustomAppTileScreen} />
       <Stack.Screen name="Home/TrackTile" component={TrackTileTrackerScreen} />
       <Stack.Screen

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -56,6 +56,7 @@ export type HomeStackParamList = {
   'Home/AuthedAppTile': {
     appTile: AppTile;
     searchParams?: { [key: string]: string };
+    refreshTodayCountOnRemove?: boolean;
   };
   'Home/CustomAppTile': { appTile: AppTile };
   'Home/Circle/Discussion': { circleTile: CircleTile };


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Switches the refetch tasks logic to use the route listeners based on a route param, removes useFocusEffect which caused  duplicate queries on load
  - Adds a specialized hook for invalidating the today tasks cache
  - Adds a delay so today activity interactions can settle on the backend before fetching the latest count (3.5 seconds worked well during my testing)
