### PR TITLE
Support typed mocking in storybook

### DIFF
--- a/example/storybook/helpers/DataProviderDecorator.tsx
+++ b/example/storybook/helpers/DataProviderDecorator.tsx
@@ -10,7 +10,7 @@ export const DataProviderDecorator = (
   builder?: (adapter: MockAdapter) => void,
 ) => {
   const axiosInstance = axios.create();
-  const mock = new MockAdapter(axiosInstance);
+  const mock = new MockAdapter(axiosInstance, { onNoMatch: 'passthrough' });
 
   if (builder) {
     builder(mock);
@@ -21,7 +21,12 @@ export const DataProviderDecorator = (
       <ActiveAccountContext.Provider
         value={
           {
-            accountHeaders: {},
+            account: {
+              id: 'mockaccount',
+            },
+            accountHeaders: {
+              'LifeOmic-Account': 'mockaccount',
+            },
           } as any
         }
       >

--- a/example/storybook/helpers/api-mocking.ts
+++ b/example/storybook/helpers/api-mocking.ts
@@ -1,0 +1,32 @@
+import { setupServer } from 'msw/native';
+import { createAPIMocker } from '@lifeomic/one-query/test-utils';
+import { RestAPIEndpoints } from '../../../src/types/rest-types';
+import { addDecorator } from '@storybook/react-native';
+
+const server = setupServer();
+
+const mocker = createAPIMocker<RestAPIEndpoints>(
+  server,
+  'https://api.us.lifeomic.com',
+);
+
+declare module '@storybook/addons' {
+  interface Parameters {
+    mockAPICalls?: (mock: typeof mocker) => void;
+  }
+}
+
+export const initializeApiMocking = () => {
+  // Do not warn or error out if a non-mocked request happens.
+  // If we don't use this, Storybook will be spammy about requests made to
+  // fetch the JS bundle etc.
+  server.listen({ onUnhandledRequest: 'bypass' });
+
+  addDecorator((storyFn, { parameters }) => {
+    mocker.reset();
+    if (parameters.mockAPICalls) {
+      parameters.mockAPICalls(mocker);
+    }
+    return storyFn();
+  });
+};

--- a/example/storybook/index.tsx
+++ b/example/storybook/index.tsx
@@ -9,11 +9,15 @@ import {
 } from '@storybook/react-native';
 import { withKnobs } from '@storybook/addon-knobs';
 import { BrandConfigProvider } from '../../src';
+import { initializeApiMocking } from './helpers/api-mocking';
 
 import './rn-addons';
 
 // LifeOmic app initialization
 init();
+
+// Set up nice API mocking.
+initializeApiMocking();
 
 // enables knobs for all stories
 addDecorator(withKnobs);

--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -9,7 +9,6 @@ import {
   LogoHeader,
   BrandConfigProvider,
   getDefaultTabs,
-  AppConfigContext,
 } from '../../../../src';
 import { withKnobs, color, boolean, number } from '@storybook/addon-knobs';
 import Color from 'color';
@@ -242,96 +241,97 @@ storiesOf('Example App', module)
       </DeveloperConfigProvider>
     );
   })
