### PR TITLE
feat: simplify useAppConfig by using one-query hook

### DIFF
--- a/example/storybook/helpers/DataProviderDecorator.tsx
+++ b/example/storybook/helpers/DataProviderDecorator.tsx
@@ -6,9 +6,17 @@ import { HttpClientContextProvider } from '../../../src/hooks/useHttpClient';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ActiveAccountContext, ActiveProjectContext } from '../../../src/hooks';
 
-export const DataProviderDecorator = (
-  builder?: (adapter: MockAdapter) => void,
-) => {
+export type DataOverrideProviderProps = {
+  children: React.ReactNode;
+  builder?: (adapter: MockAdapter) => void;
+};
+
+const mockQueryClient = new QueryClient();
+
+export const DataOverrideProvider: React.FC<DataOverrideProviderProps> = ({
+  builder,
+  children,
+}) => {
   const axiosInstance = axios.create();
   const mock = new MockAdapter(axiosInstance);
 
@@ -16,35 +24,41 @@ export const DataProviderDecorator = (
     builder(mock);
   }
 
-  const EnvironmentDecorator: DecoratorFunction<any> = (StoryFn, storyCtx) => {
-    return (
-      <ActiveAccountContext.Provider
+  return (
+    <ActiveAccountContext.Provider
+      value={
+        {
+          accountHeaders: {},
+        } as any
+      }
+    >
+      <ActiveProjectContext.Provider
         value={
           {
-            accountHeaders: {},
+            activeProject: {
+              id: 'mockProject',
+              name: 'mockProject',
+            },
+            activeSubjectId: 'mockSubjectId',
           } as any
         }
       >
-        <ActiveProjectContext.Provider
-          value={
-            {
-              activeProject: {
-                id: 'mockProject',
-                name: 'mockProject',
-              },
-              activeSubjectId: 'mockSubjectId',
-            } as any
-          }
-        >
-          <QueryClientProvider client={new QueryClient()}>
-            <HttpClientContextProvider injectedAxiosInstance={axiosInstance}>
-              {StoryFn(storyCtx)}
-            </HttpClientContextProvider>
-          </QueryClientProvider>
-        </ActiveProjectContext.Provider>
-      </ActiveAccountContext.Provider>
+        <QueryClientProvider client={mockQueryClient}>
+          <HttpClientContextProvider injectedAxiosInstance={axiosInstance}>
+            {children}
+          </HttpClientContextProvider>
+        </QueryClientProvider>
+      </ActiveProjectContext.Provider>
+    </ActiveAccountContext.Provider>
+  );
+};
+
+export const DataProviderDecorator =
+  (builder?: (adapter: MockAdapter) => void): DecoratorFunction<any> =>
+  (StoryFn, storyCtx) => {
+    return (
+      <DataOverrideProvider builder={builder}>
+        {StoryFn(storyCtx)}
+      </DataOverrideProvider>
     );
   };
-
-  return EnvironmentDecorator;
-};

--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -9,7 +9,6 @@ import {
   LogoHeader,
   BrandConfigProvider,
   getDefaultTabs,
-  AppConfigContext,
 } from '../../../../src';
 import { withKnobs, color, boolean, number } from '@storybook/addon-knobs';
 import Color from 'color';
@@ -18,6 +17,7 @@ import { Home, Bell, Settings, Menu } from '@lifeomic/chromicons-native';
 import { HelloWorldScreen } from '../../../src/screens/HelloWorldScreen';
 import { IconButton } from 'react-native-paper';
 import { navigationRef } from '../../../../src/common/ThemedNavigationContainer';
+import { DataOverrideProvider } from 'example/storybook/helpers/DataProviderDecorator';
 
 storiesOf('Example App', module)
   .addDecorator(withKnobs)
@@ -258,9 +258,9 @@ storiesOf('Example App', module)
       }}
     >
       <RootProviders authConfig={authConfig}>
-        <AppConfigContext.Provider
-          value={{
-            data: {
+        <DataOverrideProvider
+          builder={(mock) => {
+            mock.onGet().reply(200, {
               homeTab: {
                 tiles: ['myDataTile'],
                 myDataSettings: {
@@ -330,14 +330,11 @@ storiesOf('Example App', module)
                   },
                 ],
               },
-            },
-            isLoading: false,
-            isFetched: true,
-            error: undefined,
+            });
           }}
         >
           <RootStack />
-        </AppConfigContext.Provider>
+        </DataOverrideProvider>
       </RootProviders>
     </DeveloperConfigProvider>
   ));

