### PR TITLE
fix: Shrink icons, remove excess whitespace

### DIFF
--- a/src/screens/MessageScreen.tsx
+++ b/src/screens/MessageScreen.tsx
@@ -117,7 +117,7 @@ export function MessageScreen<ParamList extends ParamListBase>({
             style={{
               flexDirection: 'row',
               flex: 1,
-              maxWidth: 75,
+              maxWidth: 60,
             }}
           >
             {
@@ -310,13 +310,13 @@ const MultiGiftedAvatar = ({ profiles }: MultiGiftedAvatarProps) => {
 
 const getDiameter = (avatarIndex: number, userCount: number) => {
   if (userCount === 3) {
-    return [20, 15, 17][avatarIndex];
+    return [18, 13, 12][avatarIndex];
   }
   if (userCount === 1) {
     return 40;
   }
 
-  return 20;
+  return 17;
 };
 
 const defaultStyles = createStyles('MessageScreen', (theme) => {
@@ -337,13 +337,9 @@ const defaultStyles = createStyles('MessageScreen', (theme) => {
       ...theme.fonts.titleSmall,
     },
     listItemDividerView: {},
-    userIconView: {
-      marginLeft: theme.spacing.extraSmall,
-    },
     badgeView: {
       alignSelf: 'center',
-      paddingRight: 0,
-      marginRight: 10,
+      marginRight: 4,
       marginLeft: 4,
     },
     badgeColor: {
@@ -357,12 +353,6 @@ const defaultStyles = createStyles('MessageScreen', (theme) => {
     loadMoreButton: {},
     loadMoreText: {},
     listItemTimeText: { paddingLeft: 15 },
-    newMessageIconView: {
-      marginRight: -1,
-      borderWidth: 2,
-      borderColor: theme.colors.text,
-      borderRadius: 32,
-    },
     newMessageText: {
       color: theme.colors.text,
       fontWeight: '600',
@@ -372,8 +362,8 @@ const defaultStyles = createStyles('MessageScreen', (theme) => {
       flexDirection: 'column',
       flexWrap: 'wrap',
       alignContent: 'center',
-      maxHeight: 50,
-      maxWidth: 50,
+      maxHeight: 40,
+      maxWidth: 40,
       borderRadius: 64,
       justifyContent: 'center',
     },


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Shrink multi-icons to match size of single icon
  - Reduce excess spacing on both sides of the icon

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<img width="423" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/76954025/803e6fc9-1599-4ee2-a595-499ddf0561ee">
