### PR TITLE
fix: Don't Show Auth Error on User Cancel

### DIFF
--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -33,7 +33,10 @@ export const LoginScreen: FC = () => {
 
   const onFail = (error: any) => {
     const errorString: string = error.toString();
-    if (errorString.includes('User cancelled flow')) {
+    if (
+      errorString.includes('User cancelled flow') ||
+      errorString.includes('org.openid.appauth.general error -3') // User Cancelled Flow https://github.com/openid/AppAuth-iOS/blob/master/Source/AppAuthCore/OIDError.h#L103
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - When a user cancels the flow, don't show an error on the homescreen

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

https://github.com/lifeomic/react-native-sdk/assets/2295908/c33a826f-94fb-487d-bffb-d3e296c09aa3