### PR TITLE
fix: consent screen use mutate over async mutate

### DIFF
--- a/src/hooks/useConsent.test.tsx
+++ b/src/hooks/useConsent.test.tsx
@@ -78,9 +78,11 @@ describe('useUpdateProjectConsentDirective', () => {
   test('updates the accepted consent', async () => {
     axiosMock.onPatch('/v1/consent/directives/me/directive-id').reply(200, {});
 
+    const onSuccess = jest.fn();
+
     const useTestHook = () => {
       const { useUpdateProjectConsentDirective } = useConsent();
-      return useUpdateProjectConsentDirective();
+      return useUpdateProjectConsentDirective({ onSuccess });
     };
 
     const { result } = renderHookInContext(useTestHook);
@@ -91,6 +93,7 @@ describe('useUpdateProjectConsentDirective', () => {
       });
     });
 
+    expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(axiosMock.history.patch[0].url).toBe(
       `/v1/consent/directives/me/directive-id`,
     );

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -2,7 +2,6 @@ import { useActiveProject } from './useActiveProject';
 import { Consent, Questionnaire } from 'fhir/r3';
 import { useRestQuery, useRestMutation } from './rest-api';
 import { RestAPIEndpoints } from '../types/rest-types';
-import { UseMutationOptions } from '@tanstack/react-query';
 
 type PatchConsentDirectives =
   RestAPIEndpoints['PATCH /v1/consent/directives/me/:directiveId'];
@@ -17,15 +16,14 @@ export const useConsent = () => {
     });
   };
 
-  const useUpdateProjectConsentDirective = (
-    options: UseMutationOptions<
-      PatchConsentDirectives['Response'],
-      unknown,
-      PatchConsentDirectives['Request'] & {
+  const useUpdateProjectConsentDirective = (options?: {
+    onSuccess?: (
+      data: PatchConsentDirectives['Response'],
+      variables: PatchConsentDirectives['Request'] & {
         directiveId: string;
-      }
-    > = {},
-  ) => {
+      },
+    ) => Promise<void> | void;
+  }) => {
     const mutation = useRestMutation(
       'PATCH /v1/consent/directives/me/:directiveId',
       options,

--- a/src/hooks/useConsent.ts
+++ b/src/hooks/useConsent.ts
@@ -2,6 +2,10 @@ import { useActiveProject } from './useActiveProject';
 import { Consent, Questionnaire } from 'fhir/r3';
 import { useRestQuery, useRestMutation } from './rest-api';
 import { RestAPIEndpoints } from '../types/rest-types';
+import { UseMutationOptions } from '@tanstack/react-query';
+
+type PatchConsentDirectives =
+  RestAPIEndpoints['PATCH /v1/consent/directives/me/:directiveId'];
 
 export const useConsent = () => {
   const { activeProject } = useActiveProject();
@@ -13,9 +17,18 @@ export const useConsent = () => {
     });
   };
 
-  const useUpdateProjectConsentDirective = () => {
+  const useUpdateProjectConsentDirective = (
+    options: UseMutationOptions<
+      PatchConsentDirectives['Response'],
+      unknown,
+      PatchConsentDirectives['Request'] & {
+        directiveId: string;
+      }
+    > = {},
+  ) => {
     const mutation = useRestMutation(
       'PATCH /v1/consent/directives/me/:directiveId',
+      options,
     );
 
     const getInput = ({ directiveId, accept }: ConsentPatch) => {
@@ -38,7 +51,7 @@ export const useConsent = () => {
             },
           ],
         },
-      } as RestAPIEndpoints['PATCH /v1/consent/directives/me/:directiveId']['Request'] & {
+      } as PatchConsentDirectives['Request'] & {
         directiveId: string;
       };
     };


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Following up on an early suggestion to switch this to use `mutate` over `mutateAsync`, makes using it a bit simpler especially in the custom screen flow

## Screenshots
<!-- include screen recordings, if relevant to your changes -->