### PR TITLE
Move LoggedInProviders back to RootProviders

### DIFF
--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -12,6 +12,7 @@ import { NoInternetToastProvider } from '../hooks/NoInternetToastProvider';
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ThemedNavigationContainer } from './ThemedNavigationContainer';
+import { LoggedInProviders } from './LoggedInProviders';
 const queryClient = new QueryClient();
 
 export function RootProviders({
@@ -35,7 +36,7 @@ export function RootProviders({
                     <ActionSheetProvider>
                       <SafeAreaProvider>
                         <ThemedNavigationContainer>
-                          {children}
+                          <LoggedInProviders>{children}</LoggedInProviders>
                         </ThemedNavigationContainer>
                       </SafeAreaProvider>
                     </ActionSheetProvider>

--- a/src/navigators/RootStack.tsx
+++ b/src/navigators/RootStack.tsx
@@ -3,7 +3,6 @@ import { t } from 'i18next';
 import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
 import { useAuth } from '../hooks';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { LoggedInProviders } from '../common/LoggedInProviders';
 import { LoginScreen } from '../screens/LoginScreen';
 import { NotLoggedInRootParamList } from './types';
 import { LoggedInStack } from './LoggedInStack';
@@ -19,11 +18,7 @@ export function RootStack() {
   }
 
   if (isLoggedIn) {
-    return (
-      <LoggedInProviders>
-        <LoggedInStack />
-      </LoggedInProviders>
-    );
+    return <LoggedInStack />;
   }
 
   const Stack = createNativeStackNavigator<NotLoggedInRootParamList>();


### PR DESCRIPTION
## Changes
<!-- list your changes here -->

Injecting custom providers used to be as simple as putting them underneath RootProviders but many hooks are no longer available in RootProviders. This was caused by a refactor to separate hooks and screens that require authentication from unauthenticated hooks and screens. Splitting them out solved a number of issues including premature API requests but resulted in loosing access to the authenticated hooks within injected custom providers.

The issues that the original refactor hoped to solve for were achieved by splitting out the LoggedInStack from the RootStack and moving the providers to the LoggedInStack and out of the RootProviders was most likely unnecessary. 

Although the providers contained within LoggedInProviders could have been moved directly back into RootProviders I've opted to keep them in their own file. I believe there is still a benefit to having them organized this way so a developer can easily discern providers that require auth or not.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->