### PR TITLE
fix: Add Style Settings for Compose Message Icon

### DIFF
--- a/src/screens/MessageScreen.tsx
+++ b/src/screens/MessageScreen.tsx
@@ -66,6 +66,7 @@ export function MessageScreen<ParamList extends ParamListBase>({
   const all = compact(profiles);
   const others = all.filter((profile) => profile.id !== userData?.id);
   const { mutateAsync } = useLeaveConversation();
+  const { styles } = useStyles(defaultStyles);
 
   const { Edit2 } = useIcons();
   const { data, fetchNextPage, hasNextPage, isLoading } =
@@ -75,12 +76,19 @@ export function MessageScreen<ParamList extends ParamListBase>({
     () => (
       <IconButton
         icon={Edit2}
+        iconColor={styles.createMessageIcon?.color}
         onPress={() =>
           navigation.navigate(routeMap.ComposeMessageScreen, { tileId })
         }
       />
     ),
-    [Edit2, navigation, tileId, routeMap.ComposeMessageScreen],
+    [
+      Edit2,
+      navigation,
+      tileId,
+      routeMap.ComposeMessageScreen,
+      styles.createMessageIcon?.color,
+    ],
   );
 
   useLayoutEffect(() => {
@@ -89,8 +97,6 @@ export function MessageScreen<ParamList extends ParamListBase>({
       headerRight: iconButton,
     });
   }, [iconButton, navigation]);
-
-  const { styles } = useStyles(defaultStyles);
 
   const handlePostTapped = useCallback(
     (tappedUsers: User[], conversationId: string) => () => {
@@ -422,6 +428,7 @@ const defaultStyles = createStyles('MessageScreen', (theme) => {
       fontWeight: '500',
       paddingVertical: 20,
     },
+    createMessageIcon: {} as { color: string | undefined },
   };
 });
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Need to allow for changing the color of this icon

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
Without style options:
![image](https://github.com/lifeomic/react-native-sdk/assets/2295908/723c7ec1-4c1b-4562-b1e9-d9b142ebf107)