--- a/example/storybook/stories/SettingsScreen/SettingsScreen.stories.tsx
+++ b/example/storybook/stories/SettingsScreen/SettingsScreen.stories.tsx
@@ -2,37 +2,28 @@ import React from 'react';
 
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
-import {
-  AppConfigContext,
-  DeveloperConfigProvider,
-  SettingsScreen,
-} from '../../../../src';
+import { DeveloperConfigProvider, SettingsScreen } from '../../../../src';
 import { SafeView } from '../../helpers/SafeView';
 import { openURL } from '../../../../src/common/urls';
 import { DataProviderDecorator } from '../../helpers/DataProviderDecorator';
 
 const appConfig = {
-  data: {
-    support: {
-      url: 'https://lifeomic.com',
-    },
+  support: {
+    url: 'https://lifeomic.com',
   },
-  isLoading: false,
-  isFetched: true,
-  error: undefined,
 };
 
 storiesOf('SettingsScreen', module)
-  .addDecorator(DataProviderDecorator())
+  .addDecorator(
+    DataProviderDecorator((mock) => mock.onGet().reply(200, appConfig)),
+  )
   .add('default', () => (
-    <AppConfigContext.Provider value={appConfig}>
-      <SafeView>
-        <SettingsScreen
-          navigation={{ navigate: action('navigate') } as any}
-          route={{} as any}
-        />
-      </SafeView>
-    </AppConfigContext.Provider>
+    <SafeView>
+      <SettingsScreen
+        navigation={{ navigate: action('navigate') } as any}
+        route={{} as any}
+      />
+    </SafeView>
   ))
   .add('modify menu items', () => (
     <DeveloperConfigProvider
@@ -52,13 +43,11 @@ storiesOf('SettingsScreen', module)
         },
       }}
     >
-      <AppConfigContext.Provider value={appConfig}>
-        <SafeView>
-          <SettingsScreen
-            navigation={{ navigate: action('navigate') } as any}
-            route={{} as any}
-          />
-        </SafeView>
-      </AppConfigContext.Provider>
+      <SafeView>
+        <SettingsScreen
+          navigation={{ navigate: action('navigate') } as any}
+          route={{} as any}
+        />
+      </SafeView>
     </DeveloperConfigProvider>
   ));

--- a/src/common/LoggedInProviders.tsx
+++ b/src/common/LoggedInProviders.tsx
@@ -11,7 +11,6 @@ import { PushNotificationsProvider } from '../hooks/usePushNotifications';
 import { CircleTileContextProvider } from '../hooks/Circles/useActiveCircleTile';
 import { OnboardingCourseContextProvider } from '../hooks/useOnboardingCourse';
 import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
