### PR TITLE
FLME-340: invalidate activities list when consent is accepted

### DIFF
--- a/src/hooks/useActivities.tsx
+++ b/src/hooks/useActivities.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { gql } from 'graphql-request';
 import { useGraphQLClient } from './useGraphQLClient';
 import { useQuery } from '@tanstack/react-query';
@@ -364,15 +363,14 @@ type ActivitiesQueryResponse = {
   };
 };
 
+export const ACTIVITIES_QUERY_KEY = ['activities'];
+
 export const useActivities = (input: ActivitiesInput) => {
   const { graphQLClient } = useGraphQLClient();
 
-  const queryForActivities = useCallback(async () => {
-    return graphQLClient.request<ActivitiesQueryResponse>(
-      getActivitiesQueryDocument,
-      { input },
-    );
-  }, [graphQLClient, input]);
-
-  return useQuery(['activities'], queryForActivities);
+  return useQuery(ACTIVITIES_QUERY_KEY, () =>
+    graphQLClient.request<ActivitiesQueryResponse>(getActivitiesQueryDocument, {
+      input,
+    }),
+  );
 };

--- a/src/hooks/useConsent.test.tsx
+++ b/src/hooks/useConsent.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react-native';
-import { useConsent } from './useConsent';
+import { createConsentPatch, useConsent } from './useConsent';
 import { useHttpClient } from './useHttpClient';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
@@ -25,7 +25,7 @@ jest.mock('./useHttpClient', () => ({
 const useActiveProjectMock = useActiveProject as jest.Mock;
 const useHttpClientMock = useHttpClient as jest.Mock;
 
-const renderHookInContext = (useHook: Function) => {
+const renderHookInContext = <T extends any>(useHook: () => T) => {
   return renderHook(() => useHook(), {
     wrapper: ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -87,10 +87,9 @@ describe('useUpdateProjectConsentDirective', () => {
 
     const { result } = renderHookInContext(useTestHook);
     await act(async () => {
-      await result.current.mutateAsync({
-        directiveId: 'directive-id',
-        accept: true,
-      });
+      await result.current.mutateAsync(
+        createConsentPatch('directive-id', true),
+      );
     });
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -127,10 +126,9 @@ describe('useUpdateProjectConsentDirective', () => {
 
     const { result } = renderHookInContext(useTestHook);
     await act(async () => {
-      await result.current.mutateAsync({
-        directiveId: 'directive-id',
-        accept: false,
-      });
+      await result.current.mutateAsync(
+        createConsentPatch('directive-id', false),
+      );
     });
 
     expect(axiosMock.history.patch[0].url).toBe(

--- a/src/screens/ConsentScreen.test.tsx
+++ b/src/screens/ConsentScreen.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import { Alert } from 'react-native';
-import { useOAuthFlow, useConsent, useOnboardingCourse } from '../hooks';
+import {
+  useOAuthFlow,
+  useConsent,
+  useOnboardingCourse,
+  createConsentPatch,
+} from '../hooks';
 import { ConsentScreen } from './ConsentScreen';
 import { useDeveloperConfig } from '../hooks';
 
@@ -11,6 +16,7 @@ jest.mock('../hooks/useOAuthFlow', () => ({
   useOAuthFlow: jest.fn(),
 }));
 jest.mock('../hooks/useConsent', () => ({
+  ...jest.requireActual('../hooks/useConsent'),
   useConsent: jest.fn(),
 }));
 jest.mock('../hooks/useOnboardingCourse', () => ({
@@ -135,10 +141,9 @@ test('renders custom consent screen if present in developer config', () => {
   });
   expect(navigateMock.replace).toHaveBeenCalledWith('app');
   expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledTimes(1);
-  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith({
-    directiveId: defaultConsentDirective.id,
-    accept: true,
-  });
+  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith(
+    createConsentPatch(defaultConsentDirective.id, true),
+  );
 
   // reset for later assertions
   updateConsentDirectiveMutationMock.mutate.mockClear();
@@ -151,10 +156,9 @@ test('renders custom consent screen if present in developer config', () => {
   });
   () => expect(logoutMock).toHaveBeenCalledTimes(1);
   expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledTimes(1);
-  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith({
-    directiveId: defaultConsentDirective.id,
-    accept: false,
-  });
+  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith(
+    createConsentPatch(defaultConsentDirective.id, false),
+  );
 
   // check passed loading state
   useUpdateProjectConsentDirectiveMock.mockReturnValue({
@@ -187,10 +191,9 @@ test('renders the consent body and acceptance verbiage', () => {
 test('should accept the consent and navigate to the home screen', () => {
   const { getByText } = render(consentScreen);
   fireEvent.press(getByText('Agree'));
-  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith({
-    directiveId: defaultConsentDirective.id,
-    accept: true,
-  });
+  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith(
+    createConsentPatch(defaultConsentDirective.id, true),
+  );
   useUpdateProjectConsentDirectiveMock.mock.calls[0][0].onSuccess(undefined, {
     status: 'active',
   });
@@ -203,10 +206,9 @@ test('should accept the consent and navigate to the onboarding course screen', (
   });
   const { getByText } = render(consentScreen);
   fireEvent.press(getByText('Agree'));
-  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith({
-    directiveId: defaultConsentDirective.id,
-    accept: true,
-  });
+  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith(
+    createConsentPatch(defaultConsentDirective.id, true),
+  );
   useUpdateProjectConsentDirectiveMock.mock.calls[0][0].onSuccess(undefined, {
     status: 'active',
   });
@@ -225,10 +227,9 @@ test('Pressing logout declines the consent and logs the the user out', async () 
   const { getByText } = render(consentScreen);
   fireEvent.press(getByText('Decline'));
   alertSpy.mock.calls[0]?.[2]?.[1].onPress!();
-  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith({
-    directiveId: defaultConsentDirective.id,
-    accept: false,
-  });
+  expect(updateConsentDirectiveMutationMock.mutate).toHaveBeenCalledWith(
+    createConsentPatch(defaultConsentDirective.id, false),
+  );
   useUpdateProjectConsentDirectiveMock.mock.calls[0][0].onSuccess(undefined, {
     status: 'rejected',
   });

--- a/src/screens/ConsentScreen.tsx
+++ b/src/screens/ConsentScreen.tsx
@@ -9,6 +9,7 @@ import {
   useConsent,
   useOAuthFlow,
   useOnboardingCourse,
+  createConsentPatch,
 } from '../hooks';
 import type { ConsentAndForm } from '../hooks/useConsent';
 import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
@@ -49,10 +50,9 @@ export const ConsentScreen = ({
       if (!consentToPresent?.id) {
         return;
       }
-      updateConsentDirectiveMutation.mutate({
-        directiveId: consentToPresent.id,
-        accept,
-      });
+      updateConsentDirectiveMutation.mutate(
+        createConsentPatch(consentToPresent.id, accept),
+      );
     },
     [updateConsentDirectiveMutation, consentToPresent],
   );


### PR DESCRIPTION
## Changes
If a user has been enrolled into a program before their first login, we need to refresh their activity list whenever they accept a consent. Accepting consent can result in new activities showing up.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->