### PR TITLE
feat!: Introduce an AccountClientProvider

### DIFF
--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -13,15 +13,25 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ThemedNavigationContainer } from './ThemedNavigationContainer';
 import { LoggedInProviders } from './LoggedInProviders';
+import { AccountClientProvider } from '../hooks/AccountClientProvider';
+
 const queryClient = new QueryClient();
+
+export type RootProvidersProps = {
+  authConfig: AuthConfiguration;
+  /**
+   * A loading UI to show while the app is initializing.
+   */
+  loading: React.ReactElement;
+
+  children?: React.ReactNode;
+};
 
 export function RootProviders({
   authConfig,
+  loading,
   children,
-}: {
-  authConfig: AuthConfiguration;
-  children?: React.ReactNode;
-}) {
+}: RootProvidersProps) {
   const { apiBaseURL, theme } = useDeveloperConfig();
 
   return (
@@ -29,21 +39,23 @@ export function RootProviders({
       <AuthContextProvider>
         <HttpClientContextProvider baseURL={apiBaseURL}>
           <GraphQLClientContextProvider baseURL={apiBaseURL}>
-            <InviteProvider>
-              <OAuthContextProvider authConfig={authConfig}>
-                <BrandConfigProvider theme={theme}>
-                  <NoInternetToastProvider>
-                    <ActionSheetProvider>
-                      <SafeAreaProvider>
-                        <ThemedNavigationContainer>
-                          <LoggedInProviders>{children}</LoggedInProviders>
-                        </ThemedNavigationContainer>
-                      </SafeAreaProvider>
-                    </ActionSheetProvider>
-                  </NoInternetToastProvider>
-                </BrandConfigProvider>
-              </OAuthContextProvider>
-            </InviteProvider>
+            <AccountClientProvider loading={loading}>
+              <InviteProvider>
+                <OAuthContextProvider authConfig={authConfig}>
+                  <BrandConfigProvider theme={theme}>
+                    <NoInternetToastProvider>
+                      <ActionSheetProvider>
+                        <SafeAreaProvider>
+                          <ThemedNavigationContainer>
+                            <LoggedInProviders>{children}</LoggedInProviders>
+                          </ThemedNavigationContainer>
+                        </SafeAreaProvider>
+                      </ActionSheetProvider>
+                    </NoInternetToastProvider>
+                  </BrandConfigProvider>
+                </OAuthContextProvider>
+              </InviteProvider>
+            </AccountClientProvider>
           </GraphQLClientContextProvider>
         </HttpClientContextProvider>
       </AuthContextProvider>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -24,3 +24,4 @@ export * from './useTheme';
 export * from './useUser';
 export * from './useWearables';
 export * from './useUnreadMessages';
+export * from './useAccountClient';

--- a/src/hooks/useAccountClient.tsx
+++ b/src/hooks/useAccountClient.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import axios, { AxiosInstance } from 'axios';
+import { useActiveAccount } from './useActiveAccount';
+import { useAuth } from './useAuth';
+import { useHttpClient } from './useHttpClient';
+
+export type AccountClient = {
+  /**
+   * An Axios instance that is authenticated to the LifeOmic REST API.
+   *
+   * This client has a built-in access token and `LifeOmic-Account` header.
+   */
+  http: AxiosInstance;
+};
+
+const _Context = React.createContext<AccountClient | undefined>(undefined);
+
+export type AccountClientProviderProps = {
+  /** A UI to show while the minimum data is loading. */
+  loading: React.ReactElement;
+
+  children: React.ReactNode;
+};
+
+export const AccountClientProvider: React.FC<AccountClientProviderProps> = ({
+  loading,
+  children,
+}) => {
+  const auth = useAuth();
+  const baseClient = useHttpClient();
+  const { account } = useActiveAccount();
+
+  // Memoizing this context value is worthwhile because this provider will be
+  // used relatively high up in the component tree.
+  const context = React.useMemo(() => {
+    if (!auth.authResult?.accessToken || !account?.id) {
+      return undefined;
+    }
+
+    const client = axios.create({
+      baseURL: baseClient.httpClient.defaults.baseURL,
+      headers: {
+        Authorization: `Bearer ${auth.authResult.accessToken}`,
+        'LifeOmic-Account': account.id,
+      },
+    });
+
+    client.interceptors.request.use((config) => {
+      // Support "unsetting" the LifeOmic-Account header with ''
+      if (config.headers['LifeOmic-Account'] === '') {
+        delete config.headers['LifeOmic-Account'];
+      }
+
+      // TODO: support refreshing an expired token mid-flight to keep requests moving.
+
+      return config;
+    });
+
+    client.interceptors.response.use((error) => {
+      if (axios.isAxiosError(error)) {
+        if (__DEV__ && process.env.NODE_ENV !== 'test') {
+          console.error('Request Failed: ', error.toJSON());
+        }
+      }
+      return Promise.reject(error);
+    });
+
+    return { http: client };
+  }, [
+    baseClient.httpClient.defaults.baseURL,
+    auth.authResult?.accessToken,
+    account?.id,
+  ]);
+
+  if (!context) {
+    return loading;
+  }
+
+  return <_Context.Provider value={context}>{children}</_Context.Provider>;
+};
+
+export const useAccountClient = (): AccountClient => {
+  const context = React.useContext(_Context);
+  if (!context) {
+    throw new Error(
+      'useAccountClient must be used within a AccountClientProvider',
+    );
+  }
+  return context;
+};


### PR DESCRIPTION
## Changes
This PR introduces a new `useAccountClient` hook + provider -- it returns an Axios client that has the LifeOmic-Account built in.

See callouts below.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->