-  .add('With App Config Configured Tabs', () => (
-    <DeveloperConfigProvider
-      developerConfig={{
-        apiBaseURL: baseURL,
-        CustomStacks: {
-          CustomTabStack: () => (
-            <View style={{ flex: 1, justifyContent: 'center' }}>
-              <Text style={{ textAlign: 'center' }}>
-                {'Custom Screen\nCould be a whole @react-navigation/stack'}
-              </Text>
-            </View>
-          ),
-        },
-      }}
-    >
-      <RootProviders authConfig={authConfig}>
-        <AppConfigContext.Provider
-          value={{
-            data: {
-              homeTab: {
-                tiles: ['myDataTile'],
-                myDataSettings: {
-                  components: [],
-                },
-              },
-              tabsConfig: {
-                tabs: [
-                  {
-                    name: 'Home',
-                    type: 'home',
-                    icon: 'home',
-                  },
-                  {
-                    name: 'Notifications',
-                    type: 'notifications',
-                    icon: 'bell',
-                  },
-                  {
-                    name: 'Settings',
-                    type: 'settings',
-                    icon: 'settings',
-                  },
-                  {
-                    name: 'Custom',
-                    type: 'customTab',
-                    icon: 'zap',
-                    initialParams: {
-                      name: 'CustomTabStack',
-                    },
-                  },
-                  {
-                    name: 'Authed App Tile',
-                    type: 'appTile',
-                    icon: 'user-key',
-                    initialParams: {
-                      appTile: {
-                        title: 'Authed App Tile',
-                        source: {
-                          url: 'https://lifeapplets.dev.lifeomic.com/my-data/#/',
-                        },
-                        callbackUrls: [
-                          'https://lifeapplets.dev.lifeomic.com/my-data/',
-                        ],
-                        clientId: 'example', // requires real client id to work
-                      },
-                    },
-                  },
-                  {
-                    name: 'App tile',
-                    type: 'appTile',
-                    icon: 'user',
-                    initialParams: {
-                      appTile: {
-                        title: 'App Tile',
-                        source: {
-                          url: 'https://wikipedia.com',
-                        },
-                      },
-                    },
-                  },
-                ],
+  .add(
+    'With App Config Configured Tabs',
+    () => (
+      <DeveloperConfigProvider
+        developerConfig={{
+          apiBaseURL: baseURL,
+          CustomStacks: {
+            CustomTabStack: () => (
+              <View style={{ flex: 1, justifyContent: 'center' }}>
+                <Text style={{ textAlign: 'center' }}>
+                  {'Custom Screen\nCould be a whole @react-navigation/stack'}
+                </Text>
+              </View>
+            ),
+          },
+        }}
+      >
+        <RootProviders authConfig={authConfig}>
+          <RootStack />
+        </RootProviders>
+      </DeveloperConfigProvider>
+    ),
+    {
+      mockAPICalls: (api) =>
+        api.mock('GET /v1/life-research/projects/:projectId/app-config', {
+          status: 200,
+          data: {
+            homeTab: {
+              tiles: ['myDataTile'],
+              myDataSettings: {
+                components: [],
               },
             },
-            isLoading: false,
-            isFetched: true,
-            error: undefined,
-          }}
-        >
-          <RootStack />
-        </AppConfigContext.Provider>
-      </RootProviders>
-    </DeveloperConfigProvider>
-  ));
+            tabsConfig: {
+              tabs: [
+                {
+                  name: 'Home',
+                  type: 'home',
+                  icon: 'home',
+                },
+                {
+                  name: 'Notifications',
+                  type: 'notifications',
+                  icon: 'bell',
+                },
+                {
+                  name: 'Settings',
+                  type: 'settings',
+                  icon: 'settings',
+                },
+                {
+                  name: 'Custom',
+                  type: 'customTab',
+                  icon: 'zap',
+                  initialParams: {
+                    name: 'CustomTabStack',
+                  },
+                },
+                {
+                  name: 'Authed App Tile',
+                  type: 'appTile',
+                  icon: 'user-key',
+                  initialParams: {
+                    appTile: {
+                      title: 'Authed App Tile',
+                      source: {
+                        url: 'https://lifeapplets.dev.lifeomic.com/my-data/#/',
+                      },
+                      callbackUrls: [
+                        'https://lifeapplets.dev.lifeomic.com/my-data/',
+                      ],
+                      clientId: 'example', // requires real client id to work
+                    },
+                  },
+                },
+                {
+                  name: 'App tile',
+                  type: 'appTile',
+                  icon: 'user',
+                  initialParams: {
+                    appTile: {
+                      title: 'App Tile',
+                      source: {
+                        url: 'https://wikipedia.com',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }),
+    },
+  );

--- a/example/storybook/stories/SettingsScreen/SettingsScreen.stories.tsx
+++ b/example/storybook/stories/SettingsScreen/SettingsScreen.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import {
-  AppConfigContext,
+  AppConfigContextProvider,
   DeveloperConfigProvider,
   SettingsScreen,
 } from '../../../../src';
@@ -12,53 +12,68 @@ import { openURL } from '../../../../src/common/urls';
 import { DataProviderDecorator } from '../../helpers/DataProviderDecorator';
 
 const appConfig = {
-  data: {
-    support: {
-      url: 'https://lifeomic.com',
-    },
+  support: {
+    url: 'https://lifeomic.com',
   },
-  isLoading: false,
-  isFetched: true,
-  error: undefined,
 };
 
 storiesOf('SettingsScreen', module)
   .addDecorator(DataProviderDecorator())
-  .add('default', () => (
-    <AppConfigContext.Provider value={appConfig}>
-      <SafeView>
-        <SettingsScreen
-          navigation={{ navigate: action('navigate') } as any}
-          route={{} as any}
-        />
-      </SafeView>
-    </AppConfigContext.Provider>
-  ))
-  .add('modify menu items', () => (
-    <DeveloperConfigProvider
-      developerConfig={{
-        modifySettingScreenMenuItems(items) {
-          return items
-            .map((item) => ({
-              ...item,
-              title: `${item.title} - Modified`,
-            }))
-            .concat({
-              id: 'custom-menu-item',
-              title: 'Injected Menu Item',
-              action: () =>
-                openURL('https://github.com/lifeomic/react-native-sdk'),
-            });
-        },
-      }}
-    >
-      <AppConfigContext.Provider value={appConfig}>
+  .add(
+    'default',
+    () => (
+      <AppConfigContextProvider>
         <SafeView>
           <SettingsScreen
             navigation={{ navigate: action('navigate') } as any}
             route={{} as any}
           />
         </SafeView>
-      </AppConfigContext.Provider>
-    </DeveloperConfigProvider>
-  ));
+      </AppConfigContextProvider>
+    ),
+    {
+      mockAPICalls: (api) =>
+        api.mock('GET /v1/life-research/projects/:projectId/app-config', {
+          status: 200,
+          data: appConfig,
+        }),
+    },
+  )
+  .add(
+    'modify menu items',
+    () => (
+      <DeveloperConfigProvider
+        developerConfig={{
+          modifySettingScreenMenuItems(items) {
+            return items
+              .map((item) => ({
+                ...item,
+                title: `${item.title} - Modified`,
+              }))
+              .concat({
+                id: 'custom-menu-item',
+                title: 'Injected Menu Item',
+                action: () =>
+                  openURL('https://github.com/lifeomic/react-native-sdk'),
+              });
+          },
+        }}
+      >
+        <AppConfigContextProvider>
+          <SafeView>
+            <SettingsScreen
+              navigation={{ navigate: action('navigate') } as any}
+              route={{} as any}
+            />
+          </SafeView>
+        </AppConfigContextProvider>
+      </DeveloperConfigProvider>
+    ),
+    {
+      mockAPICalls: (api) =>
+        api.mock('GET /v1/life-research/projects/:projectId/app-config', {
+          status: 200,
+          data: appConfig,
+        }),
+    },
+  );

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "dependencies": {
     "@lifeomic/chromicons-native": "^2.16.1",
-    "@lifeomic/one-query": "^2.3.1",
+    "@lifeomic/one-query": "^3.0.0",
     "@types/fhir": "^0.0.36",
     "color": "^4.2.3",
     "d3-scale": "3.2.1",

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -54,6 +54,7 @@ export const ActiveAccountContextProvider = ({
   children,
   accountIdToSelect,
 }: {
+  fallback: React.ReactNode;
   children?: React.ReactNode;
   /** Force provider to select the available account
    * that matches the specified account id.

--- a/src/hooks/useHttpClient.tsx
+++ b/src/hooks/useHttpClient.tsx
@@ -48,7 +48,7 @@ export const HttpClientContextProvider = ({
   const { authResult, refreshForAuthFailure } = useAuth();
 
   const axiosInstance = injectedAxiosInstance || defaultAxiosInstance;
-  const apiClient = defaultAPIClientInstance;
+  const apiClient = new APIClient<RestAPIEndpoints>(axiosInstance);
 
   if (baseURL || !axiosInstance.defaults.baseURL) {
     axiosInstance.defaults.baseURL = baseURL || defaultBaseURL;

--- a/src/test-utils/rest-api-mocking.ts
+++ b/src/test-utils/rest-api-mocking.ts
@@ -1,6 +1,10 @@
+import { setupServer } from 'msw/node';
 import { createAPIMockingUtility } from '@lifeomic/one-query/test-utils';
 import { RestAPIEndpoints } from '../types/rest-types';
 
+const server = setupServer();
+server.listen({ onUnhandledRequest: 'error' });
 export const createRestAPIMock = createAPIMockingUtility<RestAPIEndpoints>({
+  server,
   baseUrl: 'https://api.us.lifeomic.com',
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,10 +1925,10 @@
   resolved "https://registry.yarnpkg.com/@lifeomic/eslint-plugin-i18next/-/eslint-plugin-i18next-2.0.1.tgz#a42dc7a810c83214b284963dcae4dffe217f8e16"
   integrity sha512-GU8m6m8w+BfSKPcuNl5eh+OVkaJeJqA1DqmnXZl05VqFYNInUcEVS3VwiCR6iwRHRvmyDu35TMZ29TR7iMX30A==
 
-"@lifeomic/one-query@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@lifeomic/one-query/-/one-query-2.3.1.tgz#0d34138c50f031f11aa1212710319a0118beb4a7"
-  integrity sha512-ELbMPxb0bYyYKIe1oWSX+4uEP33VOcdV1HrRVHHfLcIzsZXh3Stpn7ooKw0oHDU5cuOcuq0ni7hubgAoeVRagg==
+"@lifeomic/one-query@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lifeomic/one-query/-/one-query-3.0.0.tgz#d7014e548fba21a5b2a63f6f63a41e6249f21853"
+  integrity sha512-8DZ7up+77U3oM16livJWiojAg1CzWN/jxPOPdlNON+CYvGr1WMGIDjpBHHtDfW3jSWpPeae5fXJXAsf/AMxdzQ==
   dependencies:
     immer "^9.0.15"
     lodash "^4.17.21"


### PR DESCRIPTION
## Changes
This PR adds a utility to the Storybook for mocking API requests using the well-typed MSW utils provided by `one-query`.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->