### PR TITLE
Fix Login Screen Tests

### DIFF
--- a/src/screens/LoginScreen.test.tsx
+++ b/src/screens/LoginScreen.test.tsx
@@ -99,6 +99,7 @@ describe('LoginScreen', () => {
     expect(
       findByText('We encountered an error trying to log you in.'),
     ).toBeDefined();
+    oAuthLoginButtonSpy.mockRestore();
   });
 
   const NON_ERRORING_FAILURE_MESSAGES = [
@@ -125,6 +126,7 @@ describe('LoginScreen', () => {
       });
 
       expect(queryByText('Authentication Error')).toBeNull();
+      oAuthLoginButtonSpy.mockRestore();
     },
   );
 });

--- a/src/screens/LoginScreen.test.tsx
+++ b/src/screens/LoginScreen.test.tsx
@@ -27,22 +27,6 @@ const useDeveloperConfigMock = useDeveloperConfig as jest.Mock;
 const useStylesMock = useStyles as jest.Mock;
 const usePendingInviteMock = usePendingInvite as jest.Mock;
 
-beforeEach(() => {
-  useStylesMock.mockReturnValue({
-    styles: {
-      containerView: {},
-    },
-  });
-
-  useDeveloperConfigMock.mockReturnValue({
-    renderCustomLoginScreen: null,
-  });
-
-  usePendingInviteMock.mockReturnValue({
-    inviteParams: undefined,
-  });
-});
-
 const loginScreenInContext = (
   <PaperProvider>
     <LoginScreen />
@@ -50,6 +34,23 @@ const loginScreenInContext = (
 );
 
 describe('LoginScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    useStylesMock.mockReturnValue({
+      styles: {
+        containerView: {},
+      },
+    });
+
+    useDeveloperConfigMock.mockReturnValue({
+      renderCustomLoginScreen: null,
+    });
+
+    usePendingInviteMock.mockReturnValue({
+      inviteParams: undefined,
+    });
+  });
   it('renders correctly', () => {
     const { getByText } = render(loginScreenInContext);
 
@@ -99,7 +100,6 @@ describe('LoginScreen', () => {
     expect(
       findByText('We encountered an error trying to log you in.'),
     ).toBeDefined();
-    oAuthLoginButtonSpy.mockRestore();
   });
 
   const NON_ERRORING_FAILURE_MESSAGES = [
@@ -126,7 +126,6 @@ describe('LoginScreen', () => {
       });
 
       expect(queryByText('Authentication Error')).toBeNull();
-      oAuthLoginButtonSpy.mockRestore();
     },
   );
 });


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - After https://github.com/lifeomic/react-native-sdk/pull/404 we were running into https://github.com/jestjs/jest/issues/6434#issuecomment-525576660. The comment indicated adding `jest.useFakeTimers()` to a beforeEach for all tests. 