### PR TITLE
feat!: require project to be loaded before rendering children

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -210,3 +210,6 @@ const App = () => {
   _not_ render their children until the active account + project have been
   resolved. If there is no active account or project, the `InviteRequired`
   screen will be rendered in the place of children.
+
+- The `useActiveProject` hook now returns non-optional data. You can simplify
+  any conditional logic around those returned values.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -203,3 +203,10 @@ const App = () => {
   );
 };
 ```
+
+### 6.x -> 7.x
+
+- `ActiveAccountContextProvider` and `ActiveProjectContextProvider` will now
+  _not_ render their children until the active account + project have been
+  resolved. If there is no active account or project, the `InviteRequired`
+  screen will be rendered in the place of children.

--- a/src/components/TodayBadge.test.tsx
+++ b/src/components/TodayBadge.test.tsx
@@ -1,20 +1,15 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { useTodayTasks } from '../hooks/todayTile/useTodayTasks';
+import * as TodayTasksModule from '../hooks/todayTile/useTodayTasks';
 import TodayBadge from './TodayBadge';
 
-jest.mock('../hooks/todayTile/useTodayTasks', () => ({
-  ...jest.requireActual('../hooks/todayTile/useTodayTasks'),
-  useTodayTasks: jest.fn(),
-}));
-
-const useTodayTasksMock = useTodayTasks as jest.Mock;
+const useTodayTasksMock = jest.spyOn(TodayTasksModule, 'useTodayTasks');
 
 test('does not render badge if no counts', () => {
   useTodayTasksMock.mockReturnValue({
     incompleteActivitiesCount: 0,
     newTasks: [],
-  });
+  } as any);
   const badge = render(<TodayBadge />);
   expect(badge.toJSON()).toBe(null);
 });
@@ -28,7 +23,7 @@ test('renders badge with counts', () => {
   useTodayTasksMock.mockReturnValue({
     incompleteActivitiesCount: 2,
     newTasks: tasks,
-  });
+  } as any);
   const badge = render(<TodayBadge />);
   expect(badge.getByText('5')).toBeDefined();
 });

--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -54,7 +54,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
   const { ontology: devConfigOntology } = useDeveloperConfig();
 
   const accountId = account?.id || '';
-  const projectId = activeProject?.id || '';
+  const projectId = activeProject.id;
   const { includePublic = false } = appConfig?.homeTab?.trackTileSettings ?? {};
 
   const { current: cache } = useRef<{

--- a/src/hooks/Circles/useJoinCircles.tsx
+++ b/src/hooks/Circles/useJoinCircles.tsx
@@ -11,12 +11,12 @@ export function useJoinCircles() {
   const { httpClient } = useHttpClient();
 
   return useQuery(
-    [`/v1/life-research/projects/${activeProject?.id}/app-config/circles`],
+    [`/v1/life-research/projects/${activeProject.id}/app-config/circles`],
     () => {
       if (data?.homeTab?.circleTiles?.some((c) => !c.isMember)) {
         httpClient
           .patch<CircleTile[]>(
-            `/v1/life-research/projects/${activeProject?.id}/app-config/circles`,
+            `/v1/life-research/projects/${activeProject.id}/app-config/circles`,
             data.homeTab.circleTiles.map((c) => ({ ...c, isMember: true })),
             { headers: accountHeaders },
           )
@@ -26,8 +26,7 @@ export function useJoinCircles() {
       }
     },
     {
-      enabled:
-        !!accountHeaders && !!activeProject?.id && !!data?.homeTab?.circleTiles,
+      enabled: !!accountHeaders && !!data?.homeTab?.circleTiles,
     },
   );
 }

--- a/src/hooks/todayTile/useTodayTasks.tsx
+++ b/src/hooks/todayTile/useTodayTasks.tsx
@@ -43,7 +43,7 @@ const useConsentTasks = () => {
       includeForm: true,
     },
     {
-      enabled: !!accountHeaders && !!activeProject,
+      enabled: !!accountHeaders,
       axios: { headers: accountHeaders },
       select: (data) => data.items,
     },
@@ -65,15 +65,15 @@ export const useGetSurveyResponsesForProject = (
   return useRestQuery(
     'GET /v1/survey/projects/:projectId/responses',
     {
-      projectId: activeProject!.id,
-      author: activeSubjectId!,
-      patientId: activeSubjectId!,
+      projectId: activeProject.id,
+      author: activeSubjectId,
+      patientId: activeSubjectId,
       includeSurveyName: input?.includeSurveyName ?? false,
       status: input?.status ?? 'in-progress',
       pageSize: input?.pageSize ?? 100,
     },
     {
-      enabled: !!accountHeaders && !!activeProject && !!activeSubjectId,
+      enabled: !!accountHeaders,
       axios: { headers: accountHeaders },
       select: (data) => data.items,
     },

--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  act,
+  render,
+  renderHook,
+  waitFor,
+} from '@testing-library/react-native';
 import {
   ActiveAccountContextProvider,
   PREFERRED_ACCOUNT_ID_KEY,
@@ -9,6 +14,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { inviteNotifier } from '../components/Invitations/InviteNotifier';
 import { createRestAPIMock } from '../test-utils/rest-api-mocking';
 import { _store } from './useStoredValue';
+import { Text } from 'react-native';
 
 const api = createRestAPIMock();
 
@@ -223,4 +229,25 @@ test('handles accepted invites by refetching and setting account', async () => {
       invitedAccountId,
     ),
   );
+});
+
+test('renders the InviteRequired screen when the user has no accounts', async () => {
+  api.mock('GET /v1/accounts', {
+    status: 200,
+    data: { accounts: [] },
+  });
+
+  const screen = render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ActiveAccountContextProvider>
+        <Text>content</Text>
+      </ActiveAccountContextProvider>
+    </QueryClientProvider>,
+  );
+
+  await waitFor(() => {
+    screen.getByText(
+      'This app is only available to use by invitation. Please contact your administrator for access.',
+    );
+  });
 });

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -4,6 +4,7 @@ import { inviteNotifier } from '../components/Invitations/InviteNotifier';
 import { ProjectInvite } from '../types';
 import { useRestCache, useRestQuery } from './rest-api';
 import { useStoredValue } from './useStoredValue';
+import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
 
 export type ActiveAccountProps = {
   account?: Account;
@@ -81,6 +82,13 @@ export const ActiveAccountContextProvider = ({
       inviteNotifier.removeListener('inviteAccepted', listener);
     };
   }, [cache, setPreferredId]);
+
+  /**
+   * This check is temporary. It will be refactored out in a subsequent PR.
+   */
+  if (accountsResult.status === 'success' && !selectedAccount) {
+    return <InviteRequiredScreen />;
+  }
 
   return (
     <ActiveAccountContext.Provider

--- a/src/hooks/useAppConfig.tsx
+++ b/src/hooks/useAppConfig.tsx
@@ -115,9 +115,9 @@ export const useAppConfig = () => {
 
   const query = useRestQuery(
     'GET /v1/life-research/projects/:projectId/app-config',
-    { projectId: activeProject?.id! },
+    { projectId: activeProject.id },
     {
-      enabled: !!activeProject && !!accountHeaders,
+      enabled: !!accountHeaders,
       axios: {
         headers: accountHeaders,
       },

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -15,18 +15,18 @@ export const useConsent = () => {
         '/v1/consent/directives/me',
         {
           account,
-          projectId: activeProject?.id,
+          projectId: activeProject.id,
           accountHeaders,
         },
       ],
       () =>
         httpClient
           .get<{ items: ConsentAndForm[] }>('/v1/consent/directives/me', {
-            params: { projectId: activeProject?.id, includeForm: true },
+            params: { projectId: activeProject.id, includeForm: true },
             headers: { ...accountHeaders },
           })
           .then((res) => res.data),
-      { enabled: !!accountHeaders && !!activeProject?.id },
+      { enabled: !!accountHeaders },
     );
   };
 

--- a/src/hooks/useFhirClient.tsx
+++ b/src/hooks/useFhirClient.tsx
@@ -48,7 +48,7 @@ export function useFhirClient() {
       resource = merge(resource, { meta: { tag: [] } });
       resource.meta!.tag!.push({
         system: 'http://lifeomic.com/fhir/dataset',
-        code: activeProject?.id,
+        code: activeProject.id,
       });
     }
 
@@ -95,7 +95,7 @@ export function useFhirClient() {
     const params = merge(
       {
         // Defaults:
-        _tag: `http://lifeomic.com/fhir/dataset|${activeProject?.id}`,
+        _tag: `http://lifeomic.com/fhir/dataset|${activeProject.id}`,
         patient: activeSubjectId,
         next: next.toString(),
         code: toFhirCodeFilter(),
