### PR TITLE
feat!: require specifying a top-level `account`

### DIFF
--- a/example/AppDemo.tsx
+++ b/example/AppDemo.tsx
@@ -21,7 +21,7 @@ function App() {
         apiBaseURL: baseURL,
       }}
     >
-      <RootProviders authConfig={authConfig}>
+      <RootProviders account="mockaccount" authConfig={authConfig}>
         <LoggedInStack />
       </RootProviders>
     </DeveloperConfigProvider>

--- a/example/storybook/helpers/DataProviderDecorator.tsx
+++ b/example/storybook/helpers/DataProviderDecorator.tsx
@@ -4,7 +4,10 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { HttpClientContextProvider } from '../../../src/hooks/useHttpClient';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ActiveAccountContext, ActiveProjectContext } from '../../../src/hooks';
+import {
+  ActiveAccountProvider,
+  ActiveProjectContext,
+} from '../../../src/hooks';
 
 export type DataOverrideProviderProps = {
   children: React.ReactNode;
@@ -25,13 +28,7 @@ export const DataOverrideProvider: React.FC<DataOverrideProviderProps> = ({
   }
 
   return (
-    <ActiveAccountContext.Provider
-      value={
-        {
-          accountHeaders: {},
-        } as any
-      }
-    >
+    <ActiveAccountProvider account="mockaccount">
       <ActiveProjectContext.Provider
         value={
           {
@@ -49,7 +46,7 @@ export const DataOverrideProvider: React.FC<DataOverrideProviderProps> = ({
           </HttpClientContextProvider>
         </QueryClientProvider>
       </ActiveProjectContext.Provider>
-    </ActiveAccountContext.Provider>
+    </ActiveAccountProvider>
   );
 };
 

--- a/example/storybook/stories/ActivityIndicatorView.stories.tsx
+++ b/example/storybook/stories/ActivityIndicatorView.stories.tsx
@@ -18,7 +18,7 @@ storiesOf('ActivityIndicatorView', module)
         },
       }}
     >
-      <RootProviders authConfig={authConfig}>
+      <RootProviders account="mockaccount" authConfig={authConfig}>
         <ActivityIndicatorView message="Timed out, is something wrong?" />
       </RootProviders>
     </DeveloperConfigProvider>

--- a/example/storybook/stories/CustomScreenInjection/CustomScreenInjection.stories.tsx
+++ b/example/storybook/stories/CustomScreenInjection/CustomScreenInjection.stories.tsx
@@ -49,7 +49,7 @@ storiesOf('Custom Screen Injection', module)
           },
         }}
       >
-        <RootProviders authConfig={authConfig}>
+        <RootProviders account="mockaccount" authConfig={authConfig}>
           <LoggedInStack />
         </RootProviders>
       </DeveloperConfigProvider>

--- a/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
+++ b/example/storybook/stories/ExampleApp/ExampleApp.stories.tsx
@@ -36,7 +36,7 @@ storiesOf('Example App', module)
           apiBaseURL: baseURL,
         }}
       >
-        <RootProviders authConfig={authConfig}>
+        <RootProviders account="mockaccount" authConfig={authConfig}>
           <LoggedInStack />
         </RootProviders>
       </DeveloperConfigProvider>
@@ -68,7 +68,7 @@ storiesOf('Example App', module)
           apiBaseURL: baseURL,
         }}
       >
-        <RootProviders authConfig={authConfig}>
+        <RootProviders account="mockaccount" authConfig={authConfig}>
           <LoggedInStack />
         </RootProviders>
       </DeveloperConfigProvider>
@@ -146,7 +146,7 @@ storiesOf('Example App', module)
               apiBaseURL: baseURL,
             }}
           >
-            <RootProviders authConfig={authConfig}>
+            <RootProviders account="mockaccount" authConfig={authConfig}>
               <LoggedInStack />
             </RootProviders>
           </DeveloperConfigProvider>
@@ -245,7 +245,7 @@ storiesOf('Example App', module)
           apiBaseURL: baseURL,
         }}
       >
-        <RootProviders authConfig={authConfig}>
+        <RootProviders account={'mockaccount'} authConfig={authConfig}>
           <BrandConfigProvider {...brand}>
             <LogoHeader visible={true} imageSource={logo} />
             <LoggedInStack />
@@ -269,7 +269,7 @@ storiesOf('Example App', module)
         },
       }}
     >
