### PR TITLE
Only Block Go Back for App Tiles

### DIFF
--- a/src/hooks/useHandleAppTileEvents.test.ts
+++ b/src/hooks/useHandleAppTileEvents.test.ts
@@ -368,7 +368,7 @@ describe('handleAppTileNavigationStateChange', () => {
     expect(handler).toBeDefined();
 
     act(() => {
-      handler({ preventDefault });
+      handler({ preventDefault, data: { action: { type: 'GO_BACK' } } });
     });
 
     expect(preventDefault).toHaveBeenCalled();

--- a/src/hooks/useHandleAppTileEvents.ts
+++ b/src/hooks/useHandleAppTileEvents.ts
@@ -73,7 +73,7 @@ export const useHandleAppTileEvents = (webView: WebView | null = null) => {
 
   useEffect(() => {
     const listener: BeforeRemoveListener = (e) => {
-      if (blockGoBack) {
+      if (blockGoBack && e.data.action.type === 'GO_BACK') {
         e.preventDefault();
         webView?.goBack();
       }


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Before, all stack actions were blocked if the app tile had navigated
  - After, only go back actions will be prevented if the app tile has navigated

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/82a3abbe-92b8-428f-a3ed-bc080898ce87" />
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/897ae543-cb9f-4e29-81d8-6802d03842fc" />
</table>