@@ -141,11 +141,7 @@ export function useFhirClient() {
           });
       },
       {
-        enabled:
-          !!accountHeaders &&
-          !!activeProject?.id &&
-          !!activeSubjectId &&
-          (queryParams.enabled ?? true),
+        enabled: !!accountHeaders && (queryParams.enabled ?? true),
         keepPreviousData: true,
       },
     );
@@ -171,7 +167,7 @@ export function useFhirClient() {
   const useCreateResourceMutation = () => {
     return useMutation({
       mutationFn: async (resourceToUpsert: ResourceType) => {
-        if (!accountHeaders || !activeProject?.id || !activeSubjectId) {
+        if (!accountHeaders) {
           throw new Error('Cannot mutate resource in current state');
         }
 
@@ -193,7 +189,7 @@ export function useFhirClient() {
   const useCreateBundleMutation = () => {
     return useMutation({
       mutationFn: async (resources: ResourceType[]) => {
-        if (!accountHeaders || !activeProject?.id || !activeSubjectId) {
+        if (!accountHeaders) {
           throw new Error('Cannot mutate resource in current state');
         }
 

--- a/src/hooks/useOnboardingCourse.tsx
+++ b/src/hooks/useOnboardingCourse.tsx
@@ -34,10 +34,7 @@ export const OnboardingCourseContextProvider = ({
   const onboardingCourseTitle = data?.onboardingCourse?.title;
   const { activeProject } = useActiveProject();
   const [storedDidLaunchResult, storeDidLaunch, isStorageLoaded] =
-    useAsyncStorage(
-      `${activeProject?.id}-didLaunchOnboardingCourse`,
-      !!activeProject?.id,
-    );
+    useAsyncStorage(`${activeProject.id}-didLaunchOnboardingCourse`);
   const [didLaunchCourse, setDidLaunchCourse] = useState<boolean | undefined>(
     undefined,
   );
@@ -46,10 +43,8 @@ export const OnboardingCourseContextProvider = ({
   const isFetched = isAppConfigFetched && isStorageLoaded;
 
   useEffect(() => {
-    if (activeProject?.id) {
-      setDidLaunchCourse(storedDidLaunchResult === 'true');
-    }
-  }, [storedDidLaunchResult, activeProject?.id]);
+    setDidLaunchCourse(storedDidLaunchResult === 'true');
+  }, [storedDidLaunchResult]);
 
   /* Render the onboarding course if the following conditions are met:
     1. The app config and the async storage value have been fetched

--- a/src/hooks/usePushNotifications.test.tsx
+++ b/src/hooks/usePushNotifications.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HttpClientContextProvider } from './useHttpClient';
+import { PushNotificationsProvider } from './usePushNotifications';
+import { Platform, Text } from 'react-native';
+import { PushNotificationsConfig } from '../common/DeveloperConfig';
+import * as NotificationsUtils from '../common/Notifications';
+import { Notifications } from 'react-native-notifications';
+import { ActiveAccountContext } from '.';
+
+jest.mock('react-native-notifications', () => ({
+  Notifications: {
+    setNotificationChannel: jest.fn(),
+  },
+}));
+
+const renderProvider = (config?: PushNotificationsConfig) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <HttpClientContextProvider>
+        <ActiveAccountContext.Provider
+          value={{
+            isFetched: true,
+            isLoading: false,
+            setActiveAccountId: jest.fn(),
+            account: { id: 'test-account' } as any,
+          }}
+        >
+          <PushNotificationsProvider config={config}>
+            <Text>content</Text>
+          </PushNotificationsProvider>
+        </ActiveAccountContext.Provider>
+      </HttpClientContextProvider>
+    </QueryClientProvider>,
+  );
+
+beforeEach(() => {
+  jest.spyOn(Notifications, 'setNotificationChannel').mockReturnValue();
+  jest
+    .spyOn(NotificationsUtils, 'requestNotificationsPermissions')
+    .mockReturnValue();
+  jest.spyOn(NotificationsUtils, 'registerDeviceToken').mockReturnValue();
+
+  Platform.OS = 'ios';
+});
+
+test('requests permissions', async () => {
+  renderProvider({
+    enabled: true,
+    applicationName: 'test-app',
+    channelId: 'test-channel',
+    description: 'test-description',
+  });
+
+  await waitFor(() => {
+    expect(
+      NotificationsUtils.requestNotificationsPermissions,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  const callback = jest.mocked(
+    NotificationsUtils.requestNotificationsPermissions,
+  ).mock.calls[0][0];
+
+  act(() => {
+    callback({ deviceToken: 'test-token' });
+  });
+
+  expect(NotificationsUtils.registerDeviceToken).toHaveBeenCalledTimes(1);
+  expect(NotificationsUtils.registerDeviceToken).toHaveBeenCalledWith({
+    deviceToken: 'test-token',
+    application: 'test-app',
+    accountId: 'test-account',
+    httpClient: expect.anything(),
+  });
+});
+
+test('on Android, sets channel', async () => {
+  Platform.OS = 'android';
+  renderProvider({
+    enabled: true,
+    applicationName: 'test-app',
+    channelId: 'test-channel',
+    description: 'test-description',
+  });
+
+  await waitFor(() => {
+    expect(Notifications.setNotificationChannel).toHaveBeenCalledTimes(1);
+    expect(Notifications.setNotificationChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 'test-channel',
+        name: 'test-app',
+      }),
+    );
+  });
+});

--- a/src/hooks/useSetUserProfileEffect.test.ts
+++ b/src/hooks/useSetUserProfileEffect.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
   useUpdateUserMock.mockReturnValue({
     mutate: updateUser,
   });
-  useActiveProjectMock.mockReturnValue({});
+  useActiveProjectMock.mockReturnValue({ activeSubject: {} });
 });
 
 test('should update the user once all hooks load and the user does not have data', () => {

--- a/src/hooks/useSetUserProfileEffect.ts
+++ b/src/hooks/useSetUserProfileEffect.ts
@@ -11,8 +11,8 @@ export const useSetUserProfileEffect = () => {
     const hasFetchedUser = !isLoading && isFetched;
     const userHasName = !!user?.profile.givenName || !!user?.profile.familyName;
     const name =
-      activeSubject?.name?.find((v) => v.use === 'official') ??
-      activeSubject?.name?.[0];
+      activeSubject.name?.find((v) => v.use === 'official') ??
+      activeSubject.name?.[0];
     const subjectHasName = !!name?.family || !!name?.given?.length;
 
     if (hasFetchedUser && !userHasName && subjectHasName) {

--- a/src/hooks/useWearableBackfill.tsx
+++ b/src/hooks/useWearableBackfill.tsx
@@ -51,11 +51,7 @@ export const useWearableBackfill = (
     ['backfill-sync-status', ...ehrTypes],
     queryEHRSyncStatus,
     {
-      enabled:
-        !!activeSubjectId &&
-        isFetched &&
-        ehrTypes.length > 0 &&
-        !!isBackfillEnabled,
+      enabled: isFetched && ehrTypes.length > 0 && !!isBackfillEnabled,
       select(data) {
         const statuses: Record<string, boolean> = {};
 

--- a/src/navigators/LoggedInStack.tsx
+++ b/src/navigators/LoggedInStack.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { TabNavigator } from './TabNavigator';
 import { ConsentScreen } from '../screens/ConsentScreen';
 import { CircleThreadScreen } from '../screens/CircleThreadScreen';
-import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
 import { OnboardingCourseScreen } from '../screens/OnboardingCourseScreen';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { LoggedInRootParamList } from './types';
@@ -24,17 +23,8 @@ export function LoggedInStack() {
   useSetUserProfileEffect();
   // Fetch profiles early but don't wait for them
   useProfilesForAllTiles();
-  const {
-    account,
-    isLoading: isLoadingAccount,
-    isFetched: isFetchedAccount,
-  } = useActiveAccount();
-  const {
-    activeProject,
-    activeSubjectId,
-    isLoading: isLoadingProject,
-    isFetched: isFetchedProject,
-  } = useActiveProject();
+  const { account } = useActiveAccount();
+  const { activeProject, activeSubjectId } = useActiveProject();
   const { useShouldRenderConsentScreen } = useConsent();
   const { shouldRenderConsentScreen, isLoading: loadingConsents } =
     useShouldRenderConsentScreen();
@@ -49,33 +39,23 @@ export function LoggedInStack() {
     !!onAppSessionStart,
   );
 
-  const loadingProject = !isFetchedProject || isLoadingProject;
-  const loadingAccount = !isFetchedAccount || isLoadingAccount;
-  const hasAccount = !loadingAccount && !!account?.id;
-  const loadingAccountOrProject =
-    loadingAccount || (hasAccount && loadingProject);
   const loadingOnboardingCourse =
     !onboardingCourseIsFetched || onboardingCourseIsLoading;
-  const hasAccountAndProject = !!(activeProject?.id && account?.id);
 
   const resumeAppSession = useCallback(async () => {
     setShouldWaitForOnAppStart(false);
   }, [setShouldWaitForOnAppStart]);
 
-  const initialRoute = !hasAccountAndProject
-    ? 'InviteRequired'
-    : shouldRenderConsentScreen
+  const initialRoute = shouldRenderConsentScreen
     ? 'screens/ConsentScreen'
     : shouldLaunchOnboardingCourse
     ? 'screens/OnboardingCourseScreen'
     : 'app';
 
   const getLoadingMessage = useCallback(() => {
-    if (loadingAccountOrProject) {
-      return t('waiting-for-account-and-project', 'Loading account');
-    } else if (hasAccountAndProject && loadingConsents) {
+    if (loadingConsents) {
       return t('root-stack-waiting-for-consents', 'Loading consents');
-    } else if (hasAccountAndProject && loadingOnboardingCourse) {
+    } else if (loadingOnboardingCourse) {
       return t(
         'root-stack-waiting-for-app-config',
         'Loading onboarding course data',
@@ -91,9 +71,7 @@ export function LoggedInStack() {
       );
     }
   }, [
-    hasAccountAndProject,
     inviteParams?.inviteId,
-    loadingAccountOrProject,
     loadingConsents,
     loadingJoinCircles,
     loadingOnboardingCourse,
@@ -104,7 +82,7 @@ export function LoggedInStack() {
 
   useEffect(() => {
     const executeOnAppStartIfNeeded = async () => {
-      if (shouldWaitForOnAppStart && hasAccountAndProject && activeSubjectId) {
+      if (shouldWaitForOnAppStart) {
         await onAppSessionStart?.({
           resumeAppSession,
           activeSubjectId,
@@ -118,7 +96,6 @@ export function LoggedInStack() {
     account,
     activeProject,
     activeSubjectId,
-    hasAccountAndProject,
     onAppSessionStart,
     resumeAppSession,
     shouldWaitForOnAppStart,
@@ -130,14 +107,6 @@ export function LoggedInStack() {
 
   return (
     <Stack.Navigator initialRouteName={initialRoute}>
-      <Stack.Screen
-        name="InviteRequired"
-        component={InviteRequiredScreen}
-        options={{
-          presentation: 'fullScreenModal',
-          title: t('invite-required', 'Invitation Required'),
-        }}
-      />
       <Stack.Screen
         name="app"
         component={TabNavigator}

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -19,7 +19,6 @@ import { ComposeMessageParams } from '../screens/ComposeMessageScreen';
 export type LoggedInRootParamList = {
   app: NavigatorScreenParams<TabParamList> | undefined;
   'screens/ConsentScreen': undefined;
-  InviteRequired: undefined;
   'Circle/Thread': { post: Post; createNewComment?: boolean };
   'screens/OnboardingCourseScreen': undefined;
 };

--- a/src/screens/AppTileScreen.test.tsx
+++ b/src/screens/AppTileScreen.test.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { WebView } from 'react-native-webview';
 import { AppTileScreen } from './AppTileScreen';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as UseHandleAppTileEvents from '../hooks/useHandleAppTileEvents';
 
 jest.mock('react-native-webview', () => ({
   WebView: jest.fn().mockReturnValue(<></>),
@@ -34,6 +35,11 @@ const useNavigationMock = useNavigation as any as jest.Mock;
 beforeEach(() => {
   route.params.appTile = exampleAppTile;
   useNavigationMock.mockReturnValue(navigation);
+
+  jest.spyOn(UseHandleAppTileEvents, 'useHandleAppTileEvents').mockReturnValue({
+    handleAppTileMessage: jest.fn(),
+    handleAppTileNavigationStateChange: jest.fn(),
+  });
 });
 
 test('renders webview with source prop', () => {

--- a/src/screens/AuthedAppTileScreen.tsx
+++ b/src/screens/AuthedAppTileScreen.tsx
@@ -70,12 +70,7 @@ export const AuthedAppTileScreen = ({
     styles.backActionIcon?.color,
   ]);
 
-  const {
-    activeProject,
-    activeSubjectId,
-    isLoading: loadingProject,
-    isFetched: projectedFetched,
-  } = useActiveProject();
+  const { activeProject, activeSubjectId } = useActiveProject();
   const {
     account,
     isLoading: loadingAccounts,
@@ -89,9 +84,9 @@ export const AuthedAppTileScreen = ({
   const [isPageLoaded, setIsPageLoaded] = useState(false);
 
   // Conditions to be met before building the applet uri
-  const isLoading = loadingCode || loadingAccounts || loadingProject;
-  const isFetched = codeFetched && accountFetched && projectedFetched;
-  const hasData = data?.code && account?.id && activeProject?.id;
+  const isLoading = loadingCode || loadingAccounts;
+  const isFetched = codeFetched && accountFetched;
+  const hasData = data?.code && account?.id;
 
   const readyToBuildUri = isFetched && !isLoading && hasData;
   const oauthCallbackUrl = appTile.callbackUrls?.[0]!;
@@ -106,13 +101,8 @@ export const AuthedAppTileScreen = ({
       parsed.accountId = account.id;
     }
 
-    if (activeProject?.id) {
-      parsed.projectId = activeProject.id;
-    }
-
-    if (activeSubjectId) {
-      parsed.patientId = activeSubjectId;
-    }
+    parsed.projectId = activeProject.id;
+    parsed.patientId = activeSubjectId;
 
     for (const [key, value] of Object.entries(searchParams)) {
       parsed[key] = value;

--- a/src/screens/InviteRequiredScreen.tsx
+++ b/src/screens/InviteRequiredScreen.tsx
@@ -4,10 +4,10 @@ import { Text, View } from 'react-native';
 import {
   OAuthLogoutButton,
   OAuthLogoutButtonStyles,
-  createStyles,
-} from '../components';
+} from '../components/OAuthLogoutButton';
+import { createStyles } from '../components/BrandConfigProvider';
 import { tID } from '../common/testID';
-import { useStyles } from '../hooks';
+import { useStyles } from '../hooks/useStyles';
 
 export const InviteRequiredScreen = () => {
   const { styles } = useStyles(defaultStyles);

--- a/src/screens/MyDataScreen.test.tsx
+++ b/src/screens/MyDataScreen.test.tsx
@@ -10,7 +10,7 @@ import {
   startOfYear,
   addDays,
 } from 'date-fns';
-import { AppConfig, useAppConfig } from '../hooks';
+import { ActiveProjectContext, AppConfig, useAppConfig } from '../hooks';
 import { MyDataScreen } from './MyDataScreen';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
@@ -63,7 +63,16 @@ const baseURL = 'https://some-domain/unit-test';
 const myDataScreen = (
   <QueryClientProvider client={queryClient}>
     <GraphQLClientContextProvider baseURL={baseURL}>
-      <MyDataScreen />
+      <ActiveProjectContext.Provider
+        value={
+          {
+            activeProject: { id: 'mock-project' },
+            activeSubjectId: 'mock-patient',
+          } as any
+        }
+      >
+        <MyDataScreen />
+      </ActiveProjectContext.Provider>
     </GraphQLClientContextProvider>
   </QueryClientProvider>
 );

--- a/src/screens/ProfileScreen.test.tsx
+++ b/src/screens/ProfileScreen.test.tsx
@@ -5,6 +5,7 @@ import { useUser } from '../hooks/useUser';
 import { useMe } from '../hooks/useMe';
 import { User } from '../types';
 import { Patient } from 'fhir/r3';
+import { ActiveProjectContext } from '../hooks';
 
 jest.mock('../hooks/useUser', () => ({
   useUser: jest.fn(),
@@ -34,13 +35,21 @@ const exampleProfile: User = {
   },
 };
 
+const screen = (
+  <ActiveProjectContext.Provider
+    value={{ activeProject: { name: 'Test Project' } } as any}
+  >
+    <ProfileScreen />
+  </ActiveProjectContext.Provider>
+);
+
 test('renders loading indicator initially', async () => {
   useUserMock.mockReturnValue({
     isLoading: true,
     data: undefined,
   });
 
-  const { getByTestId, rerender } = render(<ProfileScreen />);
+  const { getByTestId, rerender } = render(screen);
   expect(getByTestId('activity-indicator-view')).toBeDefined();
 
   useUserMock.mockReturnValue({
@@ -48,14 +57,14 @@ test('renders loading indicator initially', async () => {
     data: undefined, // Still waiting for data
   });
 
-  rerender(<ProfileScreen />);
+  rerender(screen);
   expect(getByTestId('activity-indicator-view')).toBeDefined();
 });
 
 test('renders profile label/values given user profile', () => {
   mockUser(exampleProfile);
 
-  const { getByText, getByTestId } = render(<ProfileScreen />);
+  const { getByText, getByTestId } = render(screen);
   expect(getByTestId('Username')).toBeDefined();
   expect(getByTestId('First Name')).toBeDefined();
   expect(getByTestId('Last Name')).toBeDefined();
@@ -79,7 +88,7 @@ test('does not render fields which are not populated', () => {
     },
   });
 
-  const { queryByTestId } = render(<ProfileScreen />);
+  const { queryByTestId } = render(screen);
   expect(queryByTestId('First Name')).toBeNull();
   expect(queryByTestId('Last Name')).toBeNull();
   expect(queryByTestId('Username')).not.toBeNull();

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -106,9 +106,7 @@ export const ProfileScreen = () => {
           value={userProfile.familyName}
         />
         <Field label={t('profile-email', 'Email')} value={userProfile.email} />
-        {__DEV__ && (
-          <Field label="Active Project" value={activeProject?.name} />
-        )}
+        {__DEV__ && <Field label="Active Project" value={activeProject.name} />}
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Changes
**Reviewers:** I've separated the changes here into dedicated commits for maximum reviewability. I highly recommend reviewing by commit, with **Hide Whitespace Changes** turned on.

The commits:
- Modifications to the type contract and implementation of `useActiveProject`, as well as the other core changes to "move" the InviteRequired screen higher up the tree.

- Update internal references to `useActiveProject` to pull out any now-dead conditional logic around the return values.

- Update tests to reflect the changes above^.

- Entirely unrelated: adding a test suite to `usePushNotifications`, to put this PR above the coverage threshold requirement.

## Screenshots
I performed in-depth manual testing of this change in internal apps -- I confirmed that during the various onboarding/login flows, the previous experience is still provided.

That said, any _additional_ manual testing would of course be welcomed.