### PR TITLE
chore: deprecate useAsyncStorage

### DIFF
--- a/src/hooks/useAsyncStorage.tsx
+++ b/src/hooks/useAsyncStorage.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+/**
+ * @deprecated Prefer useStoredValue instead.
+ */
 export function useAsyncStorage(key: string, enabled: boolean = true) {
   const [value, setValue] = useState<string | null | undefined>(undefined);
 


### PR DESCRIPTION
## Changes
Proposing deprecating `useAsyncStorage` in favor of `useStoredValue`, introduced in #437.

I was going to try to migrate more use cases of `useAsyncStorage` to `useStoredValue`, but it's not so simple. Some of the features powered by `useAsyncStorage` are in end-user hands, and their stored values cannot be lost (e.g. onboarding course completed, notification read time).

So for now, would just like to encourage no _additional_ usages of `useAsyncStorage`. We can worry about migrating call sites of useAsyncStorage later.
<!-- list your changes here -->
  - Your changes...

## Screenshots
<!-- include screen recordings, if relevant to your changes -->