### PR TITLE
fix: support specifying a 'brand' via DeveloperConfig

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -157,3 +157,49 @@ After:
 
 - `LoggedInProviders` will now render the login screen if the user is not logged
   in.
+
+- If you are using a custom `BrandConfigProvider` as a child of `RootProviders`,
+  you should move your locally-specific brand to the `DeveloperConfigProvider`
+  instead. Example:
+
+```tsx
+// INSTEAD OF THIS:
+const myBrand = {
+  /* ... */
+};
+const App = () => {
+  return (
+    <DeveloperConfigProvider
+      developerConfig={
+        {
+          /* ... */
+        }
+      }
+    >
+      <RootProviders authConfig={authConfig}>
+        <BrandConfigProvider {...brand}>
+          <RootStack />
+        </BrandConfigProvider>
+      </RootProviders>
+    </DeveloperConfigProvider>
+  );
+};
+
+// DO THIS:
+const myBrand = {
+  /* ... */
+};
+const App = () => {
+  return (
+    <DeveloperConfigProvider
+      developerConfig={{
+        brand: myBrand,
+      }}
+    >
+      <RootProviders authConfig={authConfig}>
+        <LoggedInStack />
+      </RootProviders>
+    </DeveloperConfigProvider>
+  );
+};
+```

--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -2,7 +2,7 @@ import React, { ComponentType } from 'react';
 import { getBundleId } from 'react-native-device-info';
 import { AppTile, TabStyle } from '../hooks/useAppConfig';
 import { SvgProps } from 'react-native-svg';
-import { Theme } from '../components/BrandConfigProvider';
+import { Brand, Theme } from '../components/BrandConfigProvider';
 import {
   LinkingOptions,
   NavigationState,
@@ -80,6 +80,7 @@ export type OnAppSessionStartParams = {
 export type DeveloperConfig = {
   appTileScreens?: AppTileScreens;
   simpleTheme?: SimpleTheme;
+  brand?: Brand;
   apiBaseURL?: string;
   AppNavHeader?: {
     headerColors?: RouteColor[];

--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -23,7 +23,7 @@ export type RootProvidersProps = {
 };
 
 export function RootProviders({ authConfig, children }: RootProvidersProps) {
-  const { apiBaseURL, theme } = useDeveloperConfig();
+  const { apiBaseURL, theme, brand } = useDeveloperConfig();
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -32,7 +32,7 @@ export function RootProviders({ authConfig, children }: RootProvidersProps) {
           <GraphQLClientContextProvider baseURL={apiBaseURL}>
             <InviteProvider>
               <OAuthContextProvider authConfig={authConfig}>
-                <BrandConfigProvider theme={theme}>
+                <BrandConfigProvider theme={theme} {...brand}>
                   <NoInternetToastProvider>
                     <ActionSheetProvider>
                       <SafeAreaProvider>

--- a/src/components/BrandConfigProvider/BrandConfigProvider.tsx
+++ b/src/components/BrandConfigProvider/BrandConfigProvider.tsx
@@ -16,6 +16,8 @@ interface Props {
   children: React.ReactNode;
 }
 
+export type Brand = Pick<Props, 'theme' | 'styles' | 'icons'>;
+
 export function BrandConfigProvider({ theme, styles, icons, children }: Props) {
   const [brand, setBrand] = useState({
     theme: theme || {},

--- a/src/components/BrandConfigProvider/index.ts
+++ b/src/components/BrandConfigProvider/index.ts
@@ -1,4 +1,4 @@
-export { BrandConfigProvider } from './BrandConfigProvider';
+export * from './BrandConfigProvider';
 export { ThemeProp, ThemeProvider } from './theme/ThemeProvider';
 export * from './styles/types';
 export { createStyles } from './styles/createStyles';


### PR DESCRIPTION
## Changes
#462 broke a particular use case: using a custom `BrandConfigProvider` to style the LoginScreen. This PR introduces a fix to that flow, and guidance for upgrading.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->