### PR TITLE
feat: support custom consent screen

### DIFF
--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -20,6 +20,7 @@ import { Route } from '../navigators/types';
 import { LogoHeaderOptions } from '../hooks/useLogoHeaderOptions';
 import { EducationContent } from '../components/TrackTile/services/TrackTileService';
 import { Project } from '../hooks/useSubjectProjects';
+import type { CustomConsentScreenProps } from '../screens/ConsentScreen';
 
 /**
  * DeveloperConfig provides a single interface to configure the app at build-time.
@@ -122,6 +123,7 @@ export type DeveloperConfig = {
   }>;
   CustomStacks?: Record<string, () => JSX.Element>;
   renderCustomLoginScreen?: () => JSX.Element;
+  CustomConsentScreen?: (props: CustomConsentScreenProps) => JSX.Element;
   sharingRenderers?: {
     pointBreakdown: (props: PointBreakdownProps) => React.JSX.Element;
   };

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -79,6 +79,6 @@ type ConsentPatch = {
   accept: boolean;
 };
 
-type ConsentAndForm = Consent & {
+export type ConsentAndForm = Consent & {
   form: Questionnaire;
 };

--- a/src/screens/ConsentScreen.test.tsx
+++ b/src/screens/ConsentScreen.test.tsx
@@ -117,7 +117,7 @@ test('renders custom consent screen if present in developer config', async () =>
   expect(CustomConsentScreen).toHaveBeenCalled();
   expect(CustomConsentScreen).toHaveBeenCalledWith(
     {
-      consentForm: [defaultConsentDirective],
+      consentForm: defaultConsentDirective,
       acceptConsent: expect.any(Function),
       declineConsent: expect.any(Function),
       isLoadingUpdateConsent: false,
@@ -126,9 +126,8 @@ test('renders custom consent screen if present in developer config', async () =>
   );
 
   // check passed methods are correct
-  const { acceptConsent, declineConsent } = CustomConsentScreen.mock.calls
-    .at(0)
-    .at(0);
+  const { acceptConsent, declineConsent } =
+    CustomConsentScreen.mock.calls[0][0];
 
   acceptConsent();
   await waitFor(() => expect(navigateMock.replace).toHaveBeenCalledWith('app'));
@@ -145,12 +144,7 @@ test('renders custom consent screen if present in developer config', async () =>
 
   declineConsent();
   expect(alertSpy).toHaveBeenCalled();
-  const { onPress } = alertSpy?.mock?.calls
-    ?.at(0)
-    ?.at(2)
-    // @ts-ignore, doesn't know that it exists
-    ?.at(1);
-  onPress();
+  alertSpy.mock.calls[0]?.[2]?.[1].onPress!();
   await waitFor(() => expect(logoutMock).toHaveBeenCalledTimes(1));
   expect(updateConsentDirectiveMutationMock.mutateAsync).toHaveBeenCalledTimes(
     1,
@@ -174,7 +168,7 @@ test('renders custom consent screen if present in developer config', async () =>
   });
   expect(CustomConsentScreen).toHaveBeenCalledWith(
     {
-      consentForm: [defaultConsentDirective],
+      consentForm: defaultConsentDirective,
       acceptConsent: expect.any(Function),
       declineConsent: expect.any(Function),
       isLoadingUpdateConsent: true,

--- a/src/screens/ConsentScreen.tsx
+++ b/src/screens/ConsentScreen.tsx
@@ -3,7 +3,6 @@ import { View, ScrollView, Text, Alert } from 'react-native';
 import { t } from 'i18next';
 import Markdown from 'react-native-markdown-display';
 import { Button } from 'react-native-paper';
-import { Consent, Questionnaire } from 'fhir/r3';
 import { ActivityIndicatorView, createStyles } from '../components';
 import {
   useStyles,
@@ -11,6 +10,7 @@ import {
   useOAuthFlow,
   useOnboardingCourse,
 } from '../hooks';
+import type { ConsentAndForm } from '../hooks/useConsent';
 import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
 import { LoggedInRootScreenProps } from '../navigators/types';
 
@@ -103,7 +103,7 @@ export const ConsentScreen = ({
   if (CustomConsentScreen) {
     return (
       <CustomConsentScreen
-        consentForm={consentDirectives}
+        consentForm={consentToPresent}
         acceptConsent={acceptConsent}
         declineConsent={declineConsent}
         isLoadingUpdateConsent={updateConsentDirectiveMutation.isLoading}
@@ -177,11 +177,7 @@ export type CustomConsentScreenProps = {
    * The full Consent and Questionnaire FHIR Resources pertaining to the
    * consent form. Terms and acceptance text can be derived from here
    */