-      <RootProviders authConfig={authConfig}>
+      <RootProviders account={'mockaccount'} authConfig={authConfig}>
         <DataOverrideProvider
           builder={(mock) => {
             mock.onGet().reply(200, {

--- a/src/common/LoggedInProviders.tsx
+++ b/src/common/LoggedInProviders.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { ActiveAccountContextProvider } from '../hooks/useActiveAccount';
 import { NotificationsManagerProvider } from '../hooks/useNotificationManager';
 import { ActiveProjectContextProvider } from '../hooks/useActiveProject';
 import { TrackTileProvider } from '../components/TrackTile/TrackTileProvider';
@@ -50,23 +49,21 @@ export const LoggedInProviders = ({ children }: LoggedInProvidersProps) => {
   }
 
   return (
-    <ActiveAccountContextProvider>
-      <ActiveProjectContextProvider>
-        <TrackTileProvider>
-          <WearableLifecycleProvider>
-            <CircleTileContextProvider>
-              <OnboardingCourseContextProvider>
-                <PushNotificationsProvider config={pushNotificationsConfig}>
-                  <NotificationsManagerProvider>
-                    {children}
-                  </NotificationsManagerProvider>
-                </PushNotificationsProvider>
-                <CreateEditPostModal />
-              </OnboardingCourseContextProvider>
-            </CircleTileContextProvider>
-          </WearableLifecycleProvider>
-        </TrackTileProvider>
-      </ActiveProjectContextProvider>
-    </ActiveAccountContextProvider>
+    <ActiveProjectContextProvider>
+      <TrackTileProvider>
+        <WearableLifecycleProvider>
+          <CircleTileContextProvider>
+            <OnboardingCourseContextProvider>
+              <PushNotificationsProvider config={pushNotificationsConfig}>
+                <NotificationsManagerProvider>
+                  {children}
+                </NotificationsManagerProvider>
+              </PushNotificationsProvider>
+              <CreateEditPostModal />
+            </OnboardingCourseContextProvider>
+          </CircleTileContextProvider>
+        </WearableLifecycleProvider>
+      </TrackTileProvider>
+    </ActiveProjectContextProvider>
   );
 };

--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -15,45 +15,53 @@ import { LoggedInProviders } from './LoggedInProviders';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
 import { LogoHeaderDimensionsContextProvider } from '../hooks/useLogoHeaderDimensions';
+import { ActiveAccountProvider } from '../hooks';
 
 const queryClient = new QueryClient();
 
 export type RootProvidersProps = {
+  account: string;
   authConfig: AuthConfiguration;
   children?: React.ReactNode;
 };
 
-export function RootProviders({ authConfig, children }: RootProvidersProps) {
+export function RootProviders({
+  account,
+  authConfig,
+  children,
+}: RootProvidersProps) {
   const { apiBaseURL, theme, brand } = useDeveloperConfig();
 
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthContextProvider>
-        <HttpClientContextProvider baseURL={apiBaseURL}>
-          <GraphQLClientContextProvider baseURL={apiBaseURL}>
-            <InviteProvider>
-              <OAuthContextProvider authConfig={authConfig}>
-                <BrandConfigProvider theme={theme} {...brand}>
-                  <NoInternetToastProvider>
-                    <ActionSheetProvider>
-                      <SafeAreaProvider>
-                        <ThemedNavigationContainer>
-                          <Toast />
-                          <LoggedInProviders>
-                            <LogoHeaderDimensionsContextProvider>
-                              {children}
-                            </LogoHeaderDimensionsContextProvider>
-                          </LoggedInProviders>
-                        </ThemedNavigationContainer>
-                      </SafeAreaProvider>
-                    </ActionSheetProvider>
-                  </NoInternetToastProvider>
-                </BrandConfigProvider>
-              </OAuthContextProvider>
-            </InviteProvider>
-          </GraphQLClientContextProvider>
-        </HttpClientContextProvider>
-      </AuthContextProvider>
+      <ActiveAccountProvider account={account}>
+        <AuthContextProvider>
+          <HttpClientContextProvider baseURL={apiBaseURL}>
+            <GraphQLClientContextProvider baseURL={apiBaseURL}>
+              <InviteProvider>
+                <OAuthContextProvider authConfig={authConfig}>
+                  <BrandConfigProvider theme={theme} {...brand}>
+                    <NoInternetToastProvider>
+                      <ActionSheetProvider>
+                        <SafeAreaProvider>
+                          <ThemedNavigationContainer>
+                            <Toast />
+                            <LoggedInProviders>
+                              <LogoHeaderDimensionsContextProvider>
+                                {children}
+                              </LogoHeaderDimensionsContextProvider>
+                            </LoggedInProviders>
+                          </ThemedNavigationContainer>
+                        </SafeAreaProvider>
+                      </ActionSheetProvider>
+                    </NoInternetToastProvider>
+                  </BrandConfigProvider>
+                </OAuthContextProvider>
+              </InviteProvider>
+            </GraphQLClientContextProvider>
+          </HttpClientContextProvider>
+        </AuthContextProvider>
+      </ActiveAccountProvider>
     </QueryClientProvider>
   );
 }

--- a/src/components/Circles/__tests__/Post.test.tsx
+++ b/src/components/Circles/__tests__/Post.test.tsx
@@ -4,7 +4,11 @@ import {
   render,
 } from '../../../common/testHelpers/testing-library-wrapper';
 import { PostItem } from '../PostItem';
-import { Post as PostType, Priority } from '../../../hooks';
+import {
+  ActiveAccountProvider,
+  Post as PostType,
+  Priority,
+} from '../../../hooks';
 
 jest.unmock('@react-navigation/native');
 jest.mock('../ReactionsToolbar');
@@ -34,7 +38,11 @@ const post: PostType = {
 };
 
 test('renders a post', () => {
-  const postItem = render(<PostItem post={post} onComment={jest.fn()} />);
+  const postItem = render(
+    <ActiveAccountProvider account="mockaccount">
+      <PostItem post={post} onComment={jest.fn()} />
+    </ActiveAccountProvider>,
+  );
   expect(postItem.getByText('Announcement')).toBeDefined();
   expect(postItem.getByText(post.message!)).toBeDefined();
   expect(postItem.getByText(post.author!.profile.displayName)).toBeDefined();
@@ -42,7 +50,11 @@ test('renders a post', () => {
 
 test('clicking comment calls onComment', () => {
   const onComment = jest.fn();
-  const postItem = render(<PostItem post={post} onComment={onComment} />);
+  const postItem = render(
+    <ActiveAccountProvider account="mockaccount">
+      <PostItem post={post} onComment={onComment} />
+    </ActiveAccountProvider>,
+  );
 
   fireEvent.press(postItem.getByText('COMMENT'));
 

--- a/src/components/Circles/__tests__/PostList.test.tsx
+++ b/src/components/Circles/__tests__/PostList.test.tsx
@@ -5,7 +5,11 @@ import {
 } from '../../../common/testHelpers/testing-library-wrapper';
 import { PostsList } from '../PostsList';
 import { CircleTile } from '../../../hooks/useAppConfig';
-import { useInfinitePosts, useCreatePost } from '../../../hooks';
+import {
+  useInfinitePosts,
+  useCreatePost,
+  ActiveAccountProvider,
+} from '../../../hooks';
 import { CreateEditPostModal } from '../CreateEditPostModal';
 
 jest.unmock('@react-navigation/native');
@@ -28,6 +32,13 @@ jest.mock('../../../hooks/Circles/useActiveCircleTile', () => ({
 const useInfinitePostsMock = useInfinitePosts as jest.Mock;
 const useCreatePostMock = useCreatePost as jest.Mock;
 
+const renderSafe = (element: React.ReactNode) =>
+  render(
+    <ActiveAccountProvider account="mockaccount">
+      {element}
+    </ActiveAccountProvider>,
+  );
+
 test('renders no post text when no posts are returned', () => {
   useInfinitePostsMock.mockReturnValue({
     data: {
@@ -41,7 +52,7 @@ test('renders no post text when no posts are returned', () => {
     },
   });
 
-  const postsList = render(<PostsList onOpenPost={jest.fn()} />);
+  const postsList = renderSafe(<PostsList onOpenPost={jest.fn()} />);
   expect(postsList.getByText('No posts yet.')).toBeDefined();
 });
 
@@ -71,7 +82,7 @@ test('renders a post', () => {
     },
   });
 
-  const postsList = render(<PostsList onOpenPost={jest.fn()} />);
+  const postsList = renderSafe(<PostsList onOpenPost={jest.fn()} />);
   expect(postsList.getByText('Hello!')).toBeDefined();
   expect(postsList.getByText('Joe Shmoe')).toBeDefined();
 });
@@ -94,7 +105,7 @@ test('FAB shows the new post modal', () => {
     mutate: mutateMock,
   });
 
-  const postsList = render(
+  const postsList = renderSafe(
     <>
       <CreateEditPostModal />
       <PostsList onOpenPost={jest.fn()} />
@@ -136,7 +147,7 @@ test('clicking post or comment calls onOpenPost with correct data', () => {
   });
 
   const onOpenPost = jest.fn();
-  const postsList = render(<PostsList onOpenPost={onOpenPost} />);
+  const postsList = renderSafe(<PostsList onOpenPost={onOpenPost} />);
 
   fireEvent.press(postsList.getByText('Hello!'));
 

--- a/src/components/Circles/__tests__/Thread.test.tsx
+++ b/src/components/Circles/__tests__/Thread.test.tsx
@@ -5,7 +5,12 @@ import {
   waitFor,
 } from '@testing-library/react-native';
 import { Thread } from '../Thread';
-import { usePost, Post, useLoadReplies } from '../../../hooks';
+import {
+  usePost,
+  Post,
+  useLoadReplies,
+  ActiveAccountProvider,
+} from '../../../hooks';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 jest.unmock('@react-navigation/native');
@@ -89,7 +94,9 @@ const mockPost: Post = {
 const render = (children: React.ReactNode) => {
   return renderComponent(
     <QueryClientProvider client={new QueryClient()}>
-      {children}
+      <ActiveAccountProvider account="mockaccount">
+        {children}
+      </ActiveAccountProvider>
     </QueryClientProvider>,
   );
 };

--- a/src/components/Circles/__tests__/ThreadComment.test.tsx
+++ b/src/components/Circles/__tests__/ThreadComment.test.tsx
@@ -4,7 +4,7 @@ import {
   render,
 } from '../../../common/testHelpers/testing-library-wrapper';
 import { ThreadComment } from '../ThreadComment';
-import { Post } from '../../../hooks';
+import { ActiveAccountProvider, Post } from '../../../hooks';
 
 jest.unmock('@react-navigation/native');
 jest.mock('date-fns', () => ({
@@ -39,7 +39,9 @@ const mockPost: Post = {
 describe('ThreadComment', () => {
   test('renders the component', () => {
     const { getByText } = render(
-      <ThreadComment post={mockPost} onReply={jest.fn()} />,
+      <ActiveAccountProvider account="mockaccount">
+        <ThreadComment post={mockPost} onReply={jest.fn()} />
+      </ActiveAccountProvider>,
     );
 
     expect(getByText('Shaggy')).toBeDefined();
@@ -51,7 +53,9 @@ describe('ThreadComment', () => {
     const onReply = jest.fn();
 
     const { getByText } = render(
-      <ThreadComment post={mockPost} onReply={onReply} />,
+      <ActiveAccountProvider account="mockaccount">
+        <ThreadComment post={mockPost} onReply={onReply} />
+      </ActiveAccountProvider>,
     );
 
     fireEvent.press(getByText('REPLY'));

--- a/src/components/TrackTile/hooks/test/useAxiosTrackTileService.test.tsx
+++ b/src/components/TrackTile/hooks/test/useAxiosTrackTileService.test.tsx
@@ -62,7 +62,7 @@ jest.mock('../../../../hooks/useHttpClient', () => ({
 
 jest.mock('../../../../hooks/useActiveAccount', () => ({
   useActiveAccount: () => ({
-    account: { id: 'account-id' },
+    account: 'account-id',
   }),
 }));
 

--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -53,7 +53,6 @@ export const useAxiosTrackTileService = (): TrackTileService => {
   const [previousUserId, setPreviousUserId] = useState(userId);
   const { ontology: devConfigOntology } = useDeveloperConfig();
 
-  const accountId = account?.id || '';
   const projectId = activeProject.id;
   const { includePublic = false } = appConfig?.homeTab?.trackTileSettings ?? {};
 
@@ -209,7 +208,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
   };
 
   return {
-    accountId,
+    accountId: account,
     projectId,
     patientId,
 
@@ -228,10 +227,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
 
       const url = `/v1/track-tiles/trackers${params && `?${params}`}`;
 
-      const res = await httpClient.get(
-        url,
-        axiosConfig({ account: accountId }),
-      );
+      const res = await httpClient.get(url, axiosConfig({ account }));
       const fetchedTrackers: Tracker[] = res.data;
 
       cache.trackers = fetchedTrackers;
@@ -243,7 +239,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
       const res = await httpClient.put<InstalledMetric>(
         `/v1/track-tiles/metrics/installs/${metricId}`,
         settings,
-        axiosConfig({ account: accountId }),
+        axiosConfig({ account }),
       );
 
       return updateSettingsInCache(res.data) || res.data;
@@ -253,7 +249,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
       await httpClient.put(
         '/v1/track-tiles/metrics/installs',
         settings,
-        axiosConfig({ account: accountId }),
+        axiosConfig({ account }),
       );
 
       settings.forEach(updateSettingsInCache);
@@ -283,7 +279,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
           },
           query: FETCH_TRACKER_VALUES_BY_DATES_QUERY,
         },
-        axiosConfig({ account: accountId }),
+        axiosConfig({ account }),
       );
 
       const trackerValues = extractTrackerValues(res.data);
@@ -302,7 +298,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
           query: DELETE_RESOURCE(resourceType),
           variables: { id },
         },
-        axiosConfig({ account: accountId }),
+        axiosConfig({ account }),
       );
 
       if (!res.data.data) {
@@ -335,7 +331,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
               : MUTATE_PROCEDURE_RESOURCE(resource.id ? 'Update' : 'Create'),
           variables: { resource },
         },
-        axiosConfig({ account: accountId }),
+        axiosConfig({ account }),
       );
 
       if (!res.data.data) {
@@ -404,7 +400,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
             code: codeBelow,
           },
         },
-        axiosConfig({ account: accountId }),
+        axiosConfig({ account }),
       );
 
       if (!res.data.data) {

--- a/src/hooks/Circles/useInfinitePosts.tsx
+++ b/src/hooks/Circles/useInfinitePosts.tsx
@@ -60,7 +60,7 @@ export function useInfinitePosts({ circleId }: useInfinitePostsProps) {
     hasNextPage,
     fetchNextPage,
   } = useInfiniteQuery(['posts', circleTile?.circleId], queryPosts, {
-    enabled: !!accountHeaders?.['LifeOmic-Account'] && !!circleId,
+    enabled: !!circleId,
     getNextPageParam: (lastPage) => {
       return lastPage.postsV2.pageInfo.hasNextPage
         ? lastPage.postsV2.pageInfo.endCursor

--- a/src/hooks/Circles/useJoinCircles.tsx
+++ b/src/hooks/Circles/useJoinCircles.tsx
@@ -26,7 +26,7 @@ export function useJoinCircles() {
       }
     },
     {
-      enabled: !!accountHeaders && !!data?.homeTab?.circleTiles,
+      enabled: !!data?.homeTab?.circleTiles,
     },
   );
 }

--- a/src/hooks/Circles/useLoadReplies.ts
+++ b/src/hooks/Circles/useLoadReplies.ts
@@ -11,7 +11,7 @@ import { useActiveCircleTile } from './useActiveCircleTile';
 export const useLoadReplies = () => {
   const { graphQLClient } = useGraphQLClient();
   const queryClient = useQueryClient();
-  const { isFetched, accountHeaders } = useActiveAccount();
+  const { accountHeaders } = useActiveAccount();
   const [queryVariables, setQueryVariables] = useState({
     after: undefined as string | undefined,
     id: '',
@@ -37,7 +37,7 @@ export const useLoadReplies = () => {
     ],
     queryForPostReplies,
     {
-      enabled: isFetched && !!accountHeaders && !!queryVariables.id,
+      enabled: !!queryVariables.id,
       onSuccess(data) {
         if (!data) {
           return;

--- a/src/hooks/Circles/usePost.ts
+++ b/src/hooks/Circles/usePost.ts
@@ -8,7 +8,7 @@ import { PostDetailsPostQueryResponse } from './useInfinitePosts';
 
 export const usePost = (post: Partial<Post> & Pick<Post, 'id'>) => {
   const { graphQLClient } = useGraphQLClient();
-  const { isFetched, accountHeaders } = useActiveAccount();
+  const { accountHeaders } = useActiveAccount();
 
   const queryForPostDetails = useCallback(async () => {
     return graphQLClient.request<PostDetailsPostQueryResponse, { id: string }>(
@@ -21,7 +21,6 @@ export const usePost = (post: Partial<Post> & Pick<Post, 'id'>) => {
   }, [accountHeaders, graphQLClient, post.id]);
 
   return useQuery(['postDetails', post.id], queryForPostDetails, {
-    enabled: isFetched && !!accountHeaders,
     placeholderData: {
       post,
     },

--- a/src/hooks/Circles/usePrivatePosts.ts
+++ b/src/hooks/Circles/usePrivatePosts.ts
@@ -98,7 +98,7 @@ export function useInfinitePrivatePosts(userIds: string[]) {
   };
 
   return useInfiniteQuery(['privatePosts', ...users], queryPosts, {
-    enabled: !!accountHeaders?.['LifeOmic-Account'] && !!data?.id,
+    enabled: !!data?.id,
     getNextPageParam: (lastPage) => {
       return lastPage.privatePosts.pageInfo.hasNextPage
         ? lastPage.privatePosts.pageInfo.endCursor

--- a/src/hooks/Circles/useReactionMutations.test.tsx
+++ b/src/hooks/Circles/useReactionMutations.test.tsx
@@ -7,6 +7,7 @@ import {
   useCreateReactionMutation,
   useUndoReactionMutation,
 } from './useReactionMutations';
+import { ActiveAccountProvider } from '../useActiveAccount';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -30,9 +31,11 @@ const renderCreateReactionHook = async () => {
   return renderHook(() => useCreateReactionMutation(), {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>
-        <GraphQLClientContextProvider baseURL={baseURL}>
-          {children}
-        </GraphQLClientContextProvider>
+        <ActiveAccountProvider account="mockaccount">
+          <GraphQLClientContextProvider baseURL={baseURL}>
+            {children}
+          </GraphQLClientContextProvider>
+        </ActiveAccountProvider>
       </QueryClientProvider>
     ),
   });
@@ -42,9 +45,11 @@ const renderUndoReactionHook = async () => {
   return renderHook(() => useUndoReactionMutation(), {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>
-        <GraphQLClientContextProvider baseURL={baseURL}>
-          {children}
-        </GraphQLClientContextProvider>
+        <ActiveAccountProvider account="mockaccount">
+          <GraphQLClientContextProvider baseURL={baseURL}>
+            {children}
+          </GraphQLClientContextProvider>
+        </ActiveAccountProvider>
       </QueryClientProvider>
     ),
   });

--- a/src/hooks/todayTile/useTodayTasks.tsx
+++ b/src/hooks/todayTile/useTodayTasks.tsx
@@ -43,7 +43,6 @@ const useConsentTasks = () => {
       includeForm: true,
     },
     {
-      enabled: !!accountHeaders,
       axios: { headers: accountHeaders },
       select: (data) => data.items,
     },
@@ -73,7 +72,6 @@ export const useGetSurveyResponsesForProject = (
       pageSize: input?.pageSize ?? 100,
     },
     {
-      enabled: !!accountHeaders,
       axios: { headers: accountHeaders },
       select: (data) => data.items,
     },
@@ -93,7 +91,7 @@ const GetIncompleteActivitiesCount = gql`
 
 export const useGetIncompleteActivitiesCount = () => {
   const { graphQLClient } = useGraphQLClient();
-  const { isFetched, accountHeaders } = useActiveAccount();
+  const { accountHeaders } = useActiveAccount();
 
   const queryForPostDetails = useCallback(async () => {
     return graphQLClient.request<GetIncompleteActivitiesCountQueryResponse>(
@@ -103,9 +101,7 @@ export const useGetIncompleteActivitiesCount = () => {
     );
   }, [accountHeaders, graphQLClient]);
 
-  return useQuery(['getIncompleteActivitiesCount'], queryForPostDetails, {
-    enabled: isFetched && !!accountHeaders,
-  });
+  return useQuery(['getIncompleteActivitiesCount'], queryForPostDetails);
 };
 
 export const useTodayTasks = () => {

--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -1,253 +1,31 @@
 import React from 'react';
-import {
-  act,
-  render,
-  renderHook,
-  waitFor,
-} from '@testing-library/react-native';
-import {
-  ActiveAccountContextProvider,
-  PREFERRED_ACCOUNT_ID_KEY,
-  useActiveAccount,
-} from './useActiveAccount';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { inviteNotifier } from '../components/Invitations/InviteNotifier';
-import { createRestAPIMock } from '../test-utils/rest-api-mocking';
-import { _store } from './useStoredValue';
-import { Text } from 'react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { ActiveAccountProvider, useActiveAccount } from './useActiveAccount';
 
-const api = createRestAPIMock();
-
-jest.mock('./useAuth', () => ({
-  useAuth: () => ({
-    isLoggedIn: true,
-  }),
-}));
-
-const accountId1 = 'acct1';
-const accountId2 = 'acct2';
-
-const mockAccounts = [
-  {
-    id: accountId1,
-    products: ['LR'],
-  },
-  {
-    id: accountId2,
-    products: ['LR'],
-  },
-];
-
-const renderHookInContext = async (accountIdToSelect?: string) => {
+const renderHookInContext = async (account: string) => {
   return renderHook(() => useActiveAccount(), {
     wrapper: ({ children }) => (
-      <QueryClientProvider client={new QueryClient()}>
-        <ActiveAccountContextProvider accountIdToSelect={accountIdToSelect}>
-          {children}
-        </ActiveAccountContextProvider>
-      </QueryClientProvider>
+      <ActiveAccountProvider account={account}>
+        {children}
+      </ActiveAccountProvider>
     ),
   });
 };
 
-const queryMock = jest.fn();
-
-beforeEach(() => {
-  api.mock(
-    'GET /v1/accounts',
-    queryMock.mockReturnValue({
-      status: 200,
-      data: { accounts: mockAccounts },
-    }),
+test('without provider, methods fail', () => {
+  expect(() => {
+    renderHook(() => useActiveAccount());
+  }).toThrow(
+    'useActiveAccount must be used within a ActiveAccountContextProvider',
   );
-
-  _store.clearAll();
-});
-
-test('without provider, methods fail', async () => {
-  const { result } = renderHook(() => useActiveAccount());
-  await expect(
-    result.current.setActiveAccountId('bogus'),
-  ).rejects.toBeUndefined();
 });
 
 test('converts useAccounts data into helpful state', async () => {
-  const { result } = await renderHookInContext();
+  const { result } = await renderHookInContext('test-account');
   await waitFor(() =>
     expect(result.current).toMatchObject({
-      account: mockAccounts[0],
-      accountHeaders: { 'LifeOmic-Account': mockAccounts[0].id },
-      accountsWithProduct: mockAccounts,
+      account: 'test-account',
+      accountHeaders: { 'LifeOmic-Account': 'test-account' },
     }),
   );
-});
-
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-test('exposes some props from useAccounts', async () => {
-  api.mock('GET /v1/accounts', async () => {
-    // wait to simulate a loading state
-    await wait(200);
-    throw new Error('dummy error');
-  });
-  const { result } = await renderHookInContext();
-  expect(result.current).toMatchObject({
-    isLoading: true,
-  });
-});
-
-test('setActiveAccountId saves accountId', async () => {
-  const { result } = await renderHookInContext();
-
-  await waitFor(() =>
-    expect(result.current).toMatchObject({
-      account: mockAccounts[0],
-    }),
-  );
-
-  await act(async () => {
-    result.current.setActiveAccountId(accountId2);
-  });
-
-  await waitFor(() =>
-    expect(result.current).toMatchObject({
-      account: mockAccounts[1],
-    }),
-  );
-});
-
-test('indicates expired trial', async () => {
-  const expiredTrialAccount = {
-    id: 'acct',
-    name: 'name',
-    type: 'FREE',
-    products: ['LR'],
-    trialActive: true,
-    trialEndDate: new Date(Date.now() - 1).toISOString(),
-  };
-  api.mock('GET /v1/accounts', {
-    status: 200,
-    data: { accounts: [expiredTrialAccount as any] },
-  });
-
-  const { result } = await renderHookInContext();
-
-  await waitFor(() => {
-    expect(result.current).toMatchObject({
-      account: expiredTrialAccount,
-    });
-  });
-});
-
-test('provider allows for account override by id', async () => {
-  const { result } = await renderHookInContext(accountId2);
-  await waitFor(() =>
-    expect(result.current).toMatchObject({
-      account: mockAccounts[1],
-    }),
-  );
-});
-
-test('uses account from mmkv', async () => {
-  _store.set(PREFERRED_ACCOUNT_ID_KEY, accountId1);
-  const { result, rerender, unmount } = await renderHookInContext();
-  await waitFor(() => result.current.isLoading === false);
-  rerender({});
-
-  await waitFor(() =>
-    expect(result.current).toMatchObject({
-      account: mockAccounts[0],
-      accountHeaders: { 'LifeOmic-Account': mockAccounts[0].id },
-      accountsWithProduct: mockAccounts,
-    }),
-  );
-  unmount();
-
-  _store.set(PREFERRED_ACCOUNT_ID_KEY, accountId2);
-  const { result: nextResult, rerender: nextRerender } =
-    await renderHookInContext();
-  await waitFor(() => nextResult.current.isLoading === false);
-  nextRerender({});
-  await waitFor(() =>
-    expect(nextResult.current).toMatchObject({
-      account: mockAccounts[1],
-      accountHeaders: { 'LifeOmic-Account': mockAccounts[1].id },
-      accountsWithProduct: mockAccounts,
-    }),
-  );
-});
-
-test('initial render writes selected account to async storage', async () => {
-  await renderHookInContext(accountId2);
-  await waitFor(() =>
-    expect(_store.getString(PREFERRED_ACCOUNT_ID_KEY)).toStrictEqual(
-      accountId2,
-    ),
-  );
-});
-
-test('setAccountAccountId writes selected account to async storage', async () => {
-  const { result } = await renderHookInContext();
-  await waitFor(() =>
-    expect(_store.getString(PREFERRED_ACCOUNT_ID_KEY)).toStrictEqual(
-      accountId1,
-    ),
-  );
-  await act(async () => {
-    result.current.setActiveAccountId(accountId2);
-  });
-  await waitFor(() =>
-    expect(_store.getString(PREFERRED_ACCOUNT_ID_KEY)).toStrictEqual(
-      accountId2,
-    ),
-  );
-});
-
-test('handles accepted invites by refetching and setting account', async () => {
-  api.mock('GET /v1/accounts', { status: 200, data: { accounts: [] } });
-  const { rerender } = await renderHookInContext();
-  const invitedAccountId = 'invite-account-id';
-  act(() => {
-    api.mock('GET /v1/accounts', {
-      status: 200,
-      data: { accounts: [{ id: invitedAccountId, products: ['LR'] } as any] },
-    });
-
-    inviteNotifier.emit('inviteAccepted', {
-      id: 'invite-id',
-      account: invitedAccountId,
-      accountName: 'Unit test acct',
-      email: 'invitee@email.com',
-      status: 'ACCEPTED',
-      expirationTimestamp: '2025',
-    });
-    rerender({});
-  });
-
-  await waitFor(() =>
-    expect(_store.getString(PREFERRED_ACCOUNT_ID_KEY)).toStrictEqual(
-      invitedAccountId,
-    ),
-  );
-});
-
-test('renders the InviteRequired screen when the user has no accounts', async () => {
-  api.mock('GET /v1/accounts', {
-    status: 200,
-    data: { accounts: [] },
-  });
-
-  const screen = render(
-    <QueryClientProvider client={new QueryClient()}>
-      <ActiveAccountContextProvider>
-        <Text>content</Text>
-      </ActiveAccountContextProvider>
-    </QueryClientProvider>,
-  );
-
-  await waitFor(() => {
-    screen.getByText(
-      'This app is only available to use by invitation. Please contact your administrator for access.',
-    );
-  });
 });

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -1,112 +1,41 @@
-import React, { createContext, useEffect, useContext } from 'react';
-import { Account } from '../types/rest-types';
-import { inviteNotifier } from '../components/Invitations/InviteNotifier';
-import { ProjectInvite } from '../types';
-import { useRestCache, useRestQuery } from './rest-api';
-import { useStoredValue } from './useStoredValue';
-import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
+import React from 'react';
 
-export type ActiveAccountProps = {
-  account?: Account;
-  accountsWithProduct?: Account[];
-  accountHeaders?: Record<string, string>;
+export type ActiveAccountContextValue = {
+  account: string;
+  accountHeaders: { 'LifeOmic-Account': string };
 };
 
-export type ActiveAccountContextProps = ActiveAccountProps & {
-  setActiveAccountId: (accountId: string) => void;
-  isLoading: boolean;
-  isFetched: boolean;
-  error?: any;
-};
+const ActiveAccountContext = React.createContext<
+  ActiveAccountContextValue | undefined
+>(undefined);
 
-export const ActiveAccountContext = createContext({
-  setActiveAccountId: () => Promise.reject(),
-  isLoading: true,
-  isFetched: false,
-} as ActiveAccountContextProps);
-
-export const PREFERRED_ACCOUNT_ID_KEY = 'preferred-account-id';
-
-export const ActiveAccountContextProvider = ({
-  children,
-  accountIdToSelect,
-}: {
+export type ActiveAccountProviderProps = {
   children?: React.ReactNode;
-  /** Force provider to select the available account
-   * that matches the specified account id.
-   * Uses first available account if not specified.
-   */
-  accountIdToSelect?: string;
-}) => {
-  const accountsResult = useRestQuery(
-    'GET /v1/accounts',
-    {},
-    {
-      select: (data) => data.accounts.filter((a) => a.products.includes('LR')),
-    },
+  account: string;
+};
+
+export const ActiveAccountProvider = ({
+  children,
+  account,
+}: ActiveAccountProviderProps) => {
+  const memoized = React.useMemo(
+    () => ({ account, accountHeaders: { 'LifeOmic-Account': account } }),
+    [account],
   );
-
-  const accountsWithProduct = accountsResult.data ?? [];
-  const [preferredId, setPreferredId] = useStoredValue(
-    PREFERRED_ACCOUNT_ID_KEY,
-  );
-  const cache = useRestCache();
-
-  const selectedAccount = accountsWithProduct.length
-    ? accountsWithProduct?.find(
-        // Prefer the prop override first. Otherwise, use the stored preference.
-        (a) => a.id === (accountIdToSelect || preferredId),
-      ) ??
-      // Otherwise, use the first account in the list.
-      accountsWithProduct[0]
-    : undefined;
-
-  // Whenever the user's account changes, use the new account as
-  // the preferred account.
-  useEffect(() => {
-    if (selectedAccount?.id) {
-      setPreferredId(selectedAccount.id);
-    }
-  }, [selectedAccount, setPreferredId]);
-
-  // When the user accepts an invite to a new account, reset the cache,
-  // and also use _that_ account as the preferred account.
-  useEffect(() => {
-    const listener = async (acceptedInvite: ProjectInvite) => {
-      cache.resetQueries({ 'GET /v1/accounts': 'all' });
-      setPreferredId(acceptedInvite.account);
-      inviteNotifier.emit('inviteAccountSettled');
-    };
-    inviteNotifier.addListener('inviteAccepted', listener);
-    return () => {
-      inviteNotifier.removeListener('inviteAccepted', listener);
-    };
-  }, [cache, setPreferredId]);
-
-  /**
-   * This check is temporary. It will be refactored out in a subsequent PR.
-   */
-  if (accountsResult.status === 'success' && !selectedAccount) {
-    return <InviteRequiredScreen />;
-  }
 
   return (
-    <ActiveAccountContext.Provider
-      value={{
-        account: selectedAccount,
-        accountHeaders: selectedAccount
-          ? { 'LifeOmic-Account': selectedAccount.id }
-          : undefined,
-        accountsWithProduct,
-        setActiveAccountId: setPreferredId,
-        isLoading: accountsResult.isLoading,
-        isFetched: accountsResult.isFetched,
-        error: accountsResult.error,
-      }}
-    >
+    <ActiveAccountContext.Provider value={memoized}>
       {children}
     </ActiveAccountContext.Provider>
   );
 };
 
-export const useActiveAccount = () => useContext(ActiveAccountContext);
+export const useActiveAccount = () => {
+  const value = React.useContext(ActiveAccountContext);
+  if (!value) {
+    throw new Error(
+      'useActiveAccount must be used within a ActiveAccountContextProvider',
+    );
+  }
+  return value;
+};

--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -7,6 +7,8 @@ import { combineQueries } from '@lifeomic/one-query';
 import { ActivityIndicatorView } from '../components';
 import { t } from 'i18next';
 import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
+import { useRestQuery } from './rest-api';
+import { useActiveAccount } from './useActiveAccount';
 
 const selectedProjectIdKey = 'selectedProjectIdKey';
 
@@ -49,6 +51,46 @@ const findProjectAndSubjectById = (
   return { selectedProject, selectedSubject };
 };
 
+/**
+ * Why an HOC:
+ *
+ * Using a higher-order component here allows us to more easily (and type-safely)
+ * model the GET /v1/accounts network dependencies here. The idea is:
+ *
+ * - Until we're sure the user is in the active account, it is not safe to make other
+ *   network requests.
+ *   -> (because if they aren't in the account, the request will result in 401)
+ *
+ * - So, rather than deal with passing a react-query `enabled` setting through the various
+ *   project-related network calls, just avoid rendering those hooks entirely until we
+ *   know the user is in the right account.
+ */
+
+const withAccountRequired =
+  <Props extends {}>(Component: React.FC<Props>): React.FC<Props> =>
+  (props) => {
+    const { account: activeAccountId } = useActiveAccount();
+    const query = useRestQuery('GET /v1/accounts', {});
+
+    if (query.status !== 'success') {
+      return (
+        <ActivityIndicatorView
+          message={t('waiting-for-account-and-project', 'Loading account')}
+        />
+      );
+    }
+
+    const isMemberOfActiveAccount = query.data.accounts.some(
+      (account) => account.id === activeAccountId,
+    );
+
+    if (!isMemberOfActiveAccount) {
+      return <InviteRequiredScreen />;
+    }
+
+    return <Component {...props} />;
+  };
+
 type SelectionState =
   | {
       status: 'success';
@@ -60,91 +102,92 @@ type SelectionState =
   | { status: 'not-a-patient' }
   | { status: 'loading' };
 
-export const ActiveProjectContextProvider = ({
-  children,
-}: {
+export type ActiveProjectContextProviderProps = {
   children?: React.ReactNode;
-}) => {
-  const query = combineQueries([useSubjectProjects(), useMe(), useUser()]);
-  const userId = query.data?.[2].id;
-  const [storedProjectIdResult, setStoredProjectId, isStorageLoaded] =
-    useAsyncStorage(
-      `${selectedProjectIdKey}:${userId}`,
-      !!selectedProjectIdKey && !!userId,
-    );
+};
 
-  const calculateState = (): SelectionState => {
-    if (!query.data || !isStorageLoaded) {
-      return { status: 'loading' };
-    }
-
-    const [projects, me] = query.data;
-
-    const { selectedProject, selectedSubject } = findProjectAndSubjectById(
-      storedProjectIdResult,
-      projects,
-      me,
-    );
-
-    if (!selectedProject || !selectedSubject) {
-      return { status: 'not-a-patient' };
-    }
-
-    return {
-      status: 'success',
-      activeProject: selectedProject,
-      activeSubject: selectedSubject,
-      projects,
-      me,
-    };
-  };
-
-  const state = calculateState();
-
-  // This effect handles setting the initial value in async storage.
-  const activeProjectId =
-    state.status === 'success' ? state.activeProject.id : undefined;
-  useEffect(() => {
-    if (activeProjectId && activeProjectId !== storedProjectIdResult) {
-      setStoredProjectId(activeProjectId);
-    }
-  }, [activeProjectId, storedProjectIdResult, setStoredProjectId]);
-
-  if (state.status === 'loading') {
-    return (
-      <ActivityIndicatorView
-        message={t('waiting-for-account-and-project', 'Loading account')}
-      />
-    );
-  }
-  // TODO: handle error state.
-  if (state.status === 'not-a-patient') {
-    return <InviteRequiredScreen />;
-  }
-
-  const value: ActiveProjectContextValue = {
-    activeProject: state.activeProject,
-    activeSubjectId: state.activeSubject.subjectId,
-    activeSubject: state.activeSubject,
-    setActiveProjectId: (projectId: string) => {
-      const result = findProjectAndSubjectById(
-        projectId,
-        state.projects,
-        state.me,
+export const ActiveProjectContextProvider: React.FC<ActiveProjectContextProviderProps> =
+  withAccountRequired(({ children }) => {
+    const query = combineQueries([useSubjectProjects(), useMe(), useUser()]);
+    const userId = query.data?.[2].id;
+    const [storedProjectIdResult, setStoredProjectId, isStorageLoaded] =
+      useAsyncStorage(
+        `${selectedProjectIdKey}:${userId}`,
+        !!selectedProjectIdKey && !!userId,
       );
 
-      if (result.selectedProject) {
-        setStoredProjectId(result.selectedProject.id);
+    const calculateState = (): SelectionState => {
+      if (!query.data || !isStorageLoaded) {
+        return { status: 'loading' };
       }
-    },
-  };
 
-  return (
-    <ActiveProjectContext.Provider value={value}>
-      {children}
-    </ActiveProjectContext.Provider>
-  );
-};
+      const [projects, me] = query.data;
+
+      const { selectedProject, selectedSubject } = findProjectAndSubjectById(
+        storedProjectIdResult,
+        projects,
+        me,
+      );
+
+      if (!selectedProject || !selectedSubject) {
+        return { status: 'not-a-patient' };
+      }
+
+      return {
+        status: 'success',
+        activeProject: selectedProject,
+        activeSubject: selectedSubject,
+        projects,
+        me,
+      };
+    };
+
+    const state = calculateState();
+
+    // This effect handles setting the initial value in async storage.
+    const activeProjectId =
+      state.status === 'success' ? state.activeProject.id : undefined;
+    useEffect(() => {
+      if (activeProjectId && activeProjectId !== storedProjectIdResult) {
+        setStoredProjectId(activeProjectId);
+      }
+    }, [activeProjectId, storedProjectIdResult, setStoredProjectId]);
+
+    if (state.status === 'loading') {
+      return (
+        <ActivityIndicatorView
+          message={t('waiting-for-account-and-project', 'Loading account')}
+        />
+      );
+    }
+    // TODO: handle error state.
+    if (state.status === 'not-a-patient') {
+      return <InviteRequiredScreen />;
+    }
+
+    const value: ActiveProjectContextValue = {
+      activeProject: state.activeProject,
+      activeSubjectId: state.activeSubject.subjectId,
+      activeSubject: state.activeSubject,
+      setActiveProjectId: (projectId: string) => {
+        const result = findProjectAndSubjectById(
+          projectId,
+          state.projects,
+          state.me,
+        );
+
+        if (result.selectedProject) {
+          setStoredProjectId(result.selectedProject.id);
+        }
+      },
+    };
+
+    return (
+      <ActiveProjectContext.Provider value={value}>
+        {children}
+      </ActiveProjectContext.Provider>
+    );
+  });
 
 export const useActiveProject = () => {
   const value = useContext(ActiveProjectContext);

--- a/src/hooks/useActivities.tsx
+++ b/src/hooks/useActivities.tsx
@@ -367,7 +367,7 @@ type ActivitiesQueryResponse = {
 
 export const useActivities = (input: ActivitiesInput) => {
   const { graphQLClient } = useGraphQLClient();
-  const { isFetched, accountHeaders } = useActiveAccount();
+  const { accountHeaders } = useActiveAccount();
 
   const queryForActivities = useCallback(async () => {
     return graphQLClient.request<ActivitiesQueryResponse>(
@@ -379,7 +379,5 @@ export const useActivities = (input: ActivitiesInput) => {
     );
   }, [accountHeaders, graphQLClient, input]);
 
-  return useQuery(['activities'], queryForActivities, {
-    enabled: isFetched && !!accountHeaders,
-  });
+  return useQuery(['activities'], queryForActivities);
 };

--- a/src/hooks/useAppConfig.tsx
+++ b/src/hooks/useAppConfig.tsx
@@ -117,7 +117,6 @@ export const useAppConfig = () => {
     'GET /v1/life-research/projects/:projectId/app-config',
     { projectId: activeProject.id },
     {
-      enabled: !!accountHeaders,
       axios: {
         headers: accountHeaders,
       },

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -26,7 +26,6 @@ export const useConsent = () => {
             headers: { ...accountHeaders },
           })
           .then((res) => res.data),
-      { enabled: !!accountHeaders },
     );
   };
 

--- a/src/hooks/useConversations.ts
+++ b/src/hooks/useConversations.ts
@@ -103,7 +103,6 @@ export function useInfiniteConversations() {
   };
 
   return useInfiniteQuery(['conversations'], queryConversations, {
-    enabled: !!accountHeaders?.['LifeOmic-Account'],
     getNextPageParam: (lastPage) => {
       return lastPage.conversations.pageInfo.hasNextPage
         ? lastPage.conversations.pageInfo.endCursor

--- a/src/hooks/useExchangeToken.tsx
+++ b/src/hooks/useExchangeToken.tsx
@@ -23,7 +23,7 @@ export function useExchangeToken(appTileId: string, clientId?: string) {
         )
         .then((res) => res.data),
     {
-      enabled: !!accountHeaders && !!clientId,
+      enabled: !!clientId,
     },
   );
 }

--- a/src/hooks/useFeature.ts
+++ b/src/hooks/useFeature.ts
@@ -15,7 +15,6 @@ export function useFeature<T extends string>(feature: T) {
         headers: accountHeaders,
       }),
     {
-      enabled: !!accountHeaders,
       select(data) {
         return !!data.data[feature];
       },

--- a/src/hooks/useFhirClient.test.tsx
+++ b/src/hooks/useFhirClient.test.tsx
@@ -44,7 +44,7 @@ const axiosMock = new MockAdapter(axiosInstance);
 beforeEach(() => {
   useActiveAccountMock.mockReturnValue({
     accountHeaders: { 'LifeOmic-Account': 'acct1' },
-    account: { id: 'acct1' },
+    account: 'acct1',
   });
   useActiveProjectMock.mockReturnValue({
     activeProject: { id: 'projectId' },

--- a/src/hooks/useFhirClient.tsx
+++ b/src/hooks/useFhirClient.tsx
@@ -141,7 +141,7 @@ export function useFhirClient() {
           });
       },
       {
-        enabled: !!accountHeaders && (queryParams.enabled ?? true),
+        enabled: queryParams.enabled ?? true,
         keepPreviousData: true,
       },
     );
@@ -167,10 +167,6 @@ export function useFhirClient() {
   const useCreateResourceMutation = () => {
     return useMutation({
       mutationFn: async (resourceToUpsert: ResourceType) => {
-        if (!accountHeaders) {
-          throw new Error('Cannot mutate resource in current state');
-        }
-
         const resource = toResource(resourceToUpsert);
 
         return httpClient
@@ -189,10 +185,6 @@ export function useFhirClient() {
   const useCreateBundleMutation = () => {
     return useMutation({
       mutationFn: async (resources: ResourceType[]) => {
-        if (!accountHeaders) {
-          throw new Error('Cannot mutate resource in current state');
-        }
-
         const bundle: Bundle<ResourceType> = {
           resourceType: 'Bundle',
           type: 'collection',
@@ -210,7 +202,7 @@ export function useFhirClient() {
         return httpClient
           .post<Bundle<ResourceType>>(
             // TODO: Update once the bundle endpoint is exposed behind `/v1/fhir`
-            `https://fhir.us.lifeomic.com/${account?.id}/dstu3`,
+            `https://fhir.us.lifeomic.com/${account}/dstu3`,
             bundle,
             {
               headers: accountHeaders,
@@ -224,10 +216,6 @@ export function useFhirClient() {
   const useDeleteResourceMutation = () => {
     return useMutation({
       mutationFn: async (params: DeleteParams) => {
-        if (!accountHeaders) {
-          throw new Error('Cannot delete resource in current state');
-        }
-
         return httpClient
           .delete(`/v1/fhir/dstu3/${params.resourceType}/${params.id}`, {
             headers: accountHeaders,

--- a/src/hooks/useMe.ts
+++ b/src/hooks/useMe.ts
@@ -25,27 +25,22 @@ export function useMe() {
   const { httpClient } = useHttpClient();
   const { lastAcceptedId } = usePendingInvite();
 
-  const useMeQuery = useQuery(
-    ['fhir/dstu3/$me', lastAcceptedId],
-    () =>
-      httpClient
-        .get<MeResponse>('/v1/fhir/dstu3/$me', { headers: accountHeaders })
-        .then((res) =>
-          res.data.entry?.map(
-            (entry) =>
-              ({
-                subjectId: entry.resource.id,
-                projectId: entry.resource.meta?.tag?.find(
-                  (t) => t.system === 'http://lifeomic.com/fhir/dataset',
-                )?.code,
-                name: entry.resource.name,
-                subject: entry.resource,
-              } as Subject),
-          ),
+  const useMeQuery = useQuery(['fhir/dstu3/$me', lastAcceptedId], () =>
+    httpClient
+      .get<MeResponse>('/v1/fhir/dstu3/$me', { headers: accountHeaders })
+      .then((res) =>
+        res.data.entry?.map(
+          (entry) =>
+            ({
+              subjectId: entry.resource.id,
+              projectId: entry.resource.meta?.tag?.find(
+                (t) => t.system === 'http://lifeomic.com/fhir/dataset',
+              )?.code,
+              name: entry.resource.name,
+              subject: entry.resource,
+            } as Subject),
         ),
-    {
-      enabled: !!accountHeaders,
-    },
+      ),
   );
 
   return useMeQuery;

--- a/src/hooks/useMessagingProfiles.test.tsx
+++ b/src/hooks/useMessagingProfiles.test.tsx
@@ -50,7 +50,6 @@ beforeEach(() => {
     },
   });
   (useActiveAccount as jest.Mock).mockReturnValue({
-    isLoading: false,
     accountHeaders: { 'LifeOmic-Account': 'someAccount' },
   });
 });

--- a/src/hooks/useMessagingProfiles.tsx
+++ b/src/hooks/useMessagingProfiles.tsx
@@ -45,7 +45,6 @@ export const useMessagingProfiles = (userIds?: string[]) => {
               )
               .then((res) => res.data),
           {
-            enabled: !!accountHeaders,
             placeholderData: placeHolderProfile(userId),
           },
         ),

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -152,7 +152,7 @@ export function useNotifications() {
   }, [accountHeaders, data?.id, graphQLClient]);
 
   return useQuery(['notifications'], queryForNotifications, {
-    enabled: !!accountHeaders?.['LifeOmic-Account'] && !!data?.id,
+    enabled: !!data?.id,
     select: selectNotifications,
   });
 }

--- a/src/hooks/usePushNotifications.test.tsx
+++ b/src/hooks/usePushNotifications.test.tsx
@@ -7,7 +7,7 @@ import { Platform, Text } from 'react-native';
 import { PushNotificationsConfig } from '../common/DeveloperConfig';
 import * as NotificationsUtils from '../common/Notifications';
 import { Notifications } from 'react-native-notifications';
-import { ActiveAccountContext } from '.';
+import { ActiveAccountProvider } from './useActiveAccount';
 
 jest.mock('react-native-notifications', () => ({
   Notifications: {
@@ -19,18 +19,11 @@ const renderProvider = (config?: PushNotificationsConfig) =>
   render(
     <QueryClientProvider client={new QueryClient()}>
       <HttpClientContextProvider>
-        <ActiveAccountContext.Provider
-          value={{
-            isFetched: true,
-            isLoading: false,
-            setActiveAccountId: jest.fn(),
-            account: { id: 'test-account' } as any,
-          }}
-        >
+        <ActiveAccountProvider account="test-account">
           <PushNotificationsProvider config={config}>
             <Text>content</Text>
           </PushNotificationsProvider>
-        </ActiveAccountContext.Provider>
+        </ActiveAccountProvider>
       </HttpClientContextProvider>
     </QueryClientProvider>,
   );

--- a/src/hooks/usePushNotifications.tsx
+++ b/src/hooks/usePushNotifications.tsx
@@ -50,7 +50,7 @@ export function PushNotificationsProvider({
             deviceToken,
             application: config.applicationName,
             httpClient,
-            accountId: account.id,
+            accountId: account,
           });
         }
       });

--- a/src/hooks/useSubjectProjects.test.tsx
+++ b/src/hooks/useSubjectProjects.test.tsx
@@ -42,7 +42,7 @@ const axiosMock = new MockAdapter(axiosInstance);
 
 beforeEach(() => {
   useActiveAccountMock.mockReturnValue({
-    account: { id: 'acct1' },
+    account: 'acct1',
     accountHeaders: { 'LifeOmic-Account': 'acct1' },
   });
   useMeMock.mockReturnValue({

--- a/src/hooks/useSubjectProjects.tsx
+++ b/src/hooks/useSubjectProjects.tsx
@@ -20,7 +20,7 @@ export function useSubjectProjects() {
   const { lastAcceptedId } = usePendingInvite();
 
   return useQuery<Project[]>(
-    [`${account?.id}-projects`, subjects, lastAcceptedId],
+    [`${account}-projects`, subjects, lastAcceptedId],
     async () => {
       if (subjects?.length) {
         const res = await httpClient.get<ProjectsResponse>(
@@ -34,9 +34,6 @@ export function useSubjectProjects() {
         // returning a mock response to keep downstream queries moving
         return [];
       }
-    },
-    {
-      enabled: !!accountHeaders,
     },
   );
 }

--- a/src/hooks/useWearableBackfill.tsx
+++ b/src/hooks/useWearableBackfill.tsx
@@ -28,7 +28,7 @@ export const useWearableBackfill = (
   const { graphQLClient } = useGraphQLClient();
   const { httpClient } = useHttpClient();
   const { data: isBackfillEnabled } = useFeature('ehrBackfill');
-  const { isFetched, accountHeaders } = useActiveAccount();
+  const { accountHeaders } = useActiveAccount();
 
   const ehrTypes = useMemo(
     () => wearablesState?.items?.map((ehr) => ehr.ehrType as EHRType) ?? [],
@@ -51,7 +51,7 @@ export const useWearableBackfill = (
     ['backfill-sync-status', ...ehrTypes],
     queryEHRSyncStatus,
     {
-      enabled: isFetched && ehrTypes.length > 0 && !!isBackfillEnabled,
+      enabled: ehrTypes.length > 0 && !!isBackfillEnabled,
       select(data) {
         const statuses: Record<string, boolean> = {};
 

--- a/src/hooks/useWearables.ts
+++ b/src/hooks/useWearables.ts
@@ -92,28 +92,18 @@ export const useWearables = () => {
     });
 
   const useWearableIntegrationQuery = (ehrId: string) =>
-    useQuery(
-      ['get-wearable'],
-      () =>
-        httpClient.get(`/v1/wearables/${ehrId}`, { headers: accountHeaders }),
-      {
-        enabled: !!accountHeaders,
-      },
+    useQuery(['get-wearable'], () =>
+      httpClient.get(`/v1/wearables/${ehrId}`, { headers: accountHeaders }),
     );
 
   const useWearableIntegrationsQuery = () =>
-    useQuery(
-      ['get-wearables'],
-      () =>
-        httpClient
-          .get<WearablesSyncState>('/v1/wearables', {
-            params: { appId: getBundleId().toLowerCase() },
-            headers: accountHeaders,
-          })
-          .then((res) => res.data),
-      {
-        enabled: !!accountHeaders,
-      },
+    useQuery(['get-wearables'], () =>
+      httpClient
+        .get<WearablesSyncState>('/v1/wearables', {
+          params: { appId: getBundleId().toLowerCase() },
+          headers: accountHeaders,
+        })
+        .then((res) => res.data),
     );
 
   return {

--- a/src/navigators/LoggedInStack.tsx
+++ b/src/navigators/LoggedInStack.tsx
@@ -6,7 +6,6 @@ import { OnboardingCourseScreen } from '../screens/OnboardingCourseScreen';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { LoggedInRootParamList } from './types';
 import { useConsent } from '../hooks/useConsent';
-import { useActiveAccount } from '../hooks/useActiveAccount';
 import { useActiveProject } from '../hooks/useActiveProject';
 import { useOnboardingCourse } from '../hooks/useOnboardingCourse';
 import { ActivityIndicatorView } from '../components/ActivityIndicatorView';
@@ -23,7 +22,6 @@ export function LoggedInStack() {
   useSetUserProfileEffect();
   // Fetch profiles early but don't wait for them
   useProfilesForAllTiles();
-  const { account } = useActiveAccount();
   const { activeProject, activeSubjectId } = useActiveProject();
   const { useShouldRenderConsentScreen } = useConsent();
   const { shouldRenderConsentScreen, isLoading: loadingConsents } =
@@ -93,7 +91,6 @@ export function LoggedInStack() {
 
     executeOnAppStartIfNeeded();
   }, [
-    account,
     activeProject,
     activeSubjectId,
     onAppSessionStart,

--- a/src/screens/AppTileScreen.test.tsx
+++ b/src/screens/AppTileScreen.test.tsx
@@ -5,6 +5,7 @@ import { WebView } from 'react-native-webview';
 import { AppTileScreen } from './AppTileScreen';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as UseHandleAppTileEvents from '../hooks/useHandleAppTileEvents';
+import { ActiveAccountProvider } from '../hooks';
 
 jest.mock('react-native-webview', () => ({
   WebView: jest.fn().mockReturnValue(<></>),
@@ -45,7 +46,9 @@ beforeEach(() => {
 test('renders webview with source prop', () => {
   render(
     <QueryClientProvider client={new QueryClient()}>
-      <AppTileScreen navigation={navigation} route={route} />
+      <ActiveAccountProvider account="mockaccount">
+        <AppTileScreen navigation={navigation} route={route} />
+      </ActiveAccountProvider>
     </QueryClientProvider>,
   );
   expect(webviewMock.mock.calls[0][0]).toMatchObject({

--- a/src/screens/AuthedAppTileScreen.test.tsx
+++ b/src/screens/AuthedAppTileScreen.test.tsx
@@ -57,11 +57,7 @@ beforeEach(() => {
     isLoading: false,
   });
   useActiveAccountMock.mockReturnValue({
-    account: {
-      id: 'acct1',
-    },
-    isFetched: true,
-    isLoading: false,
+    account: 'acct1',
   });
   useActiveProjectMock.mockReturnValue({
     activeProject: { id: 'projectId' },

--- a/src/screens/AuthedAppTileScreen.tsx
+++ b/src/screens/AuthedAppTileScreen.tsx
@@ -71,11 +71,7 @@ export const AuthedAppTileScreen = ({
   ]);
 
   const { activeProject, activeSubjectId } = useActiveProject();
-  const {
-    account,
-    isLoading: loadingAccounts,
-    isFetched: accountFetched,
-  } = useActiveAccount();
+  const { account } = useActiveAccount();
   const {
     data,
     isLoading: loadingCode,
@@ -84,9 +80,9 @@ export const AuthedAppTileScreen = ({
   const [isPageLoaded, setIsPageLoaded] = useState(false);
 
   // Conditions to be met before building the applet uri
-  const isLoading = loadingCode || loadingAccounts;
-  const isFetched = codeFetched && accountFetched;
-  const hasData = data?.code && account?.id;
+  const isLoading = loadingCode;
+  const isFetched = codeFetched;
+  const hasData = data?.code;
 
   const readyToBuildUri = isFetched && !isLoading && hasData;
   const oauthCallbackUrl = appTile.callbackUrls?.[0]!;
@@ -97,9 +93,7 @@ export const AuthedAppTileScreen = ({
       parsed.code = data.code;
     }
 
-    if (account?.id) {
-      parsed.accountId = account.id;
-    }
+    parsed.accountId = account;
 
     parsed.projectId = activeProject.id;
     parsed.patientId = activeSubjectId;

--- a/src/screens/DirectMessagesScreen.tsx
+++ b/src/screens/DirectMessagesScreen.tsx
@@ -105,6 +105,7 @@ export const DirectMessagesScreen = ({
       messages={incomingMessages}
       loadEarlier={hasNextPage}
       onLoadEarlier={() => {
+        /* istanbul ignore next */
         if (hasNextPage && !isLoading) {
           fetchNextPage();
         }

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -64,9 +64,7 @@ const homeScreen = (
 );
 
 beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    isLoading: false,
-  });
+  useActiveAccountMock.mockReturnValue({});
   useAppConfigMock.mockReturnValue({
     isLoading: false,
     data: exampleAppConfig,

--- a/src/screens/MyDataScreen.test.tsx
+++ b/src/screens/MyDataScreen.test.tsx
@@ -10,7 +10,12 @@ import {
   startOfYear,
   addDays,
 } from 'date-fns';
-import { ActiveProjectContext, AppConfig, useAppConfig } from '../hooks';
+import {
+  ActiveAccountProvider,
+  ActiveProjectContext,
+  AppConfig,
+  useAppConfig,
+} from '../hooks';
 import { MyDataScreen } from './MyDataScreen';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
@@ -62,18 +67,20 @@ const queryClient = new QueryClient({
 const baseURL = 'https://some-domain/unit-test';
 const myDataScreen = (
   <QueryClientProvider client={queryClient}>
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ActiveProjectContext.Provider
-        value={
-          {
-            activeProject: { id: 'mock-project' },
-            activeSubjectId: 'mock-patient',
-          } as any
-        }
-      >
-        <MyDataScreen />
-      </ActiveProjectContext.Provider>
-    </GraphQLClientContextProvider>
+    <ActiveAccountProvider account="mockaccount">
+      <GraphQLClientContextProvider baseURL={baseURL}>
+        <ActiveProjectContext.Provider
+          value={
+            {
+              activeProject: { id: 'mock-project' },
+              activeSubjectId: 'mock-patient',
+            } as any
+          }
+        >
+          <MyDataScreen />
+        </ActiveProjectContext.Provider>
+      </GraphQLClientContextProvider>
+    </ActiveAccountProvider>
   </QueryClientProvider>
 );
 


### PR DESCRIPTION
## Changes
**Reviewers**: I _highly_ recommend reviewing this change:
- by commit, and
- with _Hide Whitespace Changes_

I've intentionally separated the change into three commits:
- Updating the core logic in `useActiveAccount` + `useActiveProject`
- Updating the `ActiveAccountProvider` call sites.
- Updating the `useActiveAccount` call sites.
- [extra]: add an `istanbul ignore` to an uncovered line to remain above coverage threshold

## Testing
I've tested this change thoroughly in internal apps. Any external testing would be greatly appreciated.