-import { AppConfigContextProvider } from '../hooks/useAppConfig';
 
 export const LoggedInProviders = ({
   children,
@@ -22,23 +21,21 @@ export const LoggedInProviders = ({
   return (
     <ActiveAccountContextProvider>
       <ActiveProjectContextProvider>
-        <AppConfigContextProvider>
-          <TrackTileProvider>
-            <WearableLifecycleProvider>
-              <CircleTileContextProvider>
-                <OnboardingCourseContextProvider>
-                  <PushNotificationsProvider config={pushNotificationsConfig}>
-                    <NotificationsManagerProvider>
-                      {children}
-                    </NotificationsManagerProvider>
-                  </PushNotificationsProvider>
-                  <CreateEditPostModal />
-                  <Toast />
-                </OnboardingCourseContextProvider>
-              </CircleTileContextProvider>
-            </WearableLifecycleProvider>
-          </TrackTileProvider>
-        </AppConfigContextProvider>
+        <TrackTileProvider>
+          <WearableLifecycleProvider>
+            <CircleTileContextProvider>
+              <OnboardingCourseContextProvider>
+                <PushNotificationsProvider config={pushNotificationsConfig}>
+                  <NotificationsManagerProvider>
+                    {children}
+                  </NotificationsManagerProvider>
+                </PushNotificationsProvider>
+                <CreateEditPostModal />
+                <Toast />
+              </OnboardingCourseContextProvider>
+            </CircleTileContextProvider>
+          </WearableLifecycleProvider>
+        </TrackTileProvider>
       </ActiveProjectContextProvider>
     </ActiveAccountContextProvider>
   );

--- a/src/hooks/useAppConfig.test.tsx
+++ b/src/hooks/useAppConfig.test.tsx
@@ -5,6 +5,7 @@ import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { HttpClientContextProvider } from './useHttpClient';
 import { createRestAPIMock } from '../test-utils/rest-api-mocking';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const api = createRestAPIMock();
 
@@ -28,7 +29,9 @@ const mockAppTile = (id: string): AppTile => ({
 const renderHookInContext = async () => {
   return renderHook(() => useAppConfig(), {
     wrapper: ({ children }) => (
-      <HttpClientContextProvider>{children}</HttpClientContextProvider>
+      <QueryClientProvider client={new QueryClient()}>
+        <HttpClientContextProvider>{children}</HttpClientContextProvider>
+      </QueryClientProvider>
     ),
   });
 };

--- a/src/hooks/useAppConfig.test.tsx
+++ b/src/hooks/useAppConfig.test.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
-import {
-  AppConfig,
-  useAppConfig,
-  AppTile,
-  AppConfigContextProvider,
-} from './useAppConfig';
+import { AppConfig, useAppConfig, AppTile } from './useAppConfig';
 import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { HttpClientContextProvider } from './useHttpClient';
@@ -33,9 +28,7 @@ const mockAppTile = (id: string): AppTile => ({
 const renderHookInContext = async () => {
   return renderHook(() => useAppConfig(), {
     wrapper: ({ children }) => (
-      <HttpClientContextProvider>
-        <AppConfigContextProvider>{children}</AppConfigContextProvider>
-      </HttpClientContextProvider>
+      <HttpClientContextProvider>{children}</HttpClientContextProvider>
     ),
   });
 };

--- a/src/hooks/useAppConfig.test.tsx
+++ b/src/hooks/useAppConfig.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { AppConfig, useAppConfig, AppTile } from './useAppConfig';
+import { useAppConfig, AppTile } from './useAppConfig';
 import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { HttpClientContextProvider } from './useHttpClient';
@@ -36,19 +36,11 @@ const renderHookInContext = async () => {
   });
 };
 
-const configWith = (homeTab: AppConfig['homeTab']) => {
-  api.mock(
-    'GET /v1/life-research/projects/:projectId/app-config',
-    jest.fn().mockReturnValue({
-      status: 200,
-      data: { homeTab },
-    }),
-  );
-};
-
 beforeEach(() => {
   useActiveAccountMock.mockReturnValue({
-    account: 'acct1',
+    accountHeaders: {
+      'LifeOmic-Account': 'acct1',
+    },
   });
   useActiveProjectMock.mockReturnValue({
     activeProject: { id: 'projectId' },
@@ -57,7 +49,14 @@ beforeEach(() => {
 
 test('configured appTiles are returned', async () => {
   const mockAppTiles = ['appTile-1', 'appTile-2', 'appTile-3'].map(mockAppTile);
-  configWith({ appTiles: mockAppTiles });
+  api.mock('GET /v1/life-research/projects/:projectId/app-config', {
+    status: 200,
+    data: {
+      homeTab: {
+        appTiles: mockAppTiles,
+      },
+    },
+  });
   const { result } = await renderHookInContext();
 
   await waitFor(() => {

--- a/src/hooks/useAppConfig.tsx
+++ b/src/hooks/useAppConfig.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from 'react';
 import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { Trace } from '../components/MyData/LineChart/TraceLine';
 import { SvgProps } from 'react-native-svg';
 import { useRestQuery } from './rest-api';
+import { appConfigNotifier } from '../common/AppConfigNotifier';
 
 export interface AppTile {
   id: string;
@@ -98,7 +100,8 @@ export interface AppConfig {
 export const useAppConfig = () => {
   const { accountHeaders } = useActiveAccount();
   const { activeProject } = useActiveProject();
-  return useRestQuery(
+
+  const query = useRestQuery(
     'GET /v1/life-research/projects/:projectId/app-config',
     { projectId: activeProject?.id! },
     {
@@ -108,4 +111,10 @@ export const useAppConfig = () => {
       },
     },
   );
+
+  useEffect(() => {
+    appConfigNotifier.emit(query.data);
+  }, [query.data]);
+
+  return query;
 };

--- a/src/hooks/useAppConfig.tsx
+++ b/src/hooks/useAppConfig.tsx
@@ -1,10 +1,8 @@
-import React, { createContext, useContext, useRef, useState } from 'react';
 import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { Trace } from '../components/MyData/LineChart/TraceLine';
-import { useHttpClient } from './useHttpClient';
-import { appConfigNotifier } from '../common/AppConfigNotifier';
 import { SvgProps } from 'react-native-svg';
+import { useRestQuery } from './rest-api';
 
 export interface AppTile {
   id: string;
@@ -97,76 +95,17 @@ export interface AppConfig {
   };
 }
 
-type AppConfigContextProps = {
-  data: AppConfig | undefined;
-  isLoading: boolean | undefined;
-  isFetched: boolean | undefined;
-  error: any;
-};
-
-export const AppConfigContext = createContext<AppConfigContextProps>({
-  data: undefined,
-  isLoading: undefined,
-  isFetched: undefined,
-  error: undefined,
-});
-
-export const AppConfigContextProvider = ({
-  children,
-}: {
-  children?: React.ReactNode;
-}) => {
-  const { accountHeaders, account } = useActiveAccount();
-  const { activeProject } = useActiveProject();
-  const { apiClient } = useHttpClient();
-  const [appConfig, setAppConfig] = useState<AppConfig | undefined>(undefined);
-  const isLoading = useRef<boolean | undefined>(undefined);
-  const error = useRef<undefined>(undefined);
-
-  if (!appConfig && !!activeProject?.id && !!account) {
-    isLoading.current = true;
-    apiClient
-      .request(
-        'GET /v1/life-research/projects/:projectId/app-config',
-        {
-          projectId: activeProject?.id!,
-        },
-        { headers: accountHeaders },
-      )
-      .then((res) => {
-        isLoading.current = false;
-        error.current = undefined;
-        setAppConfig(res.data);
-        appConfigNotifier.emit(res.data);
-      })
-      .catch((err) => {
-        isLoading.current = false;
-        error.current = err;
-        setAppConfig(undefined);
-        appConfigNotifier.emit(undefined);
-      });
-  }
-
-  return (
-    <AppConfigContext.Provider
-      value={{
-        data: appConfig,
-        isLoading: isLoading.current,
-        error: error.current,
-        isFetched: !!appConfig,
-      }}
-    >
-      {children}
-    </AppConfigContext.Provider>
-  );
-};
-
 export const useAppConfig = () => {
-  const appConfigContext = useContext(AppConfigContext);
-  if (!appConfigContext) {
-    throw new Error(
-      'No AppConfigContext.Provider found when calling useAppConfig.',
-    );
-  }
-  return appConfigContext;
+  const { accountHeaders } = useActiveAccount();
+  const { activeProject } = useActiveProject();
+  return useRestQuery(
+    'GET /v1/life-research/projects/:projectId/app-config',
+    { projectId: activeProject?.id! },
+    {
+      enabled: !!activeProject && !!accountHeaders,
+      axios: {
+        headers: accountHeaders,
+      },
+    },
+  );
 };

--- a/src/screens/AppTileScreen.test.tsx
+++ b/src/screens/AppTileScreen.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import { WebView } from 'react-native-webview';
 import { AppTileScreen } from './AppTileScreen';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 jest.mock('react-native-webview', () => ({
   WebView: jest.fn().mockReturnValue(<></>),
@@ -36,7 +37,11 @@ beforeEach(() => {
 });
 
 test('renders webview with source prop', () => {
-  render(<AppTileScreen navigation={navigation} route={route} />);
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <AppTileScreen navigation={navigation} route={route} />
+    </QueryClientProvider>,
+  );
   expect(webviewMock.mock.calls[0][0]).toMatchObject({
     source: { uri: exampleAppTile.source.url },
   });


### PR DESCRIPTION
## Changes
The `useAppConfig` hook currently uses a provider + custom logic for fetching -- we can achieve the same result with less code by just using `useRestQuery`.

I had to make a few other changes in response to the refactor. I explain them each below.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->