-  consentForm:
-    | (Consent & {
-        form: Questionnaire;
-      })[]
-    | undefined;
+  consentForm: ConsentAndForm | undefined;
   /** Mutation to accept consent is in flight */
   isLoadingUpdateConsent: boolean;
   /** Mutation to accept consent */

--- a/src/screens/ConsentScreen.tsx
+++ b/src/screens/ConsentScreen.tsx
@@ -3,6 +3,7 @@ import { View, ScrollView, Text, Alert } from 'react-native';
 import { t } from 'i18next';
 import Markdown from 'react-native-markdown-display';
 import { Button } from 'react-native-paper';
+import { Consent, Questionnaire } from 'fhir/r3';
 import { ActivityIndicatorView, createStyles } from '../components';
 import {
   useStyles,
@@ -10,12 +11,14 @@ import {
   useOAuthFlow,
   useOnboardingCourse,
 } from '../hooks';
+import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
 import { LoggedInRootScreenProps } from '../navigators/types';
 
 export const ConsentScreen = ({
   navigation,
 }: LoggedInRootScreenProps<'screens/ConsentScreen'>) => {
   const { styles } = useStyles(defaultStyles);
+  const { CustomConsentScreen } = useDeveloperConfig();
   const { useShouldRenderConsentScreen, useUpdateProjectConsentDirective } =
     useConsent();
   const { consentDirectives, isLoading: loadingDirectives } =
@@ -97,6 +100,17 @@ export const ConsentScreen = ({
     );
   }
 
+  if (CustomConsentScreen) {
+    return (
+      <CustomConsentScreen
+        consentForm={consentDirectives}
+        acceptConsent={acceptConsent}
+        declineConsent={declineConsent}
+        isLoadingUpdateConsent={updateConsentDirectiveMutation.isLoading}
+      />
+    );
+  }
+
   return (
     <View style={styles.view}>
       <ScrollView style={styles.scrollView}>
@@ -157,3 +171,24 @@ declare module '@styles' {
 }
 
 export type ConsentScreenStyles = NamedStylesProp<typeof defaultStyles>;
+
+export type CustomConsentScreenProps = {
+  /**
+   * The full Consent and Questionnaire FHIR Resources pertaining to the
+   * consent form. Terms and acceptance text can be derived from here
+   */
+  consentForm:
+    | (Consent & {
+        form: Questionnaire;
+      })[]
+    | undefined;
+  /** Mutation to accept consent is in flight */
+  isLoadingUpdateConsent: boolean;
+  /** Mutation to accept consent */
+  acceptConsent: () => Promise<void>;
+  /**
+   * Warns user with system alert that app can not be used without
+   * accepting consent and continuing will log them out
+   */
+  declineConsent: () => void;
+};


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Support passing a custom Consent screen, similar to custom login and home screens 
    - The custom component will be provided props to be able to render and act on the consent

## Screenshots
<!-- include screen recordings, if relevant to your changes -->



![image](https://github.com/lifeomic/react-native-sdk/assets/19804196/d62a808d-056f-4a46-8416-baa852ebeb91)
