### PR TITLE
fix(FHIR API): path param :id to :resourceId

### DIFF
--- a/src/types/fhir-api-types.ts
+++ b/src/types/fhir-api-types.ts
@@ -54,14 +54,18 @@ export type FhirAPIEndpoints = {
     Response: WithIdDefined<FhirResourcesByName[Name]>;
   };
 } & {
+  // We specifically use :resourceId instead of :id here because the FHIR API
+  // does a check between the path param property value and the data body
+  // property value, and throws if they do not match. Since 'one-query' removes
+  // any path params properties from the data body, having :id causes a failure.
   // PUT /<resource>/:resourceId
   [Name in keyof FhirResourcesByName as `PUT /v1/fhir/dstu3/${Name}/:resourceId`]: {
     Request: WithIdDefined<FhirResourcesByName[Name]>;
     Response: WithIdDefined<FhirResourcesByName[Name]>;
   };
 } & {
-  // GET /<resource>/:resourceId
-  [Name in keyof FhirResourcesByName as `GET /v1/fhir/dstu3/${Name}/:resourceId`]: {
+  // GET /<resource>/:id
+  [Name in keyof FhirResourcesByName as `GET /v1/fhir/dstu3/${Name}/:id`]: {
     Request: {};
     Response: WithIdDefined<FhirResourcesByName[Name]>;
   };

--- a/src/types/fhir-api-types.ts
+++ b/src/types/fhir-api-types.ts
@@ -54,14 +54,14 @@ export type FhirAPIEndpoints = {
     Response: WithIdDefined<FhirResourcesByName[Name]>;
   };
 } & {
-  // PUT /<resource>/:id
-  [Name in keyof FhirResourcesByName as `PUT /v1/fhir/dstu3/${Name}/:id`]: {
+  // PUT /<resource>/:resourceId
+  [Name in keyof FhirResourcesByName as `PUT /v1/fhir/dstu3/${Name}/:resourceId`]: {
     Request: WithIdDefined<FhirResourcesByName[Name]>;
     Response: WithIdDefined<FhirResourcesByName[Name]>;
   };
 } & {
-  // GET /<resource>/:id
-  [Name in keyof FhirResourcesByName as `GET /v1/fhir/dstu3/${Name}/:id`]: {
+  // GET /<resource>/:resourceId
+  [Name in keyof FhirResourcesByName as `GET /v1/fhir/dstu3/${Name}/:resourceId`]: {
     Request: {};
     Response: WithIdDefined<FhirResourcesByName[Name]>;
   };


### PR DESCRIPTION
## Changes

I hit an issue with `one-query` + the FHIR API. The patient service API does validation between the ID in the path param and the ID in the data payload. If they do not match, it throws an error. I checked out the `one-query` code, and we do remove any path param properties from the data payload. 

To avoid having to ship API changes right now, I'm just fixing this issue client side by changing `:id` to `:resourceId` in the `one-query` routes, that way, they payload won't replace `id`. We'll just have to specify both `resourceId` and `id` in the payload when calling `one-query`.

## Screenshots

N/A