### PR TITLE
FLME-278: add basic FHIR types to the useRest hooks

### DIFF
--- a/src/types/fhir-api-types.ts
+++ b/src/types/fhir-api-types.ts
@@ -1,0 +1,70 @@
+import {
+  Appointment,
+  Bundle,
+  Observation,
+  Patient,
+  Questionnaire,
+  QuestionnaireResponse,
+} from 'fhir/r3';
+
+/**
+ * Add entries to this type to support them in the hooks.
+ */
+type FhirResourcesByName = {
+  Patient: Patient;
+  Observation: Observation;
+  Questionnaire: Questionnaire;
+  QuestionnaireResponse: QuestionnaireResponse;
+  Appointment: Appointment;
+};
+
+/**
+ * Add any globally-supported search params here.
+ *
+ * string and number are the only supported value types.
+ */
+type BaseSearchParams = {
+  _tag?: string;
+  pageSize?: number;
+};
+
+/**
+ * Add resource-specific search params here.
+ */
+type AdditionalSearchParamsByName = {
+  Appointment: {
+    patient?: string;
+    status?: Appointment['status'];
+  };
+};
+
+type SearchParamsForResourceType<Name extends keyof FhirResourcesByName> =
+  Name extends keyof AdditionalSearchParamsByName
+    ? AdditionalSearchParamsByName[Name] & BaseSearchParams
+    : BaseSearchParams;
+
+export type FhirAPIEndpoints = {
+  // POST /<resource>
+  [Name in keyof FhirResourcesByName as `POST /v1/fhir/dstu3/${Name}`]: {
+    Request: FhirResourcesByName[Name];
+    Response: FhirResourcesByName[Name];
+  };
+} & {
+  // PUT /<resource>/:id
+  [Name in keyof FhirResourcesByName as `PUT /v1/fhir/dstu3/${Name}/:id`]: {
+    Request: FhirResourcesByName[Name] & { id: string };
+    Response: FhirResourcesByName[Name];
+  };
+} & {
+  // GET /<resource>/:id
+  [Name in keyof FhirResourcesByName as `GET /v1/fhir/dstu3/${Name}/:id`]: {
+    Request: {};
+    Response: FhirResourcesByName[Name];
+  };
+} & {
+  // GET /<resource>
+  [Name in keyof FhirResourcesByName as `GET /v1/fhir/dstu3/${Name}`]: {
+    Request: SearchParamsForResourceType<Name>;
+    Response: Bundle<FhirResourcesByName[Name]>;
+  };
+};

--- a/src/types/rest-types.ts
+++ b/src/types/rest-types.ts
@@ -1,6 +1,7 @@
 import { ConsentDirective, SurveyResponse } from '../hooks/todayTile/types';
 import { AppConfig } from '../hooks/useAppConfig';
 import { ProjectInvite, User } from '../types';
+import { FhirAPIEndpoints } from './fhir-api-types';
 
 export interface Account {
   id: string;
@@ -19,7 +20,7 @@ export interface Account {
  *
  * It is structured in the format specified by [one-query](https://github.com/lifeomic/one-query).
  */
-export type RestAPIEndpoints = {
+export type RestAPIEndpoints = FhirAPIEndpoints & {
   'GET /v1/accounts': {
     Request: {};
     Response: {


### PR DESCRIPTION
## Changes
This PR adds support for interacting with the FHIR API fully type-safe via the existing `one-query` hooks. It puts in place a small system that allows for easily adding new resource types.

## Screenshots
This video showcases the developer experience.

https://github.com/lifeomic/react-native-sdk/assets/14932834/8e945529-7f1f-42cf-9914-c309446650b3

