### PR TITLE
fix: simplify useExchangeToken hook

### DIFF
--- a/src/hooks/useExchangeToken.test.tsx
+++ b/src/hooks/useExchangeToken.test.tsx
@@ -65,7 +65,6 @@ test('posts token/clientId to /v1/client-tokens', async () => {
   expect(axiosMock.history.post[0].url).toBe('/v1/client-tokens');
   expect(axiosMock.history.post[0].data).toBe(
     JSON.stringify({
-      accessToken: 'someToken',
       targetClientId: 'someClientId',
     }),
   );

--- a/src/hooks/useExchangeToken.tsx
+++ b/src/hooks/useExchangeToken.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { useActiveAccount } from './useActiveAccount';
-import { useAuth } from './useAuth';
 import { useHttpClient } from './useHttpClient';
 
 export type ExchangeResult = {
@@ -8,35 +7,27 @@ export type ExchangeResult = {
 };
 
 export function useExchangeToken(appTileId: string, clientId?: string) {
-  const { httpClient } = useHttpClient();
-  const { authResult } = useAuth();
+  const { apiClient } = useHttpClient();
   const { accountHeaders } = useActiveAccount();
 
   return useQuery(
     [
       'client-tokens',
       {
-        accessToken: authResult?.accessToken,
         targetClientId: clientId,
         appTileId,
       },
     ],
-    () => {
-      return httpClient
-        .post<ExchangeResult>(
-          '/v1/client-tokens',
-          {
-            accessToken: authResult?.accessToken,
-            targetClientId: clientId,
-          },
-          {
-            headers: { ...accountHeaders },
-          },
+    () =>
+      apiClient
+        .request(
+          'POST /v1/client-tokens',
+          { targetClientId: clientId! },
+          { headers: accountHeaders },
         )
-        .then((res) => res.data);
-    },
+        .then((res) => res.data),
     {
-      enabled: !!accountHeaders && !!authResult?.accessToken && !!clientId,
+      enabled: !!accountHeaders && !!clientId,
     },
   );
 }

--- a/src/hooks/useExchangeToken.tsx
+++ b/src/hooks/useExchangeToken.tsx
@@ -2,10 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
 
-export type ExchangeResult = {
-  code: string;
-};
-
 export function useExchangeToken(appTileId: string, clientId?: string) {
   const { apiClient } = useHttpClient();
   const { accountHeaders } = useActiveAccount();

--- a/src/types/rest-types.ts
+++ b/src/types/rest-types.ts
@@ -43,6 +43,15 @@ export type RestAPIEndpoints = FhirAPIEndpoints & {
     Response: User;
   };
 
+  'POST /v1/client-tokens': {
+    Request: {
+      targetClientId: string;
+    };
+    Response: {
+      code: string;
+    };
+  };
+
   'GET /v1/survey/projects/:projectId/responses': {
     Request: {
       patientId: string;


### PR DESCRIPTION
## Changes
This API was simplified to _not_ require passing the `accessToken` in the request body. It's now gather from the (also required) `Authorization` header.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->