### PR TITLE
fix: Make Message View Avoid Keyboard

### DIFF
--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -14,6 +14,7 @@ import { ThemedNavigationContainer } from './ThemedNavigationContainer';
 import { LoggedInProviders } from './LoggedInProviders';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
+import { LogoHeaderDimensionsContextProvider } from '../hooks/useLogoHeaderDimensions';
 
 const queryClient = new QueryClient();
 
@@ -38,7 +39,11 @@ export function RootProviders({ authConfig, children }: RootProvidersProps) {
                       <SafeAreaProvider>
                         <ThemedNavigationContainer>
                           <Toast />
-                          <LoggedInProviders>{children}</LoggedInProviders>
+                          <LoggedInProviders>
+                            <LogoHeaderDimensionsContextProvider>
+                              {children}
+                            </LogoHeaderDimensionsContextProvider>
+                          </LoggedInProviders>
                         </ThemedNavigationContainer>
                       </SafeAreaProvider>
                     </ActionSheetProvider>

--- a/src/components/LogoHeader.tsx
+++ b/src/components/LogoHeader.tsx
@@ -7,11 +7,13 @@ import {
   LogoHeaderOptions,
   useHandleOptionEvents,
 } from '../hooks/useLogoHeaderOptions';
+import { useLogoHeaderDimensions } from '../hooks/useLogoHeaderDimensions';
 
 export function LogoHeader(defaultOptions: LogoHeaderOptions) {
   const { styles } = useStyles(defaultStyles);
   const androidFix = Platform.OS === 'android' ? { marginTop: 12 } : {};
   const [options, setOptions] = useState<LogoHeaderOptions>(defaultOptions);
+  const [_, setLogoHeaderDimensions] = useLogoHeaderDimensions();
 
   // Subscribe to events to receive option updates
   useHandleOptionEvents(setOptions, defaultOptions);
@@ -21,7 +23,10 @@ export function LogoHeader(defaultOptions: LogoHeaderOptions) {
   }
 
   return (
-    <View style={styles.view}>
+    <View
+      style={styles.view}
+      onLayout={(event) => setLogoHeaderDimensions(event.nativeEvent.layout)}
+    >
       <SafeAreaView
         edges={['left', 'right', 'top']}
         style={[androidFix, styles.safeAreaView]}

--- a/src/components/MessagesTile/MessagesTile.test.tsx
+++ b/src/components/MessagesTile/MessagesTile.test.tsx
@@ -32,6 +32,7 @@ const directMessageScreen = (
   <QueryClientProvider client={queryClient}>
     <GraphQLClientContextProvider baseURL={baseURL}>
       <MessagesTile
+        Icon={() => null}
         navigation={navigateMock as any}
         id="some-messages-tile"
         title="Message your doctor"

--- a/src/components/MessagesTile/MessagesTile.tsx
+++ b/src/components/MessagesTile/MessagesTile.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { Tile } from '../tiles/Tile';
 import { HomeStackScreenProps } from '../../navigators';
-import { useIcons } from '../BrandConfigProvider';
 import { tID } from '../TrackTile/common/testID';
 import { useHasUnread } from '../../hooks/useConversations';
+import { SvgProps } from 'react-native-svg';
 
 interface Props extends Pick<HomeStackScreenProps<'Home'>, 'navigation'> {
   id: string;
   title: string;
+  Icon: React.FC<SvgProps>;
 }
 
-export function MessagesTile({ navigation, title, id }: Props) {
-  const { MessageCircle } = useIcons();
+export function MessagesTile({ navigation, title, id, Icon }: Props) {
   const hasUnread = useHasUnread();
 
   return (
@@ -20,7 +20,7 @@ export function MessagesTile({ navigation, title, id }: Props) {
       key={id}
       title={title}
       testID={tID('message-tile')}
-      Icon={MessageCircle}
+      Icon={Icon}
       showBadge={hasUnread}
       onPress={() => {
         navigation.navigate('Home/Messages', {

--- a/src/components/Messaging/ComposeInputBar.tsx
+++ b/src/components/Messaging/ComposeInputBar.tsx
@@ -14,7 +14,6 @@ import { uniq } from 'lodash';
 import type { ComposeScreenParamTypes } from '../../screens/ComposeMessageScreen';
 import { toRouteMap } from '../../screens/utils/stack-helpers';
 import { UserProfile } from '../../hooks/useMessagingProfiles';
-import { KeyboardAvoidingView, Platform } from 'react-native';
 
 type Props<ParamList extends ParamListBase> = {
   users: UserProfile[];
@@ -90,28 +89,23 @@ export function ComposeInputBar<ParamList extends ParamListBase>({
   ]);
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-    >
-      <InputToolbar
-        containerStyle={styles.inputToolbarContainer}
-        primaryStyle={styles.inputToolbarPrimaryView}
-        renderSend={SendButton}
-        renderComposer={(props) => {
-          return (
-            <Composer
-              {...props}
-              onTextChanged={(text) => setMessageText(text)}
-              text={messageText}
-              textInputStyle={styles.inputText}
-              multiline={true}
-              placeholderTextColor={styles.placeholderText?.color?.toString()}
-            />
-          );
-        }}
-      />
-    </KeyboardAvoidingView>
+    <InputToolbar
+      containerStyle={styles.inputToolbarContainer}
+      primaryStyle={styles.inputToolbarPrimaryView}
+      renderSend={SendButton}
+      renderComposer={(props) => {
+        return (
+          <Composer
+            {...props}
+            onTextChanged={(text) => setMessageText(text)}
+            text={messageText}
+            textInputStyle={styles.inputText}
+            multiline={true}
+            placeholderTextColor={styles.placeholderText?.color?.toString()}
+          />
+        );
+      }}
+    />
   );
 }
 
@@ -126,6 +120,7 @@ const defaultStyles = createStyles('ComposeInputBar', (theme) => ({
     flex: 1,
     position: 'relative',
     alignContent: 'flex-start',
+    minHeight: 150,
   },
   inputToolbarPrimaryView: {
     flex: 1,
@@ -135,7 +130,6 @@ const defaultStyles = createStyles('ComposeInputBar', (theme) => ({
   inputText: {
     textAlignVertical: 'top',
     flex: 1,
-    minHeight: 300,
   },
   sendIconColor: {
     enabled: theme.colors.primary,

--- a/src/components/tiles/TilesList.tsx
+++ b/src/components/tiles/TilesList.tsx
@@ -136,7 +136,12 @@ export function TilesList({ navigation, styles: instanceStyles }: Props) {
           />
         ))}
         {data?.homeTab?.messageTiles?.map(({ id, displayName }) => (
-          <MessagesTile navigation={navigation} title={displayName} id={id} />
+          <MessagesTile
+            Icon={tileIcon('MessageCircle', `message-tile-${id}`)}
+            navigation={navigation}
+            title={displayName}
+            id={id}
+          />
         ))}
         {data?.homeTab?.circleTiles?.map((circleTile: CircleTile) => (
           <Tile

--- a/src/hooks/useLogoHeaderDimensions.tsx
+++ b/src/hooks/useLogoHeaderDimensions.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from 'react';
+import { LayoutRectangle } from 'react-native';
+
+const defaultValue: LayoutRectangle = {
+  x: 0,
+  y: 0,
+  height: 0,
+  width: 0,
+};
+const LogoHeaderContext = createContext([{ ...defaultValue }, () => {}] as [
+  LayoutRectangle,
+  React.Dispatch<React.SetStateAction<LayoutRectangle>>,
+]);
+
+type Props = {
+  children?: React.ReactNode;
+};
+
+export const LogoHeaderDimensionsContextProvider = ({ children }: Props) => {
+  const state = useState<LayoutRectangle>({ ...defaultValue });
+
+  return (
+    <LogoHeaderContext.Provider value={state}>
+      {children}
+    </LogoHeaderContext.Provider>
+  );
+};
+
+export const useLogoHeaderDimensions = () => useContext(LogoHeaderContext);

--- a/src/navigators/BottomNavigationBar.tsx
+++ b/src/navigators/BottomNavigationBar.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { useTheme } from '../hooks/useTheme';
+import { BottomNavigation, shadow } from 'react-native-paper';
+import { CommonActions } from '@react-navigation/native';
+import { createStyles } from '../components/BrandConfigProvider';
+import { useStyles } from '../hooks';
+import { ViewStyle } from 'react-native';
+
+export const BottomNavigationBar = ({
+  navigation,
+  state,
+  descriptors,
+  insets,
+}: BottomTabBarProps) => {
+  const { styles } = useStyles(defaultStyles);
+  const theme = useTheme();
+
+  return (
+    <BottomNavigation.Bar
+      labeled
+      shifting={true}
+      activeColor={theme.colors.onSurface}
+      inactiveColor={theme.colors.onSurfaceDisabled}
+      navigationState={state}
+      safeAreaInsets={insets}
+      style={styles.barStyle}
+      onTabPress={({ route, preventDefault }) => {
+        const event = navigation.emit({
+          type: 'tabPress',
+          target: route.key,
+          canPreventDefault: true,
+        });
+
+        if (event.defaultPrevented) {
+          preventDefault();
+        } else {
+          navigation.dispatch({
+            ...CommonActions.navigate(route),
+            target: state.key,
+          });
+        }
+      }}
+      renderIcon={({ route, focused, color }) => {
+        const { options } = descriptors[route.key];
+        if (options.tabBarIcon) {
+          return options.tabBarIcon({ focused, color, size: 24 });
+        }
+
+        return null;
+      }}
+      getLabelText={({ route }) => {
+        const { options } = descriptors[route.key];
+        const label =
+          typeof options.tabBarLabel === 'string'
+            ? options.tabBarLabel
+            : options.title !== undefined
+            ? options.title
+            : route.title;
+
+        return label;
+      }}
+    />
+  );
+};
+
+const defaultStyles = createStyles('TabNavigator', (theme) => ({
+  barStyle: {
+    backgroundColor: theme.colors.background,
+    zIndex: 1,
+    ...shadow(4),
+  } as ViewStyle,
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}
+
+export type TabNavigatorStyles = NamedStylesProp<typeof defaultStyles>;

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -1,39 +1,29 @@
-import React from 'react';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
-import { useStyles } from '../hooks/useStyles';
-import { createStyles, useIcons } from '../components/BrandConfigProvider';
-import { useTheme } from '../hooks/useTheme';
-import { shadow } from 'react-native-paper';
-import { ViewStyle } from 'react-native';
+import React, { useCallback } from 'react';
+import {
+  BottomTabBarProps,
+  createBottomTabNavigator,
+} from '@react-navigation/bottom-tabs';
+import { useIcons } from '../components/BrandConfigProvider';
 import { TabParamList } from './types';
 import { useTabsConfig } from '../hooks/useTabsConfig';
 import { TabBar } from './TabBar';
 import { getDefaultTabs } from './getDefaultTabs';
+import { BottomNavigationBar } from './BottomNavigationBar';
+
+const Tab = createBottomTabNavigator<TabParamList>();
 
 export function TabNavigator() {
-  const { styles } = useStyles(defaultStyles);
-  const theme = useTheme();
   const icons = useIcons();
   const { tabs, useTabBar } = useTabsConfig(getDefaultTabs(icons));
 
-  const Tab = useTabBar
-    ? createBottomTabNavigator<TabParamList>()
-    : createMaterialBottomTabNavigator<TabParamList>();
-
-  const tabBar = (props: any) => {
-    return useTabBar ? <TabBar {...props} /> : null;
-  };
+  const tabBar = useCallback(
+    (props: BottomTabBarProps) =>
+      useTabBar ? <TabBar {...props} /> : <BottomNavigationBar {...props} />,
+    [useTabBar],
+  );
 
   return (
-    <Tab.Navigator
-      tabBar={tabBar}
-      shifting={true}
-      barStyle={styles.barStyle}
-      activeColor={theme.colors.onSurface}
-      inactiveColor={theme.colors.onSurfaceDisabled}
-      labeled
-    >
+    <Tab.Navigator tabBar={tabBar}>
       {tabs?.map((tab) => (
         <Tab.Screen
           name={tab.name}
@@ -51,18 +41,3 @@ export function TabNavigator() {
     </Tab.Navigator>
   );
 }
-
-const defaultStyles = createStyles('TabNavigator', (theme) => ({
-  barStyle: {
-    backgroundColor: theme.colors.background,
-    zIndex: 1,
-    ...shadow(4),
-  } as ViewStyle,
-}));
-
-declare module '@styles' {
-  interface ComponentStyles
-    extends ComponentNamedStyles<typeof defaultStyles> {}
-}
-
-export type TabNavigatorStyles = NamedStylesProp<typeof defaultStyles>;

--- a/src/screens/ComposeMessageScreen.test.tsx
+++ b/src/screens/ComposeMessageScreen.test.tsx
@@ -8,6 +8,15 @@ import { useNavigation } from '@react-navigation/native';
 import { useAppConfig } from '../hooks/useAppConfig';
 
 jest.mock('../hooks/useMessagingProfiles');
+jest.mock('@react-navigation/elements', () => ({
+  useHeaderHeight: jest.fn(() => 0),
+}));
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: jest.fn(() => 0),
+}));
+jest.mock('../hooks/useLogoHeaderDimensions', () => ({
+  useLogoHeaderDimensions: () => [{ height: 0 }],
+}));
 jest.mock('../hooks/useUser', () => ({
   useUser: jest.fn(),
 }));


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes the keyboard avoiding view to correctly account for the header and logoHeader
  - Fixes the messageTile icon display (wasn't using theme on iOS and wasn't visible on Android)
  - Reworks the tabs so that the material (paper) tabs use the BottomTabsBar Navigator so that we can get the height of the tabs (createMaterialBottomTabNavigator is removed in React Native Navigation 6.x so this will help with an eventual upgrade)

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/89be5dbe-5c8e-4eb7-93d8-a42949628cc8" />
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/aa9bd6aa-7b1a-4cd6-a908-24877a4c9e8f" />
</table>

