### PR TITLE
feat!: include LifeOmic-Account header in HTTP and GraphQL clients

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -256,3 +256,30 @@ const MyComponent = () => {
 
 - `ActiveAccountContextProvider` has been renamed and refactored into
   `ActiveAccountProvider`.
+
+### 8.x -> 9.x
+
+- The clients returned from `useHttpClient` and `useGraphQLClient` now
+  automatically include the `LifeOmic-Account` header. You do not need to
+  specify it manually. This also includes the `useRest****` hooks. Example:
+
+```tsx
+const MyComponent = () => {
+  const { httpClient } = useHttpClient();
+  const { accountHeaders } = useActiveAccount();
+  const query = useQuery(['my-query'], () =>
+    httpClient.get('/something', { headers: accountHeaders }),
+  );
+};
+
+// This^ can be simplified to:
+const MyComponent = () => {
+  const { httpClient } = useHttpClient();
+  const query = useQuery(['my-query'], () => httpClient.get('/something'));
+  // the "accountHeaders" are included automatically.
+};
+```
+
+- To _avoid_ including the `LifeOmic-Account` header, you can specify an empty
+  string for the header value, like so: `'LifeOmic-Account': ''`. When that
+  empty string is provided, the header will be removed from the request.

--- a/src/common/Notifications.test.ts
+++ b/src/common/Notifications.test.ts
@@ -81,7 +81,6 @@ test('isRegisteredForRemoteNotifications: returns if the device is registered fo
 test('registerDeviceToken: registers the device token', () => {
   const deviceToken = 'a-device-token';
   const application = 'test-application';
-  const accountId = 'account-id';
   const axiosInstance = axios.create();
   const axiosMock = new MockAdapter(axiosInstance);
 
@@ -90,7 +89,6 @@ test('registerDeviceToken: registers the device token', () => {
     deviceToken,
     application,
     httpClient: axiosInstance,
-    accountId,
   });
   expect(axiosMock.history.post[0].url).toBe('/v1/device-endpoints');
 });

--- a/src/common/Notifications.ts
+++ b/src/common/Notifications.ts
@@ -13,12 +13,10 @@ export const registerDeviceToken = ({
   deviceToken,
   application,
   httpClient,
-  accountId,
 }: {
   deviceToken: string;
   application: string;
   httpClient: AxiosInstance;
-  accountId: string;
 }) => {
   const provider = Platform.OS === 'ios' ? 'APNS' : 'GCM';
   const params = {
@@ -26,12 +24,7 @@ export const registerDeviceToken = ({
     deviceToken,
     application,
   };
-  const options = {
-    headers: {
-      'LifeOmic-Account': accountId,
-    },
-  };
-  httpClient.post('/v1/device-endpoints', params, options);
+  httpClient.post('/v1/device-endpoints', params);
 };
 
 export const getInitialNotification = () => {

--- a/src/common/testHelpers/testing-library-wrapper.tsx
+++ b/src/common/testHelpers/testing-library-wrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render as realRender } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../../hooks/useGraphQLClient';
+import { ActiveAccountProvider } from '../../hooks';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,9 +17,11 @@ const baseURL = 'https://some-domain/unit-test';
 const wrapper = ({ children }: any) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <GraphQLClientContextProvider baseURL={baseURL}>
-        {children}
-      </GraphQLClientContextProvider>
+      <ActiveAccountProvider account="mockaccount">
+        <GraphQLClientContextProvider baseURL={baseURL}>
+          {children}
+        </GraphQLClientContextProvider>
+      </ActiveAccountProvider>
     </QueryClientProvider>
   );
 };

--- a/src/components/Circles/__tests__/ReactionsToolbar.test.tsx
+++ b/src/components/Circles/__tests__/ReactionsToolbar.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../../../hooks/useGraphQLClient';
 import type { Post } from '../../../hooks';
 import {
+  ActiveAccountProvider,
   useCreateReactionMutation,
   useUndoReactionMutation,
 } from '../../../hooks';
@@ -32,8 +33,10 @@ useUserMock.mockReturnValue({
 const baseURL = 'https://some-domain/unit-test';
 const toolbarComponent = (post: Post) => (
   <QueryClientProvider client={new QueryClient()}>
-    <GraphQLClientContextProvider baseURL={baseURL} />
-    <ReactionsToolbar post={post} />
+    <ActiveAccountProvider account="mockaccount">
+      <GraphQLClientContextProvider baseURL={baseURL} />
+      <ReactionsToolbar post={post} />
+    </ActiveAccountProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/Invitations/InviteProvider.test.tsx
+++ b/src/components/Invitations/InviteProvider.test.tsx
@@ -98,6 +98,10 @@ describe('accepting invite', () => {
         params: { inviteId: mockInviteParams.inviteId },
       }),
     );
+    // Confirm account header was not sent.
+    expect(
+      mutationMock.mock.calls[0][0].headers['LifeOmic-Account'],
+    ).toBeUndefined();
   });
 
   it('refreshes auth token, emits inviteAccepted, then waits for inviteAccountSettled to resets cache and mutation', async () => {
@@ -118,6 +122,10 @@ describe('accepting invite', () => {
         params: { inviteId: mockInviteParams.inviteId },
       }),
     );
+    // Confirm account header was not sent.
+    expect(
+      mutationMock.mock.calls[0][0].headers['LifeOmic-Account'],
+    ).toBeUndefined();
     expect(result.current.inviteParams).toEqual({});
     expect(refreshForInviteAccept).toHaveBeenCalled();
     expect(acceptListener).toHaveBeenCalled();
@@ -147,6 +155,10 @@ describe('accepting invite', () => {
         params: { inviteId: mockInviteParams.inviteId },
       }),
     );
+    // Confirm account header was not sent.
+    expect(
+      mutationMock.mock.calls[0][0].headers['LifeOmic-Account'],
+    ).toBeUndefined();
     expect(refreshForInviteAccept).not.toHaveBeenCalled();
     expect(result.current.inviteParams).toEqual({});
   });

