### PR TITLE
fix: use incognito prop for webview

### DIFF
--- a/src/screens/AuthedAppTileScreen.tsx
+++ b/src/screens/AuthedAppTileScreen.tsx
@@ -121,6 +121,7 @@ export const AuthedAppTileScreen = ({
       source={source}
       ref={webViewRef}
       cacheEnabled={false}
+      incognito={true}
       onMessage={handleAppTileMessage}
       onNavigationStateChange={handleAppTileNavigationStateChange}
       onLoad={handlePageLoaded}


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
Supply an `incognito={true}` prop the webview for app tiles. This will prevent them from excessively caching.