### PR TITLE
feat: add Practitioner to FhirResourcesByName

### DIFF
--- a/src/types/fhir-api-types.ts
+++ b/src/types/fhir-api-types.ts
@@ -3,6 +3,7 @@ import {
   Bundle,
   Observation,
   Patient,
+  Practitioner,
   Questionnaire,
   QuestionnaireResponse,
 } from 'fhir/r3';
@@ -16,6 +17,7 @@ type FhirResourcesByName = {
   Questionnaire: Questionnaire;
   QuestionnaireResponse: QuestionnaireResponse;
   Appointment: Appointment;
+  Practitioner: Practitioner;
 };
 
 /**


### PR DESCRIPTION
## Motivations

We'll be fetching a patient's practitioner, so we're adding the type to the REST API hooks.

## Changes
  - Adding `Practitioner` to `FhirResourcesByName`.
  
## Screenshots
N/A