### PR TITLE
fix: remove unused invite events

### DIFF
--- a/src/components/Invitations/InviteNotifier.test.ts
+++ b/src/components/Invitations/InviteNotifier.test.ts
@@ -1,23 +1,18 @@
-import { EventTypes, inviteNotifier } from './InviteNotifier';
+import { inviteNotifier } from './InviteNotifier';
 
 it('allows simplified EventEmitter functionality', async () => {
   const inviteParams = {
     inviteId: 'invite-id',
     evc: 'evc',
   };
-  for (const eventType of [
-    'inviteAccepted',
-    'inviteDetected',
-  ] as EventTypes[]) {
-    const listener = jest.fn();
-    inviteNotifier.addListener(eventType, listener);
-    inviteNotifier.emit(eventType, inviteParams);
-    inviteNotifier.removeListener(eventType, listener);
-    inviteNotifier.emit(eventType, inviteParams);
+  const listener = jest.fn();
+  inviteNotifier.addListener('inviteDetected', listener);
+  inviteNotifier.emit('inviteDetected', inviteParams);
+  inviteNotifier.removeListener('inviteDetected', listener);
+  inviteNotifier.emit('inviteDetected', inviteParams);
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith(inviteParams);
-  }
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith(inviteParams);
 });
 
 it('caches last emitted invite detected so new listeners can consume invite params', async () => {

--- a/src/components/Invitations/InviteNotifier.ts
+++ b/src/components/Invitations/InviteNotifier.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import { ProjectInvite } from '../../types';
 
 export type InviteParams = {
   inviteId?: string;
@@ -8,8 +7,6 @@ export type InviteParams = {
 
 export type EventTypeHandlers = {
   inviteDetected: (inviteParams: InviteParams) => void;
-  inviteAccepted: (invite: ProjectInvite) => void;
-  inviteAccountSettled: () => void;
 };
 
 export type EventTypes = keyof EventTypeHandlers;
@@ -41,9 +38,7 @@ export class InviteNotifier {
     eventType: T,
     ...params: Parameters<EventTypeHandler<T>>
   ) {
-    if (eventType === 'inviteDetected') {
-      this.lastInviteDetectedParams = params[0] as InviteParams;
-    }
+    this.lastInviteDetectedParams = params[0] as InviteParams;
     return this.emitter.emit(eventType, ...params);
   }
 

--- a/src/components/Invitations/InviteProvider.test.tsx
+++ b/src/components/Invitations/InviteProvider.test.tsx
@@ -104,9 +104,7 @@ describe('accepting invite', () => {
     ).toBeUndefined();
   });
 
-  it('refreshes auth token, emits inviteAccepted, then waits for inviteAccountSettled to resets cache and mutation', async () => {
-    const acceptListener = jest.fn();
-    inviteNotifier.addListener('inviteAccepted', acceptListener);
+  it('refreshes auth token', async () => {
     const { result, rerender } = await renderHookInContext();
     await act(async () => {
       inviteNotifier.emit('inviteDetected', mockInviteParams);
@@ -128,14 +126,6 @@ describe('accepting invite', () => {
     ).toBeUndefined();
     expect(result.current.inviteParams).toEqual({});
     expect(refreshForInviteAccept).toHaveBeenCalled();
-    expect(acceptListener).toHaveBeenCalled();
-
-    await act(async () => {
-      inviteNotifier.emit('inviteAccountSettled');
-      await rerender({});
-    });
-
-    inviteNotifier.removeListener('inviteAccepted', acceptListener);
   });
 
   it('catches unknown errors and still clears cache', async () => {

--- a/src/components/Invitations/InviteProvider.tsx
+++ b/src/components/Invitations/InviteProvider.tsx
@@ -79,7 +79,6 @@ export const InviteProvider = ({ children }: ProviderProps) => {
         await refreshForInviteAccept();
         clearPendingInvite();
         reset();
-        inviteNotifier.emit('inviteAccepted', acceptedInvite);
       } catch (error) {
         if (
           (error as any)?.response?.data?.code === 'INVITATION_ALREADY_ACCEPTED'
@@ -130,18 +129,6 @@ export const InviteProvider = ({ children }: ProviderProps) => {
       inviteNotifier.removeListener('inviteDetected', listener);
     };
   }, []);
-
-  // Listen to inviteAccountSettled event to clear state
-  useEffect(() => {
-    const listener = async () => {
-      clearPendingInvite();
-      reset();
-    };
-    inviteNotifier.addListener('inviteAccountSettled', listener);
-    return () => {
-      inviteNotifier.removeListener('inviteAccountSettled', listener);
-    };
-  }, [clearPendingInvite, reset]);
 
   return (
     <InviteContext.Provider


### PR DESCRIPTION
## Changes
I'm working the existing issue that flashes the InviteRequired screen. To make subsequent changes cleaner, removing these currently defunct invitation events.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->