### PR TITLE
Remove redundant/unused logic in useActiveAccount

### DIFF
--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -77,7 +77,6 @@ beforeEach(() => {
 
 test('without provider, methods fail', async () => {
   const { result } = renderHook(() => useActiveAccount());
-  await expect(result.current.refetch()).rejects.toBeUndefined();
   await expect(
     result.current.setActiveAccountId('bogus'),
   ).rejects.toBeUndefined();
@@ -106,18 +105,6 @@ test('exposes some props from useAccounts', async () => {
   expect(result.current).toMatchObject({
     isLoading: true,
   });
-});
-
-test('refetch forwards to useAccounts', async () => {
-  const { result } = await renderHookInContext();
-
-  await waitFor(() => expect(queryMock).toHaveBeenCalledTimes(1));
-
-  await act(async () => {
-    result.current.refetch();
-  });
-
-  await waitFor(() => expect(queryMock).toHaveBeenCalledTimes(2));
 });
 
 test('setActiveAccountId saves accountId', async () => {

--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -146,7 +146,6 @@ test('indicates expired trial', async () => {
   await waitFor(() => {
     expect(result.current).toMatchObject({
       account: expiredTrialAccount,
-      trialExpired: true,
     });
   });
 });

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -18,7 +18,6 @@ export type ActiveAccountProps = {
   account?: Account;
   accountsWithProduct?: Account[];
   accountHeaders?: Record<string, string>;
-  trialExpired?: boolean;
 };
 
 export type ActiveAccountContextProps = ActiveAccountProps & {
@@ -42,11 +41,6 @@ const filterNonLRAccounts = (accounts?: Account[]) =>
 const getValidAccount = (validAccounts?: Account[], accountId?: string) => {
   return validAccounts?.find((a) => a.id === accountId);
 };
-
-const getTrialExpired = (account: Account) =>
-  account.type === 'FREE'
-    ? !account.trialActive || new Date(account.trialEndDate) < new Date()
-    : undefined;
 
 export const ActiveAccountContextProvider = ({
   children,
@@ -100,7 +94,6 @@ export const ActiveAccountContextProvider = ({
       accountHeaders: {
         'LifeOmic-Account': selectedAccount.id,
       },
-      trialExpired: getTrialExpired(selectedAccount),
     };
   }, [
     accountsWithProduct,


### PR DESCRIPTION
## Changes
This PR simplifies a number of pieces of logic in `useActiveAccount` that seemed to be no longer useful.

I've highlighted each change below via a comment -- review appreciated.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->