### PR TITLE
fix: Layout Issue for Direct Messages Input

### DIFF
--- a/src/components/tiles/TilesList.tsx
+++ b/src/components/tiles/TilesList.tsx
@@ -141,6 +141,7 @@ export function TilesList({ navigation, styles: instanceStyles }: Props) {
             navigation={navigation}
             title={displayName}
             id={id}
+            key={id}
           />
         ))}
         {data?.homeTab?.circleTiles?.map((circleTile: CircleTile) => (

--- a/src/screens/DirectMessagesScreen.test.tsx
+++ b/src/screens/DirectMessagesScreen.test.tsx
@@ -12,6 +12,9 @@ import {
 
 jest.unmock('i18next');
 jest.unmock('@react-navigation/native');
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: jest.fn(() => 0),
+}));
 jest.mock('../hooks/useUser', () => ({
   useUser: jest.fn(),
 }));

--- a/src/screens/DirectMessagesScreen.tsx
+++ b/src/screens/DirectMessagesScreen.tsx
@@ -27,6 +27,8 @@ import {
 } from '../hooks/useConversations';
 import { User } from '../types';
 import { ScreenProps } from './utils/stack-helpers';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { Platform } from 'react-native';
 
 export type DirectMessageParams = {
   users: User[];
@@ -44,6 +46,7 @@ export const DirectMessagesScreen = ({
   const { mutateAsync: markAsRead } = useMarkAsRead();
   const { data: conversations } = useInfiniteConversations();
   const { data: userData, isLoading: userLoading } = useUser();
+  const tabsHeight = useBottomTabBarHeight();
   const otherProfiles = users.filter((user) => user.id !== userData?.id);
 
   useEffect(() => {
@@ -113,6 +116,7 @@ export const DirectMessagesScreen = ({
       user={{
         _id: userData.id,
       }}
+      bottomOffset={Platform.select({ ios: tabsHeight })}
       messagesContainerStyle={styles.messagesContainerStyle}
       renderBubble={(props) => {
         return (


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes a bug on iOS for Direct Message Input where there was too much space added (accounted for tabs which should only happen on android)
  - Fixes a missing key warning

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><b>Before
 <td><b>After
<tr>
 <td><img src="https://github.com/lifeomic/react-native-sdk/assets/2295908/5522e3cf-8f59-4549-b33a-dbbc19dc9e05" />
 <td><img src="https://github.com/lifeomic/react-native-sdk/assets/2295908/ba0f02e8-b7d9-44cf-902b-8864f001b90e" />
</table>