--- a/src/components/Invitations/InviteProvider.tsx
+++ b/src/components/Invitations/InviteProvider.tsx
@@ -31,6 +31,10 @@ export const InviteProvider = ({ children }: ProviderProps) => {
   const [lastAcceptedId, setAcceptedId] = useState<string>('');
   const { isLoading, isSuccess, isError, reset, mutateAsync } = useRestMutation(
     'PATCH /v1/invitations/:inviteId',
+    {
+      // Do not include account header on this request.
+      axios: { headers: { 'LifeOmic-Account': '' } },
+    },
   );
   const { authResult, refreshForInviteAccept } = useAuth();
 

--- a/src/components/MessagesTile/MessagesTile.test.tsx
+++ b/src/components/MessagesTile/MessagesTile.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
-import { useUser } from '../../hooks';
+import { ActiveAccountProvider, useUser } from '../../hooks';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../../hooks/useGraphQLClient';
 import { MessagesTile } from '.';
@@ -30,14 +30,16 @@ const queryClient = new QueryClient({
 const baseURL = 'https://some-domain/unit-test';
 const directMessageScreen = (
   <QueryClientProvider client={queryClient}>
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <MessagesTile
-        Icon={() => null}
-        navigation={navigateMock as any}
-        id="some-messages-tile"
-        title="Message your doctor"
-      />
-    </GraphQLClientContextProvider>
+    <ActiveAccountProvider account="mockaccount">
+      <GraphQLClientContextProvider baseURL={baseURL}>
+        <MessagesTile
+          Icon={() => null}
+          navigation={navigateMock as any}
+          id="some-messages-tile"
+          title="Message your doctor"
+        />
+      </GraphQLClientContextProvider>
+    </ActiveAccountProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/TrackTile/hooks/test/useAxiosTrackTileService.test.tsx
+++ b/src/components/TrackTile/hooks/test/useAxiosTrackTileService.test.tsx
@@ -31,14 +31,12 @@ const valuesContext: TrackerValuesContext = {
 const DATASTORE_HEADERS = {
   headers: expect.objectContaining({
     'LifeOmic-TrackTile-Capabilities-Version': 3,
-    'LifeOmic-Account': 'account-id',
   }),
 };
 
 const ACCOUNT_HEADERS = {
   headers: expect.objectContaining({
     'LifeOmic-TrackTile-Capabilities-Version': 3,
-    'LifeOmic-Account': 'account-id',
   }),
 };
 

--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -1,4 +1,3 @@
-import { AxiosRequestConfig } from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import {
   InstalledMetric,
@@ -36,12 +35,11 @@ import {
 } from '../../../common/RefreshNotifier';
 import { useAppConfig } from '../../../hooks/useAppConfig';
 
-const axiosConfig = (obj: { account: string }): AxiosRequestConfig => ({
+const axiosConfig = {
   headers: {
-    'LifeOmic-Account': obj.account,
     [TRACK_TILE_CAPABILITIES_VERSION_HEADER]: TRACK_TILE_CAPABILITIES_VERSION,
   },
-});
+};
 
 export const useAxiosTrackTileService = (): TrackTileService => {
   const { httpClient } = useHttpClient();
@@ -227,7 +225,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
 
       const url = `/v1/track-tiles/trackers${params && `?${params}`}`;
 
-      const res = await httpClient.get(url, axiosConfig({ account }));
+      const res = await httpClient.get(url, axiosConfig);
       const fetchedTrackers: Tracker[] = res.data;
 
       cache.trackers = fetchedTrackers;
@@ -239,7 +237,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
       const res = await httpClient.put<InstalledMetric>(
         `/v1/track-tiles/metrics/installs/${metricId}`,
         settings,
-        axiosConfig({ account }),
+        axiosConfig,
       );
 
       return updateSettingsInCache(res.data) || res.data;
@@ -249,7 +247,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
       await httpClient.put(
         '/v1/track-tiles/metrics/installs',
         settings,
-        axiosConfig({ account }),
+        axiosConfig,
       );
 
       settings.forEach(updateSettingsInCache);
@@ -279,7 +277,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
           },
           query: FETCH_TRACKER_VALUES_BY_DATES_QUERY,
         },
-        axiosConfig({ account }),
+        axiosConfig,
       );
 
       const trackerValues = extractTrackerValues(res.data);
@@ -298,7 +296,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
           query: DELETE_RESOURCE(resourceType),
           variables: { id },
         },
-        axiosConfig({ account }),
+        axiosConfig,
       );
 
       if (!res.data.data) {
@@ -331,7 +329,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
               : MUTATE_PROCEDURE_RESOURCE(resource.id ? 'Update' : 'Create'),
           variables: { resource },
         },
-        axiosConfig({ account }),
+        axiosConfig,
       );
 
       if (!res.data.data) {
@@ -400,7 +398,7 @@ export const useAxiosTrackTileService = (): TrackTileService => {
             code: codeBelow,
           },
         },
-        axiosConfig({ account }),
+        axiosConfig,
       );
 
       if (!res.data.data) {

--- a/src/hooks/Circles/useCreatePost.ts
+++ b/src/hooks/Circles/useCreatePost.ts
@@ -1,6 +1,5 @@
 import { cloneDeep, omit } from 'lodash';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
-import { useActiveAccount } from '../useActiveAccount';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { useUser } from '../useUser';
 import { ParentType, Priority, AttachmentType, Post } from './types';
@@ -26,7 +25,6 @@ type CreatePostInput = {
 
 export function useCreatePost() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const { data } = useUser();
   const queryClient = useQueryClient();
   const { circleTile } = useActiveCircleTile();
@@ -36,11 +34,7 @@ export function useCreatePost() {
       input,
     };
 
-    return graphQLClient.request(
-      createPostMutationDocument,
-      variables,
-      accountHeaders,
-    );
+    return graphQLClient.request(createPostMutationDocument, variables);
   };
 
   return useMutation(['createPost'], createPostMutation, {

--- a/src/hooks/Circles/useDeletePost.ts
+++ b/src/hooks/Circles/useDeletePost.ts
@@ -1,13 +1,11 @@
 import { gql } from 'graphql-request';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
-import { useActiveAccount } from '../useActiveAccount';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { optimisticallyDeletePosts } from './utils/optimisticallyDeletePosts';
 import { useActiveCircleTile } from './useActiveCircleTile';
 
 export function useDeletePost() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const queryClient = useQueryClient();
   const { circleTile } = useActiveCircleTile();
 
@@ -16,11 +14,7 @@ export function useDeletePost() {
       input,
     };
 
-    return graphQLClient.request(
-      deletePostMutationDocument,
-      variables,
-      accountHeaders,
-    );
+    return graphQLClient.request(deletePostMutationDocument, variables);
   };
 
   return useMutation(['deletePost'], deletePostMutation, {

--- a/src/hooks/Circles/useInfinitePosts.test.tsx
+++ b/src/hooks/Circles/useInfinitePosts.test.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { useActiveAccount } from '../useActiveAccount';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../useGraphQLClient';
 import { InfinitePostsData, useInfinitePosts } from './useInfinitePosts';
 import nock from 'nock';
-
-jest.mock('../useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
+import { ActiveAccountProvider } from '../useActiveAccount';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -23,23 +19,15 @@ const renderHookWithInjectedClient = async () => {
   return renderHook(() => useInfinitePosts({ circleId: 'circle' }), {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>
-        <GraphQLClientContextProvider baseURL={baseURL}>
-          {children}
-        </GraphQLClientContextProvider>
+        <ActiveAccountProvider account="mockaccount">
+          <GraphQLClientContextProvider baseURL={baseURL}>
+            {children}
+          </GraphQLClientContextProvider>
+        </ActiveAccountProvider>
       </QueryClientProvider>
     ),
   });
 };
-
-const useActiveAccountMock = useActiveAccount as jest.Mock;
-
-beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: {
-      'LifeOmic-Account': 'unittest',
-    },
-  });
-});
 
 test('useInfinitePosts query can page', async () => {
   const data = {

--- a/src/hooks/Circles/useInfinitePosts.tsx
+++ b/src/hooks/Circles/useInfinitePosts.tsx
@@ -1,7 +1,6 @@
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 import { gql } from 'graphql-request';
 import { useGraphQLClient } from '../useGraphQLClient';
-import { useActiveAccount } from '../useActiveAccount';
 import { ParentType, Post, postDetailsFragment } from './types';
 import { useActiveCircleTile } from './useActiveCircleTile';
 
@@ -32,7 +31,6 @@ type useInfinitePostsProps = {
 
 export function useInfinitePosts({ circleId }: useInfinitePostsProps) {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const { circleTile } = useActiveCircleTile();
 
   const queryPosts = async ({ pageParam }: { pageParam?: string }) => {
@@ -44,11 +42,7 @@ export function useInfinitePosts({ circleId }: useInfinitePostsProps) {
       after: pageParam,
     };
 
-    return graphQLClient.request<PostsData>(
-      postsV2QueryDocument,
-      variables,
-      accountHeaders,
-    );
+    return graphQLClient.request<PostsData>(postsV2QueryDocument, variables);
   };
 
   const {

--- a/src/hooks/Circles/useJoinCircles.test.tsx
+++ b/src/hooks/Circles/useJoinCircles.test.tsx
@@ -5,7 +5,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 import { useHttpClient } from '../useHttpClient';
-import { useActiveAccount } from '../useActiveAccount';
 import { useActiveProject } from '../useActiveProject';
 import { CircleTile, useAppConfig } from '../useAppConfig';
 import { useJoinCircles } from './useJoinCircles';
@@ -29,9 +28,6 @@ const renderHookInContext = async () => {
 const axiosInstance = axios.create();
 const axiosMock = new MockAdapter(axiosInstance);
 
-jest.mock('../useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
 jest.mock('../useHttpClient', () => ({
   useHttpClient: jest.fn(),
 }));
@@ -45,16 +41,12 @@ jest.mock('../useAppConfig', () => ({
   useAppConfig: jest.fn(),
 }));
 
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 const useActiveProjectMock = useActiveProject as jest.Mock;
 const useHttpClientMock = useHttpClient as jest.Mock;
 const useAuthMock = useAuth as jest.Mock;
 const useAppConfigMock = useAppConfig as jest.Mock;
 
 beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'acct1' },
-  });
   useActiveProjectMock.mockReturnValue({
     activeProject: { id: 'projectId' },
     activeSubjectId: 'subjectId',

--- a/src/hooks/Circles/useJoinCircles.tsx
+++ b/src/hooks/Circles/useJoinCircles.tsx
@@ -1,12 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { useActiveAccount } from '../useActiveAccount';
 import { useActiveProject } from '../useActiveProject';
 import { CircleTile, useAppConfig } from '../useAppConfig';
 import { useHttpClient } from '../useHttpClient';
 
 export function useJoinCircles() {
   const { data } = useAppConfig();
-  const { accountHeaders } = useActiveAccount();
   const { activeProject } = useActiveProject();
   const { httpClient } = useHttpClient();
 
@@ -18,7 +16,6 @@ export function useJoinCircles() {
           .patch<CircleTile[]>(
             `/v1/life-research/projects/${activeProject.id}/app-config/circles`,
             data.homeTab.circleTiles.map((c) => ({ ...c, isMember: true })),
-            { headers: accountHeaders },
           )
           .then((res) => {
             return res.data;

--- a/src/hooks/Circles/useLoadReplies.ts
+++ b/src/hooks/Circles/useLoadReplies.ts
@@ -1,7 +1,6 @@
 import { gql } from 'graphql-request';
 import { useState, useCallback } from 'react';
 import { useQueryClient, useQuery } from '@tanstack/react-query';
-import { useActiveAccount } from '../useActiveAccount';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { Post, postDetailsFragment } from './types';
 import { PostRepliesQueryResponse } from './useInfinitePosts';
@@ -11,7 +10,6 @@ import { useActiveCircleTile } from './useActiveCircleTile';
 export const useLoadReplies = () => {
   const { graphQLClient } = useGraphQLClient();
   const queryClient = useQueryClient();
-  const { accountHeaders } = useActiveAccount();
   const [queryVariables, setQueryVariables] = useState({
     after: undefined as string | undefined,
     id: '',
@@ -25,8 +23,8 @@ export const useLoadReplies = () => {
     return graphQLClient.request<
       PostRepliesQueryResponse,
       { id: string; after?: string }
-    >(postRepliesQueryDocument, queryVariables, accountHeaders);
-  }, [accountHeaders, graphQLClient, queryVariables]);
+    >(postRepliesQueryDocument, queryVariables);
+  }, [graphQLClient, queryVariables]);
 
   const repliesRes = useQuery(
     [

--- a/src/hooks/Circles/usePost.ts
+++ b/src/hooks/Circles/usePost.ts
@@ -1,14 +1,12 @@
 import { gql } from 'graphql-request';
 import { useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useActiveAccount } from '../useActiveAccount';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { Post, postDetailsFragment } from './types';
 import { PostDetailsPostQueryResponse } from './useInfinitePosts';
 
 export const usePost = (post: Partial<Post> & Pick<Post, 'id'>) => {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
 
   const queryForPostDetails = useCallback(async () => {
     return graphQLClient.request<PostDetailsPostQueryResponse, { id: string }>(
@@ -16,9 +14,8 @@ export const usePost = (post: Partial<Post> & Pick<Post, 'id'>) => {
       {
         id: post.id,
       },
-      accountHeaders,
     );
-  }, [accountHeaders, graphQLClient, post.id]);
+  }, [graphQLClient, post.id]);
 
   return useQuery(['postDetails', post.id], queryForPostDetails, {
     placeholderData: {

--- a/src/hooks/Circles/usePrivatePosts.ts
+++ b/src/hooks/Circles/usePrivatePosts.ts
@@ -6,7 +6,6 @@ import {
 } from '@tanstack/react-query';
 import { gql } from 'graphql-request';
 import { useGraphQLClient } from '../useGraphQLClient';
-import { useActiveAccount } from '../useActiveAccount';
 import { Post, postDetailsFragment } from './types';
 import { useUser } from '../useUser';
 import { IMessage } from 'react-native-gifted-chat';
@@ -77,7 +76,6 @@ const uniqSort = (userIds: Array<string | undefined>) => {
 */
 export function useInfinitePrivatePosts(userIds: string[]) {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const { data } = useUser();
   const users = uniqSort([data?.id, ...userIds]);
 
@@ -93,7 +91,6 @@ export function useInfinitePrivatePosts(userIds: string[]) {
     return graphQLClient.request<PrivatePostsData>(
       privatePostsQueryDocument,
       variables,
-      accountHeaders,
     );
   };
 
@@ -155,7 +152,6 @@ interface CreatePrivatePostMutationProps {
 
 export function useCreatePrivatePostMutation() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const queryClient = useQueryClient();
   const { data: userData } = useUser();
 
@@ -171,11 +167,7 @@ export function useCreatePrivatePostMutation() {
       },
     };
 
-    return graphQLClient.request(
-      createPrivatePostMutationDocument,
-      variables,
-      accountHeaders,
-    );
+    return graphQLClient.request(createPrivatePostMutationDocument, variables);
   };
 
   return useMutation(['createPrivatePost'], {

--- a/src/hooks/Circles/useReactionMutations.tsx
+++ b/src/hooks/Circles/useReactionMutations.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { gql } from 'graphql-request';
 import { useGraphQLClient } from '../useGraphQLClient';
-import { useActiveAccount } from '../useActiveAccount';
 import { Post } from './types';
 import { optimisticallyUpdatePosts } from './utils/optimisticallyUpdatePosts';
 import { useActiveCircleTile } from './useActiveCircleTile';
@@ -21,7 +20,6 @@ interface UndoReactionMutationProps {
 
 export function useCreateReactionMutation() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const queryClient = useQueryClient();
   const { circleTile } = useActiveCircleTile();
 
@@ -39,7 +37,6 @@ export function useCreateReactionMutation() {
     return graphQLClient.request<Reaction>(
       createReactionMutationDocument,
       variables,
-      accountHeaders,
     );
   };
 
@@ -72,7 +69,6 @@ export function useCreateReactionMutation() {
 
 export function useUndoReactionMutation() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const queryClient = useQueryClient();
   const { circleTile } = useActiveCircleTile();
 
@@ -92,7 +88,6 @@ export function useUndoReactionMutation() {
     return graphQLClient.request<Reaction>(
       undoReactionMutationDocument,
       variables,
-      accountHeaders,
     );
   };
 

--- a/src/hooks/Circles/useUpdatePostMessage.ts
+++ b/src/hooks/Circles/useUpdatePostMessage.ts
@@ -1,13 +1,11 @@
 import { gql } from 'graphql-request';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
-import { useActiveAccount } from '../useActiveAccount';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { optimisticallyUpdatePosts } from './utils/optimisticallyUpdatePosts';
 import { useActiveCircleTile } from './useActiveCircleTile';
 
 export function useUpdatePostMessage() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const queryClient = useQueryClient();
   const { circleTile } = useActiveCircleTile();
 
@@ -19,11 +17,7 @@ export function useUpdatePostMessage() {
       input,
     };
 
-    return graphQLClient.request(
-      updatePostMessageMutationDocument,
-      variables,
-      accountHeaders,
-    );
+    return graphQLClient.request(updatePostMessageMutationDocument, variables);
   };
 
   return useMutation(['updatePostMessage'], updatePostMessageMutation, {

--- a/src/hooks/todayTile/useTodayTasks.test.tsx
+++ b/src/hooks/todayTile/useTodayTasks.test.tsx
@@ -7,13 +7,9 @@ import { useMe } from '../useMe';
 import { useUser } from '../useUser';
 import { useActiveProject } from '../useActiveProject';
 import { ConsentDirective, SurveyResponse } from './types';
-import { useActiveAccount } from '../useActiveAccount';
 
 jest.mock('../useActiveProject', () => ({
   useActiveProject: jest.fn(),
-}));
-jest.mock('../useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
 }));
 jest.mock('../useMe', () => ({
   useMe: jest.fn(),
@@ -23,7 +19,6 @@ jest.mock('../useUser', () => ({
 }));
 
 const useActiveProjectMock = useActiveProject as jest.Mock;
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 const useMeMock = useMe as jest.Mock;
 const useUserMock = useUser as jest.Mock;
 
@@ -71,9 +66,6 @@ beforeEach(() => {
   });
   useUserMock.mockReturnValue({
     data: { id: 'mockUser' },
-  });
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'lifeomic' },
   });
   api.reset();
 });

--- a/src/hooks/todayTile/useTodayTasks.tsx
+++ b/src/hooks/todayTile/useTodayTasks.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { useGraphQLClient } from '../useGraphQLClient';
 import { gql } from 'graphql-request';
-import { useActiveAccount } from '../useActiveAccount';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useActiveProject } from '../useActiveProject';
 import { useRestQuery, useRestCache } from '../rest-api';
@@ -34,7 +33,6 @@ export const useInvalidateTodayCountCache = () => {
 
 const useConsentTasks = () => {
   const { activeProject } = useActiveProject();
-  const { accountHeaders } = useActiveAccount();
 
   return useRestQuery(
     'GET /v1/consent/directives/me',
@@ -43,7 +41,6 @@ const useConsentTasks = () => {
       includeForm: true,
     },
     {
-      axios: { headers: accountHeaders },
       select: (data) => data.items,
     },
   );
@@ -59,7 +56,6 @@ export const useGetSurveyResponsesForProject = (
   input?: SurveyResponseInput,
 ) => {
   const { activeSubjectId, activeProject } = useActiveProject();
-  const { accountHeaders } = useActiveAccount();
 
   return useRestQuery(
     'GET /v1/survey/projects/:projectId/responses',
@@ -72,7 +68,6 @@ export const useGetSurveyResponsesForProject = (
       pageSize: input?.pageSize ?? 100,
     },
     {
-      axios: { headers: accountHeaders },
       select: (data) => data.items,
     },
   );
@@ -91,15 +86,13 @@ const GetIncompleteActivitiesCount = gql`
 
 export const useGetIncompleteActivitiesCount = () => {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
 
   const queryForPostDetails = useCallback(async () => {
     return graphQLClient.request<GetIncompleteActivitiesCountQueryResponse>(
       GetIncompleteActivitiesCount,
       undefined,
-      accountHeaders,
     );
-  }, [accountHeaders, graphQLClient]);
+  }, [graphQLClient]);
 
   return useQuery(['getIncompleteActivitiesCount'], queryForPostDetails);
 };

--- a/src/hooks/useActiveAccount.test.tsx
+++ b/src/hooks/useActiveAccount.test.tsx
@@ -25,7 +25,6 @@ test('converts useAccounts data into helpful state', async () => {
   await waitFor(() =>
     expect(result.current).toMatchObject({
       account: 'test-account',
-      accountHeaders: { 'LifeOmic-Account': 'test-account' },
     }),
   );
 });

--- a/src/hooks/useActiveAccount.tsx
+++ b/src/hooks/useActiveAccount.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 export type ActiveAccountContextValue = {
   account: string;
-  accountHeaders: { 'LifeOmic-Account': string };
 };
 
 const ActiveAccountContext = React.createContext<
@@ -18,10 +17,7 @@ export const ActiveAccountProvider = ({
   children,
   account,
 }: ActiveAccountProviderProps) => {
-  const memoized = React.useMemo(
-    () => ({ account, accountHeaders: { 'LifeOmic-Account': account } }),
-    [account],
-  );
+  const memoized = React.useMemo(() => ({ account }), [account]);
 
   return (
     <ActiveAccountContext.Provider value={memoized}>

--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -70,7 +70,14 @@ const withAccountRequired =
   <Props extends {}>(Component: React.FC<Props>): React.FC<Props> =>
   (props) => {
     const { account: activeAccountId } = useActiveAccount();
-    const query = useRestQuery('GET /v1/accounts', {});
+    const query = useRestQuery(
+      'GET /v1/accounts',
+      {},
+      {
+        // Do not include account header on this request.
+        axios: { headers: { 'LifeOmic-Account': '' } },
+      },
+    );
 
     if (query.status !== 'success') {
       return (

--- a/src/hooks/useActivities.tsx
+++ b/src/hooks/useActivities.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { gql } from 'graphql-request';
 import { useGraphQLClient } from './useGraphQLClient';
-import { useActiveAccount } from './useActiveAccount';
 import { useQuery } from '@tanstack/react-query';
 
 const getActivitiesQueryDocument = gql`
@@ -367,17 +366,13 @@ type ActivitiesQueryResponse = {
 
 export const useActivities = (input: ActivitiesInput) => {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
 
   const queryForActivities = useCallback(async () => {
     return graphQLClient.request<ActivitiesQueryResponse>(
       getActivitiesQueryDocument,
-      {
-        input,
-      },
-      accountHeaders,
+      { input },
     );
-  }, [accountHeaders, graphQLClient, input]);
+  }, [graphQLClient, input]);
 
   return useQuery(['activities'], queryForActivities);
 };

--- a/src/hooks/useAppConfig.test.tsx
+++ b/src/hooks/useAppConfig.test.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useAppConfig, AppTile } from './useAppConfig';
-import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { HttpClientContextProvider } from './useHttpClient';
 import { createRestAPIMock } from '../test-utils/rest-api-mocking';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ActiveAccountProvider } from './useActiveAccount';
 
 const api = createRestAPIMock();
 
-jest.mock('./useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
 jest.mock('./useActiveProject', () => ({
   useActiveProject: jest.fn(),
 }));
 
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 const useActiveProjectMock = useActiveProject as jest.Mock;
 
 const mockAppTile = (id: string): AppTile => ({
@@ -30,18 +26,15 @@ const renderHookInContext = async () => {
   return renderHook(() => useAppConfig(), {
     wrapper: ({ children }) => (
       <QueryClientProvider client={new QueryClient()}>
-        <HttpClientContextProvider>{children}</HttpClientContextProvider>
+        <ActiveAccountProvider account="mockaccount">
+          <HttpClientContextProvider>{children}</HttpClientContextProvider>
+        </ActiveAccountProvider>
       </QueryClientProvider>
     ),
   });
 };
 
 beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: {
-      'LifeOmic-Account': 'acct1',
-    },
-  });
   useActiveProjectMock.mockReturnValue({
     activeProject: { id: 'projectId' },
   });

--- a/src/hooks/useAppConfig.tsx
+++ b/src/hooks/useAppConfig.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { Trace } from '../components/MyData/LineChart/TraceLine';
 import { SvgProps } from 'react-native-svg';
@@ -110,17 +109,11 @@ export interface AppConfig {
 }
 
 export const useAppConfig = () => {
-  const { accountHeaders } = useActiveAccount();
   const { activeProject } = useActiveProject();
 
   const query = useRestQuery(
     'GET /v1/life-research/projects/:projectId/app-config',
     { projectId: activeProject.id },
-    {
-      axios: {
-        headers: accountHeaders,
-      },
-    },
   );
 
   useEffect(() => {

--- a/src/hooks/useConsent.test.tsx
+++ b/src/hooks/useConsent.test.tsx
@@ -5,7 +5,6 @@ import { useHttpClient } from './useHttpClient';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 
 const queryClient = new QueryClient({
@@ -16,9 +15,6 @@ const queryClient = new QueryClient({
   },
 });
 
-jest.mock('./useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
 jest.mock('./useActiveProject', () => ({
   useActiveProject: jest.fn(),
 }));
@@ -26,7 +22,6 @@ jest.mock('./useHttpClient', () => ({
   useHttpClient: jest.fn(),
 }));
 
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 const useActiveProjectMock = useActiveProject as jest.Mock;
 const useHttpClientMock = useHttpClient as jest.Mock;
 
@@ -44,9 +39,6 @@ const axiosMock = new MockAdapter(axiosInstance);
 const activeProject = { id: 'projectId' };
 
 beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'acct1' },
-  });
   useActiveProjectMock.mockReturnValue({
     activeProject,
     activeSubjectId: 'subjectId',

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -1,11 +1,9 @@
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
 import { useActiveProject } from './useActiveProject';
 import { Consent, Questionnaire } from 'fhir/r3';
 
 export const useConsent = () => {
-  const { accountHeaders, account } = useActiveAccount();
   const { activeProject } = useActiveProject();
   const { httpClient } = useHttpClient();
 
@@ -14,16 +12,13 @@ export const useConsent = () => {
       [
         '/v1/consent/directives/me',
         {
-          account,
           projectId: activeProject.id,
-          accountHeaders,
         },
       ],
       () =>
         httpClient
           .get<{ items: ConsentAndForm[] }>('/v1/consent/directives/me', {
             params: { projectId: activeProject.id, includeForm: true },
-            headers: { ...accountHeaders },
           })
           .then((res) => res.data),
     );
@@ -32,30 +27,24 @@ export const useConsent = () => {
   const useUpdateProjectConsentDirective = () => {
     return useMutation({
       mutationFn: async (params: ConsentPatch) =>
-        httpClient.patch(
-          `/v1/consent/directives/me/${params.directiveId}`,
-          {
-            status: params.accept ? 'active' : 'rejected',
-            response: {
-              item: [
-                {
-                  linkId: 'terms',
-                },
-                {
-                  linkId: 'acceptance',
-                  answer: [
-                    {
-                      valueBoolean: params.accept,
-                    },
-                  ],
-                },
-              ],
-            },
+        httpClient.patch(`/v1/consent/directives/me/${params.directiveId}`, {
+          status: params.accept ? 'active' : 'rejected',
+          response: {
+            item: [
+              {
+                linkId: 'terms',
+              },
+              {
+                linkId: 'acceptance',
+                answer: [
+                  {
+                    valueBoolean: params.accept,
+                  },
+                ],
+              },
+            ],
           },
-          {
-            headers: { ...accountHeaders },
-          },
-        ),
+        }),
     });
   };
 

--- a/src/hooks/useConversations.ts
+++ b/src/hooks/useConversations.ts
@@ -6,7 +6,6 @@ import {
 } from '@tanstack/react-query';
 import { gql } from 'graphql-request';
 import { useGraphQLClient } from './useGraphQLClient';
-import { useActiveAccount } from './useActiveAccount';
 import cloneDeep from 'lodash/cloneDeep';
 
 const conversationsQueryDocument = gql`
@@ -88,7 +87,6 @@ export function useHasUnread() {
 
 export function useInfiniteConversations() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
 
   const queryConversations = async ({ pageParam }: { pageParam?: string }) => {
     const variables = {
@@ -98,7 +96,6 @@ export function useInfiniteConversations() {
     return graphQLClient.request<ConversationsData>(
       conversationsQueryDocument,
       variables,
-      accountHeaders,
     );
   };
 
@@ -113,18 +110,13 @@ export function useInfiniteConversations() {
 
 export function useMarkAsRead() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
 
   const markAsReadMutation = async (input: MarkAsReadInput) => {
     const variables = {
       input,
     };
 
-    return graphQLClient.request(
-      markAsReadMutationDocument,
-      variables,
-      accountHeaders,
-    );
+    return graphQLClient.request(markAsReadMutationDocument, variables);
   };
 
   return useMutation({ mutationFn: markAsReadMutation });
@@ -132,7 +124,6 @@ export function useMarkAsRead() {
 
 export function useLeaveConversation() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const queryClient = useQueryClient();
 
   const leaveConversationMutation = async (input: LeaveConversationInput) => {
@@ -140,11 +131,7 @@ export function useLeaveConversation() {
       input,
     };
 
-    return graphQLClient.request(
-      leaveConversationMutationDocument,
-      variables,
-      accountHeaders,
-    );
+    return graphQLClient.request(leaveConversationMutationDocument, variables);
   };
 
   return useMutation({

--- a/src/hooks/useExchangeToken.test.tsx
+++ b/src/hooks/useExchangeToken.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { useActiveAccount } from './useActiveAccount';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useExchangeToken } from './useExchangeToken';
 import { createRestAPIMock } from '../test-utils/rest-api-mocking';
@@ -15,12 +14,6 @@ const queryClient = new QueryClient({
 
 const api = createRestAPIMock();
 
-jest.mock('./useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
-
-const useActiveAccountMock = useActiveAccount as jest.Mock;
-
 const renderHookInContext = async () => {
   return renderHook(() => useExchangeToken('someAppTileId', 'someClientId'), {
     wrapper: ({ children }) => (
@@ -28,12 +21,6 @@ const renderHookInContext = async () => {
     ),
   });
 };
-
-beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'acct1' },
-  });
-});
 
 test('posts token/clientId to /v1/client-tokens', async () => {
   const mock = jest.fn();
@@ -50,9 +37,7 @@ test('posts token/clientId to /v1/client-tokens', async () => {
   expect(mock).toHaveBeenCalledTimes(1);
   expect(mock).toHaveBeenCalledWith({
     body: { targetClientId: 'someClientId' },
-    headers: expect.objectContaining({
-      'lifeomic-account': 'acct1',
-    }),
+    headers: expect.objectContaining({}),
     params: {},
   });
 });

--- a/src/hooks/useExchangeToken.tsx
+++ b/src/hooks/useExchangeToken.tsx
@@ -1,10 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
-import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
 
 export function useExchangeToken(appTileId: string, clientId?: string) {
   const { apiClient } = useHttpClient();
-  const { accountHeaders } = useActiveAccount();
 
   return useQuery(
     [
@@ -16,11 +14,7 @@ export function useExchangeToken(appTileId: string, clientId?: string) {
     ],
     () =>
       apiClient
-        .request(
-          'POST /v1/client-tokens',
-          { targetClientId: clientId! },
-          { headers: accountHeaders },
-        )
+        .request('POST /v1/client-tokens', { targetClientId: clientId! })
         .then((res) => res.data),
     {
       enabled: !!clientId,

--- a/src/hooks/useFeature.test.tsx
+++ b/src/hooks/useFeature.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { useActiveAccount } from './useActiveAccount';
 import { useFeature } from './useFeature';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MockAdapter from 'axios-mock-adapter';
@@ -15,14 +14,10 @@ const queryClient = new QueryClient({
   },
 });
 
-jest.mock('./useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
 jest.mock('./useHttpClient', () => ({
   useHttpClient: jest.fn(),
 }));
 
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 const useHttpClientMock = useHttpClient as jest.Mock;
 
 const renderHookInContext = async (feature: string) => {
@@ -38,9 +33,6 @@ const axiosInstance = axios.create();
 const axiosMock = new MockAdapter(axiosInstance);
 
 beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'acct1' },
-  });
   useHttpClientMock.mockReturnValue({ httpClient: axiosInstance });
 });
 

--- a/src/hooks/useFeature.ts
+++ b/src/hooks/useFeature.ts
@@ -1,19 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
 
 type Response<T extends string> = Record<T, boolean>;
 
 export function useFeature<T extends string>(feature: T) {
-  const { accountHeaders } = useActiveAccount();
   const { httpClient } = useHttpClient();
 
   return useQuery(
     ['Features', feature],
-    () =>
-      httpClient.get<Response<T>>(`/v1/features/${feature}`, {
-        headers: accountHeaders,
-      }),
+    () => httpClient.get<Response<T>>(`/v1/features/${feature}`),
     {
       select(data) {
         return !!data.data[feature];

--- a/src/hooks/useFhirClient.test.tsx
+++ b/src/hooks/useFhirClient.test.tsx
@@ -43,7 +43,6 @@ const axiosMock = new MockAdapter(axiosInstance);
 
 beforeEach(() => {
   useActiveAccountMock.mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'acct1' },
     account: 'acct1',
   });
   useActiveProjectMock.mockReturnValue({

--- a/src/hooks/useFhirClient.tsx
+++ b/src/hooks/useFhirClient.tsx
@@ -28,7 +28,7 @@ type DeleteParams = {
 
 export function useFhirClient() {
   const { httpClient } = useHttpClient();
-  const { accountHeaders, account } = useActiveAccount();
+  const { account } = useActiveAccount();
   const { activeProject, activeSubjectId } = useActiveProject();
 
   const toResource = (source: ResourceType) => {
@@ -130,9 +130,6 @@ export function useFhirClient() {
           .post<Bundle<ResourceTypes[typeof resourceType]>>(
             `/v1/fhir/dstu3/${resourceType}/_search`,
             params,
-            {
-              headers: accountHeaders,
-            },
           )
           .then((res) => {
             const { data } = res;
@@ -173,9 +170,6 @@ export function useFhirClient() {
           .post<ResourceType>(
             `/v1/fhir/dstu3/${resource.resourceType}`,
             resource,
-            {
-              headers: accountHeaders,
-            },
           )
           .then((res) => res.data);
       },
@@ -204,9 +198,6 @@ export function useFhirClient() {
             // TODO: Update once the bundle endpoint is exposed behind `/v1/fhir`
             `https://fhir.us.lifeomic.com/${account}/dstu3`,
             bundle,
-            {
-              headers: accountHeaders,
-            },
           )
           .then((res) => res.data);
       },
@@ -217,9 +208,7 @@ export function useFhirClient() {
     return useMutation({
       mutationFn: async (params: DeleteParams) => {
         return httpClient
-          .delete(`/v1/fhir/dstu3/${params.resourceType}/${params.id}`, {
-            headers: accountHeaders,
-          })
+          .delete(`/v1/fhir/dstu3/${params.resourceType}/${params.id}`)
           .then((res) => res.data);
       },
     });

--- a/src/hooks/useGraphQLClient.test.tsx
+++ b/src/hooks/useGraphQLClient.test.tsx
@@ -6,6 +6,7 @@ import {
   useGraphQLClient,
 } from './useGraphQLClient';
 import { mockGraphQLResponse } from '../common/testHelpers/mockGraphQLResponse';
+import { ActiveAccountProvider } from './useActiveAccount';
 
 jest.mock('./useAuth', () => ({
   useAuth: jest.fn(),
@@ -25,9 +26,11 @@ const baseURL = 'http://localhost:8080/unit-test';
 const renderHookInContext = async () => {
   return renderHook(() => useGraphQLClient(), {
     wrapper: ({ children }) => (
-      <GraphQLClientContextProvider baseURL={baseURL}>
-        {children}
-      </GraphQLClientContextProvider>
+      <ActiveAccountProvider account="mockaccount">
+        <GraphQLClientContextProvider baseURL={baseURL}>
+          {children}
+        </GraphQLClientContextProvider>
+      </ActiveAccountProvider>
     ),
   });
 };
@@ -50,7 +53,7 @@ test('if authResult is not present, has no Authorization header', async () => {
   scope.done();
 });
 
-test('once authResult is set, adds bearer token', async () => {
+test('once authResult is set, adds bearer token and account header', async () => {
   const { result, rerender } = await renderHookInContext();
 
   act(() => {
@@ -61,6 +64,7 @@ test('once authResult is set, adds bearer token', async () => {
   const scope = mockGraphQLResponse(`${baseURL}/v1/graphql`, {
     'content-type': 'application/json',
     authorization: `Bearer ${authResult.accessToken}`,
+    'lifeomic-account': 'mockaccount',
   });
 
   await result.current.graphQLClient.request('');

--- a/src/hooks/useGraphQLClient.tsx
+++ b/src/hooks/useGraphQLClient.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import { useAuth } from './useAuth';
 import { GraphQLClient as GQLClient } from 'graphql-request';
+import { useActiveAccount } from './useActiveAccount';
 
 const defaultBaseURL = 'https://api.us.lifeomic.com/v1/graphql';
 const defaultHeaders = {
@@ -34,6 +35,7 @@ export const GraphQLClientContextProvider = ({
   children?: React.ReactNode;
 }) => {
   const { authResult } = useAuth();
+  const { account } = useActiveAccount();
   const graphQLInstance =
     injectedGraphQLInstance || defaultGraphQLClientInstance;
 
@@ -51,8 +53,9 @@ export const GraphQLClientContextProvider = ({
       'Authorization',
       `Bearer ${authResult.accessToken}`,
     );
+    graphQLInstance.setHeader('LifeOmic-Account', account);
     return graphQLInstance;
-  }, [authResult?.accessToken, graphQLInstance]);
+  }, [authResult?.accessToken, account, graphQLInstance]);
 
   const context: GraphQLClient = { graphQLClient };
 

--- a/src/hooks/useMe.test.tsx
+++ b/src/hooks/useMe.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { useActiveAccount } from './useActiveAccount';
 import { useMe } from './useMe';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MockAdapter from 'axios-mock-adapter';
@@ -15,14 +14,10 @@ const queryClient = new QueryClient({
   },
 });
 
-jest.mock('./useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
 jest.mock('./useHttpClient', () => ({
   useHttpClient: jest.fn(),
 }));
 
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 const useHttpClientMock = useHttpClient as jest.Mock;
 
 const renderHookInContext = async () => {
@@ -37,9 +32,6 @@ const axiosInstance = axios.create();
 const axiosMock = new MockAdapter(axiosInstance);
 
 beforeEach(() => {
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'acct1' },
-  });
   useHttpClientMock.mockReturnValue({ httpClient: axiosInstance });
 });
 

--- a/src/hooks/useMe.ts
+++ b/src/hooks/useMe.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
 import { Patient } from 'fhir/r3';
 import { usePendingInvite } from './usePendingInvite';
@@ -21,26 +20,23 @@ interface MeResponse {
 }
 
 export function useMe() {
-  const { accountHeaders } = useActiveAccount();
   const { httpClient } = useHttpClient();
   const { lastAcceptedId } = usePendingInvite();
 
   const useMeQuery = useQuery(['fhir/dstu3/$me', lastAcceptedId], () =>
-    httpClient
-      .get<MeResponse>('/v1/fhir/dstu3/$me', { headers: accountHeaders })
-      .then((res) =>
-        res.data.entry?.map(
-          (entry) =>
-            ({
-              subjectId: entry.resource.id,
-              projectId: entry.resource.meta?.tag?.find(
-                (t) => t.system === 'http://lifeomic.com/fhir/dataset',
-              )?.code,
-              name: entry.resource.name,
-              subject: entry.resource,
-            } as Subject),
-        ),
+    httpClient.get<MeResponse>('/v1/fhir/dstu3/$me').then((res) =>
+      res.data.entry?.map(
+        (entry) =>
+          ({
+            subjectId: entry.resource.id,
+            projectId: entry.resource.meta?.tag?.find(
+              (t) => t.system === 'http://lifeomic.com/fhir/dataset',
+            )?.code,
+            name: entry.resource.name,
+            subject: entry.resource,
+          } as Subject),
       ),
+    ),
   );
 
   return useMeQuery;

--- a/src/hooks/useMessagingProfiles.test.tsx
+++ b/src/hooks/useMessagingProfiles.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useProfilesForTile } from './useMessagingProfiles';
 import { useAppConfig } from './useAppConfig';
-import { useActiveAccount } from './useActiveAccount';
 import { useUser } from './useUser';
 import { createRestAPIMock } from '../test-utils/rest-api-mocking';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -11,7 +10,6 @@ import { QueryClient } from '@tanstack/query-core';
 const api = createRestAPIMock();
 
 jest.mock('./useAppConfig');
-jest.mock('./useActiveAccount');
 jest.mock('./useUser');
 jest.mock('./useAuth', () => ({
   useAuth: () => ({
@@ -48,9 +46,6 @@ beforeEach(() => {
         ],
       },
     },
-  });
-  (useActiveAccount as jest.Mock).mockReturnValue({
-    accountHeaders: { 'LifeOmic-Account': 'someAccount' },
   });
 });
 

--- a/src/hooks/useMessagingProfiles.tsx
+++ b/src/hooks/useMessagingProfiles.tsx
@@ -1,5 +1,4 @@
 import { useAppConfig } from './useAppConfig';
-import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
 import { UseQueryOptions, useQueries } from '@tanstack/react-query';
 import { combineQueries } from '@lifeomic/one-query';
@@ -29,7 +28,6 @@ const placeHolderProfile = (userId: string) => ({
 
 export const useMessagingProfiles = (userIds?: string[]) => {
   const { apiClient } = useHttpClient();
-  const { accountHeaders } = useActiveAccount();
 
   const queries = useQueries({
     queries:
@@ -38,11 +36,7 @@ export const useMessagingProfiles = (userIds?: string[]) => {
           userId,
           () =>
             apiClient
-              .request(
-                'GET /v1/account/users/:userId',
-                { userId },
-                { headers: accountHeaders },
-              )
+              .request('GET /v1/account/users/:userId', { userId })
               .then((res) => res.data),
           {
             placeholderData: placeHolderProfile(userId),

--- a/src/hooks/useNotifications.test.tsx
+++ b/src/hooks/useNotifications.test.tsx
@@ -1,5 +1,4 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
-import { useActiveAccount } from './useActiveAccount';
 import { useUser } from './useUser';
 import {
   FeedNotification,
@@ -11,10 +10,7 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from './useGraphQLClient';
 import { mockGraphQLResponse } from '../common/testHelpers/mockGraphQLResponse';
-
-jest.mock('./useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
+import { ActiveAccountProvider } from './useActiveAccount';
 
 jest.mock('./useUser', () => ({
   useUser: jest.fn(),
@@ -39,16 +35,17 @@ const renderHookWithInjectedClient = async () => {
   return renderHook(() => useNotifications(), {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>
-        <GraphQLClientContextProvider baseURL={baseURL}>
-          {children}
-        </GraphQLClientContextProvider>
+        <ActiveAccountProvider account="mockaccount">
+          <GraphQLClientContextProvider baseURL={baseURL}>
+            {children}
+          </GraphQLClientContextProvider>
+        </ActiveAccountProvider>
       </QueryClientProvider>
     ),
   });
 };
 
 const useUserMock = useUser as jest.Mock;
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 
 beforeEach(() => {
   useUserMock.mockReturnValue({
@@ -57,11 +54,6 @@ beforeEach(() => {
       profile: {},
     },
     isLoading: false,
-  });
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: {
-      'LifeOmic-Account': 'unittest',
-    },
   });
 });
 

--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { gql } from 'graphql-request';
 import { useGraphQLClient } from './useGraphQLClient';
-import { useActiveAccount } from './useActiveAccount';
 import { useUser } from './useUser';
 
 export type NotificationBase = {
@@ -138,18 +137,13 @@ const selectNotifications = (
 
 export function useNotifications() {
   const { graphQLClient } = useGraphQLClient();
-  const { accountHeaders } = useActiveAccount();
   const { data } = useUser();
 
   const queryForNotifications = useCallback(() => {
-    return graphQLClient.request<NotificationQueryResponse>(
-      notificationQuery,
-      {
-        userId: data?.id,
-      },
-      accountHeaders,
-    );
-  }, [accountHeaders, data?.id, graphQLClient]);
+    return graphQLClient.request<NotificationQueryResponse>(notificationQuery, {
+      userId: data?.id,
+    });
+  }, [data?.id, graphQLClient]);
 
   return useQuery(['notifications'], queryForNotifications, {
     enabled: !!data?.id,

--- a/src/hooks/usePushNotifications.test.tsx
+++ b/src/hooks/usePushNotifications.test.tsx
@@ -18,13 +18,13 @@ jest.mock('react-native-notifications', () => ({
 const renderProvider = (config?: PushNotificationsConfig) =>
   render(
     <QueryClientProvider client={new QueryClient()}>
-      <HttpClientContextProvider>
-        <ActiveAccountProvider account="test-account">
+      <ActiveAccountProvider account="test-account">
+        <HttpClientContextProvider>
           <PushNotificationsProvider config={config}>
             <Text>content</Text>
           </PushNotificationsProvider>
-        </ActiveAccountProvider>
-      </HttpClientContextProvider>
+        </HttpClientContextProvider>
+      </ActiveAccountProvider>
     </QueryClientProvider>,
   );
 
@@ -64,7 +64,6 @@ test('requests permissions', async () => {
   expect(NotificationsUtils.registerDeviceToken).toHaveBeenCalledWith({
     deviceToken: 'test-token',
     application: 'test-app',
-    accountId: 'test-account',
     httpClient: expect.anything(),
   });
 });

--- a/src/hooks/usePushNotifications.tsx
+++ b/src/hooks/usePushNotifications.tsx
@@ -7,7 +7,6 @@ import { PushNotificationsConfig } from '../../src/common/DeveloperConfig';
 import { Platform } from 'react-native';
 import { Notifications } from 'react-native-notifications';
 import { useHttpClient } from './useHttpClient';
-import { useActiveAccount } from './useActiveAccount';
 
 export const PushNotificationsContext = createContext<{}>({});
 
@@ -19,7 +18,6 @@ export function PushNotificationsProvider({
   children: React.ReactNode;
 }) {
   const { httpClient } = useHttpClient();
-  const { account } = useActiveAccount();
 
   const enabled = config?.applicationName && config?.enabled;
 
@@ -44,18 +42,17 @@ export function PushNotificationsProvider({
   useEffect(() => {
     if (enabled) {
       requestNotificationsPermissions(({ deviceToken }) => {
-        if (deviceToken && account) {
+        if (deviceToken) {
           // Register the device with the LifeOmic platform to start receiving push notifications
           registerDeviceToken({
             deviceToken,
             application: config.applicationName,
             httpClient,
-            accountId: account,
           });
         }
       });
     }
-  }, [account, httpClient, config, enabled]);
+  }, [httpClient, config, enabled]);
 
   return (
     <PushNotificationsContext.Provider value={{}}>

--- a/src/hooks/useSubjectProjects.test.tsx
+++ b/src/hooks/useSubjectProjects.test.tsx
@@ -43,7 +43,6 @@ const axiosMock = new MockAdapter(axiosInstance);
 beforeEach(() => {
   useActiveAccountMock.mockReturnValue({
     account: 'acct1',
-    accountHeaders: { 'LifeOmic-Account': 'acct1' },
   });
   useMeMock.mockReturnValue({
     data: [{ projectId: 'proj1' }, { projectId: 'proj2' }],

--- a/src/hooks/useSubjectProjects.tsx
+++ b/src/hooks/useSubjectProjects.tsx
@@ -14,7 +14,7 @@ interface ProjectsResponse {
 }
 
 export function useSubjectProjects() {
-  const { account, accountHeaders } = useActiveAccount();
+  const { account } = useActiveAccount();
   const { data: subjects } = useMe();
   const { httpClient } = useHttpClient();
   const { lastAcceptedId } = usePendingInvite();
@@ -25,7 +25,6 @@ export function useSubjectProjects() {
       if (subjects?.length) {
         const res = await httpClient.get<ProjectsResponse>(
           `/v1/projects?${subjects?.map((s) => `id=${s.projectId}`).join('&')}`,
-          { headers: accountHeaders },
         );
         return res.data.items;
       } else {

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,12 +1,21 @@
 import { useRestCache, useRestMutation, useRestQuery } from './rest-api';
 
 export function useUser() {
-  return useRestQuery('GET /v1/user', {});
+  return useRestQuery(
+    'GET /v1/user',
+    {},
+    {
+      // Do not include account header on this request.
+      axios: { headers: { 'LifeOmic-Account': '' } },
+    },
+  );
 }
 
 export const useUpdateUser = () => {
   const cache = useRestCache();
   return useRestMutation('PATCH /v1/user', {
+    // Do not include account header on this request.
+    axios: { headers: { 'LifeOmic-Account': '' } },
     onSuccess: (user) => {
       cache.updateCache('GET /v1/user', {}, user);
     },

--- a/src/hooks/useWearableBackfill.test.tsx
+++ b/src/hooks/useWearableBackfill.test.tsx
@@ -184,15 +184,11 @@ describe('useWearableBackfill', () => {
     });
 
     expect(data).toEqual(true);
-    expect(post).toHaveBeenCalledWith(
-      '/ehrs/ehrId/backfill',
-      {
-        project: 'project-id',
-        end: mockDate.toISOString(),
-        start: addDays(mockDate, -30).toISOString(),
-      },
-      { headers: { 'LifeOmic-Account': '' } },
-    );
+    expect(post).toHaveBeenCalledWith('/ehrs/ehrId/backfill', {
+      project: 'project-id',
+      end: mockDate.toISOString(),
+      start: addDays(mockDate, -30).toISOString(),
+    });
   });
 
   it('should NOT invoke a backfill if feature is disabled', async () => {

--- a/src/hooks/useWearableBackfill.tsx
+++ b/src/hooks/useWearableBackfill.tsx
@@ -3,7 +3,6 @@ import { addDays } from 'date-fns';
 import { gql } from 'graphql-request';
 import { useQuery } from '@tanstack/react-query';
 import { EHRType, WearablesSyncState } from '../components';
-import { useActiveAccount } from './useActiveAccount';
 import { useActiveProject } from './useActiveProject';
 import { useGraphQLClient } from './useGraphQLClient';
 import { useHttpClient } from './useHttpClient';
@@ -28,7 +27,6 @@ export const useWearableBackfill = (
   const { graphQLClient } = useGraphQLClient();
   const { httpClient } = useHttpClient();
   const { data: isBackfillEnabled } = useFeature('ehrBackfill');
-  const { accountHeaders } = useActiveAccount();
 
   const ehrTypes = useMemo(
     () => wearablesState?.items?.map((ehr) => ehr.ehrType as EHRType) ?? [],
@@ -37,14 +35,10 @@ export const useWearableBackfill = (
 
   const queryEHRSyncStatus = useCallback(
     () =>
-      graphQLClient.request<Response>(
-        buildEHRRecordsQueryDocument(ehrTypes),
-        {
-          patientId: activeSubjectId,
-        },
-        accountHeaders,
-      ),
-    [graphQLClient, activeSubjectId, ehrTypes, accountHeaders],
+      graphQLClient.request<Response>(buildEHRRecordsQueryDocument(ehrTypes), {
+        patientId: activeSubjectId,
+      }),
+    [graphQLClient, activeSubjectId, ehrTypes],
   );
 
   const { data: syncStatus } = useQuery(

--- a/src/hooks/useWearableBackfill.tsx
+++ b/src/hooks/useWearableBackfill.tsx
@@ -104,11 +104,18 @@ export const useWearableBackfill = (
 
       const createBackfillResponse = await httpClient.post<{
         ingestionId: string;
-      }>(`/ehrs/${ehrId}/backfill`, {
-        project: activeProject,
-        end: new Date(end).toISOString(),
-        start: start.toISOString(),
-      });
+      }>(
+        `/ehrs/${ehrId}/backfill`,
+        {
+          project: activeProject,
+          end: new Date(end).toISOString(),
+          start: start.toISOString(),
+        },
+        {
+          // Do not include account header on this request.
+          headers: { 'LifeOmic-Account': '' },
+        },
+      );
 
       return !!createBackfillResponse.data.ingestionId;
     },

--- a/src/hooks/useWearableBackfill.tsx
+++ b/src/hooks/useWearableBackfill.tsx
@@ -98,18 +98,11 @@ export const useWearableBackfill = (
 
       const createBackfillResponse = await httpClient.post<{
         ingestionId: string;
-      }>(
-        `/ehrs/${ehrId}/backfill`,
-        {
-          project: activeProject,
-          end: new Date(end).toISOString(),
-          start: start.toISOString(),
-        },
-        {
-          // Do not include account header on this request.
-          headers: { 'LifeOmic-Account': '' },
-        },
-      );
+      }>(`/ehrs/${ehrId}/backfill`, {
+        project: activeProject,
+        end: new Date(end).toISOString(),
+        start: start.toISOString(),
+      });
 
       return !!createBackfillResponse.data.ingestionId;
     },

--- a/src/hooks/useWearables.ts
+++ b/src/hooks/useWearables.ts
@@ -7,7 +7,6 @@ import {
   WearableIntegrationStatus,
   WearablesSyncState,
 } from '../components/Wearables/WearableTypes';
-import { useActiveAccount } from './useActiveAccount';
 import { useHttpClient } from './useHttpClient';
 
 /**
@@ -46,7 +45,6 @@ interface SetWearableState {
 
 export const useWearables = () => {
   const { httpClient } = useHttpClient();
-  const { accountHeaders } = useActiveAccount();
 
   const setWearableState = async ({
     ehrId,
@@ -62,46 +60,33 @@ export const useWearables = () => {
       : meta;
 
     return httpClient
-      .patch<ToggleWearableResult>(
-        `/v1/wearables/${ehrId}`,
-        {
-          enabled,
-          meta: metaToSend,
-        },
-        { headers: accountHeaders },
-      )
+      .patch<ToggleWearableResult>(`/v1/wearables/${ehrId}`, {
+        enabled,
+        meta: metaToSend,
+      })
       .then((res) => res.data);
   };
 
   const setLastSync = async ({ ehrId, lastSync, failureCode }: SetLastSync) =>
-    httpClient.patch(
-      `/v1/wearables/${ehrId}`,
-      {
-        lastSync,
-        status: failureCode
-          ? WearableIntegrationStatus.Failure
-          : WearableIntegrationStatus.Syncing,
-        failureCode,
-      },
-      { headers: accountHeaders },
-    );
-
-  const setSyncTypes = async (settings: SyncTypeSettings) =>
-    httpClient.put('/v1/wearables/sync-types', settings, {
-      headers: accountHeaders,
+    httpClient.patch(`/v1/wearables/${ehrId}`, {
+      lastSync,
+      status: failureCode
+        ? WearableIntegrationStatus.Failure
+        : WearableIntegrationStatus.Syncing,
+      failureCode,
     });
 
+  const setSyncTypes = async (settings: SyncTypeSettings) =>
+    httpClient.put('/v1/wearables/sync-types', settings);
+
   const useWearableIntegrationQuery = (ehrId: string) =>
-    useQuery(['get-wearable'], () =>
-      httpClient.get(`/v1/wearables/${ehrId}`, { headers: accountHeaders }),
-    );
+    useQuery(['get-wearable'], () => httpClient.get(`/v1/wearables/${ehrId}`));
 
   const useWearableIntegrationsQuery = () =>
     useQuery(['get-wearables'], () =>
       httpClient
         .get<WearablesSyncState>('/v1/wearables', {
           params: { appId: getBundleId().toLowerCase() },
-          headers: accountHeaders,
         })
         .then((res) => res.data),
     );

--- a/src/screens/ComposeMessageScreen.test.tsx
+++ b/src/screens/ComposeMessageScreen.test.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import {
+  fireEvent,
+  render as baseRender,
+  waitFor,
+} from '@testing-library/react-native';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
 import { useMessagingProfiles } from '../hooks/useMessagingProfiles';
 import { ComposeMessageScreen } from './ComposeMessageScreen';
 import { useUser } from '../hooks/useUser';
 import { useNavigation } from '@react-navigation/native';
 import { useAppConfig } from '../hooks/useAppConfig';
+import { ActiveAccountProvider } from '../hooks';
 
 jest.mock('../hooks/useMessagingProfiles');
 jest.mock('@react-navigation/elements', () => ({
@@ -53,6 +58,15 @@ const routeMap = {
   DirectMessageScreen: 'Home/DirectMessages',
 };
 
+const render = (element: React.ReactElement) =>
+  baseRender(
+    <ActiveAccountProvider account="mockaccount">
+      <GraphQLClientContextProvider baseURL={baseURL}>
+        {element}
+      </GraphQLClientContextProvider>
+    </ActiveAccountProvider>,
+  );
+
 beforeEach(() => {
   const otherProfiles = [...Array(10)].map((_, i) => ({
     id: `user-${i}`,
@@ -82,38 +96,34 @@ beforeEach(() => {
 
 test('no items when nothing is searched', () => {
   const { queryAllByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-        routeMapIn={routeMap}
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+      routeMapIn={routeMap}
+    />,
   );
   expect(queryAllByTestId('user-list-item').length).toBe(0);
 });
 
 test('all items returned when matched', () => {
   const { queryAllByTestId, getByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-        routeMapIn={routeMap}
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+      routeMapIn={routeMap}
+    />,
   );
 
   const addButton = getByTestId('add-provider-button');
@@ -125,19 +135,17 @@ test('all items returned when matched', () => {
 
 test('single item returned when searched', () => {
   const { queryAllByTestId, getByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-        routeMapIn={routeMap}
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+      routeMapIn={routeMap}
+    />,
   );
 
   const addButton = getByTestId('add-provider-button');
@@ -149,19 +157,17 @@ test('single item returned when searched', () => {
 
 test('item added as chip but removed from search when selected', () => {
   const { queryAllByTestId, getByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-        routeMapIn={routeMap}
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+      routeMapIn={routeMap}
+    />,
   );
 
   const addButton = getByTestId('add-provider-button');
@@ -178,19 +184,17 @@ test('item added as chip but removed from search when selected', () => {
 
 test('compose button disabled by default', () => {
   const { getByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-        routeMapIn={routeMap}
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+      routeMapIn={routeMap}
+    />,
   );
   const sendButton = getByTestId('send-button');
   fireEvent.press(sendButton);
@@ -199,19 +203,17 @@ test('compose button disabled by default', () => {
 
 test('compose button disabled with user selected but no message text', () => {
   const { getByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-        routeMapIn={routeMap}
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+      routeMapIn={routeMap}
+    />,
   );
   const textInput = getByTestId('Type a message...');
   fireEvent.changeText(textInput, 'some new message');
@@ -223,19 +225,17 @@ test('compose button disabled with user selected but no message text', () => {
 
 test('compose button enabled when user selected and message entered', async () => {
   const { getByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-        routeMapIn={routeMap}
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+      routeMapIn={routeMap}
+    />,
   );
   const addButton = await getByTestId('add-provider-button');
   fireEvent.press(addButton);
@@ -261,19 +261,17 @@ test('compose button enabled when user selected and message entered', async () =
 
 test('cannot select more than one non-provider', async () => {
   const { getByTestId, queryAllByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        routeMapIn={routeMap}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      routeMapIn={routeMap}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+    />,
   );
 
   expect(queryAllByTestId('chip').length).toBe(0);
@@ -295,19 +293,17 @@ test('cannot select more than one non-provider', async () => {
 
 test('can remove non-provider', async () => {
   const { getByTestId, queryAllByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        navigation={useNavigation() as any}
-        routeMapIn={routeMap}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      navigation={useNavigation() as any}
+      routeMapIn={routeMap}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+    />,
   );
 
   expect(queryAllByTestId('chip').length).toBe(0);
@@ -328,19 +324,17 @@ test('can remove non-provider', async () => {
 
 test('can select more than one provider', async () => {
   const { getByTestId, queryAllByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        routeMapIn={routeMap}
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      routeMapIn={routeMap}
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+    />,
   );
 
   expect(queryAllByTestId('chip').length).toBe(0);
@@ -361,19 +355,17 @@ test('can select more than one provider', async () => {
 
 test('can remove provider', async () => {
   const { getByTestId, queryAllByTestId } = render(
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <ComposeMessageScreen
-        routeMapIn={routeMap}
-        navigation={useNavigation() as any}
-        route={
-          {
-            params: {
-              tileId: 'mockTileId',
-            },
-          } as any
-        }
-      />
-    </GraphQLClientContextProvider>,
+    <ComposeMessageScreen
+      routeMapIn={routeMap}
+      navigation={useNavigation() as any}
+      route={
+        {
+          params: {
+            tileId: 'mockTileId',
+          },
+        } as any
+      }
+    />,
   );
 
   expect(queryAllByTestId('chip').length).toBe(0);

--- a/src/screens/DirectMessagesScreen.test.tsx
+++ b/src/screens/DirectMessagesScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
-import { useUser } from '../hooks';
+import { ActiveAccountProvider, useUser } from '../hooks';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
 import { DirectMessagesScreen } from './DirectMessagesScreen';
@@ -105,19 +105,21 @@ const mockYouProfile = {
 const baseURL = 'https://some-domain/unit-test';
 const directMessageScreen = (
   <QueryClientProvider client={queryClient}>
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <DirectMessagesScreen
-        navigation={navigateMock as any}
-        route={
-          {
-            params: {
-              users: [mockMeProfile, mockYouProfile],
-              conversationId: 'someId',
-            },
-          } as any
-        }
-      />
-    </GraphQLClientContextProvider>
+    <ActiveAccountProvider account="mockaccount">
+      <GraphQLClientContextProvider baseURL={baseURL}>
+        <DirectMessagesScreen
+          navigation={navigateMock as any}
+          route={
+            {
+              params: {
+                users: [mockMeProfile, mockYouProfile],
+                conversationId: 'someId',
+              },
+            } as any
+          }
+        />
+      </GraphQLClientContextProvider>
+    </ActiveAccountProvider>
   </QueryClientProvider>
 );
 

--- a/src/screens/NotificationsScreen.test.tsx
+++ b/src/screens/NotificationsScreen.test.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react-native';
-import { useActiveAccount, useUser } from '../hooks';
+import { ActiveAccountProvider, useUser } from '../hooks';
 import { NotificationQueryResponse } from '../hooks/useNotifications';
 import { mockGraphQLResponse } from '../common/testHelpers/mockGraphQLResponse';
 import { NotificationsScreen } from './NotificationsScreen';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
 
-jest.mock('../hooks/useActiveAccount', () => ({
-  useActiveAccount: jest.fn(),
-}));
 jest.mock('../hooks/useUser', () => ({
   useUser: jest.fn(),
 }));
@@ -30,13 +27,14 @@ const queryClient = new QueryClient({
 const baseURL = 'https://some-domain/unit-test';
 const notificationsScreen = (
   <QueryClientProvider client={queryClient}>
-    <GraphQLClientContextProvider baseURL={baseURL}>
-      <NotificationsScreen />
-    </GraphQLClientContextProvider>
+    <ActiveAccountProvider account="mockaccount">
+      <GraphQLClientContextProvider baseURL={baseURL}>
+        <NotificationsScreen />
+      </GraphQLClientContextProvider>
+    </ActiveAccountProvider>
   </QueryClientProvider>
 );
 
-const useActiveAccountMock = useActiveAccount as jest.Mock;
 const useUserMock = useUser as jest.Mock;
 
 beforeEach(() => {
@@ -46,11 +44,6 @@ beforeEach(() => {
       profile: {},
     },
     isLoading: false,
-  });
-  useActiveAccountMock.mockReturnValue({
-    accountHeaders: {
-      'LifeOmic-Account': 'unittest',
-    },
   });
 });
 


### PR DESCRIPTION
## Motivation
Of all the API interactions within the SDK, there are only a small handful that should not receive an account header:
- `PATCH /v1/invitations/:id`
- `GET /v1/accounts`
- `GET /v1/user`
- `PATCH /v1/user`

Every other API interaction (there are dozens) should receive the header.

As of now, our abstraction around specifying the account header is balanced in the _opposite_ direction -- every call site must specify the header, even though only a small minority of requests should exclude it.

This PR **builds in** the LifeOmic-Account header to the HTTP + GraphQL clients, so that it does not need to be specified at every API interaction that needs it.

The APIs listed above that do _not_ need the header "opt-out" by specifying `LifeOmic-Account: ''`, which causes the client to remove the header.

This change optimizes the common case (needing the header). As a result, >100 lines of code were able to be removed from the SDK. And, consumers of the SDK should see similar simplifications.

## Changes
I intentionally split this PR into individual commits for maximum reviewability. **I highly recommend reviewing by commit:**
- Updating `useHttpClient` and `useGraphQLClient` to include the account header on all requests by default, with an opt-out mechanism.

- Opt-out the API calls that should not include the header.

- Update consumers of the hooks to not specify the headers unnecessarily.

- Add docs for upgrading.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->