### PR TITLE
Fix Android Colors on Dark Mode

### DIFF
--- a/src/components/Messaging/ComposeInputBar.tsx
+++ b/src/components/Messaging/ComposeInputBar.tsx
@@ -130,13 +130,14 @@ const defaultStyles = createStyles('ComposeInputBar', (theme) => ({
   inputText: {
     textAlignVertical: 'top',
     flex: 1,
+    color: theme.colors.scrim,
   },
   sendIconColor: {
     enabled: theme.colors.primary,
     disabled: theme.colors.primaryContainer,
   },
   placeholderText: {
-    color: theme.colors.surfaceDisabled,
+    color: theme.colors.text,
   },
   sendButton: {
     position: 'absolute',

--- a/src/screens/ComposeMessageScreen.tsx
+++ b/src/screens/ComposeMessageScreen.tsx
@@ -302,11 +302,13 @@ const defaultStyles = createStyles('ComposeMessageScreen', (theme) => ({
   },
   toProvidersLabel: {
     fontWeight: '700',
+    color: theme.colors.onBackground,
   },
   writeMessageLabel: {
     fontWeight: '700',
     marginLeft: theme.spacing.medium,
     marginBottom: theme.spacing.medium,
+    color: theme.colors.onBackground,
   },
   plusIcon: {
     color: theme.colors.secondary,


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Explicitly set the text colors so they appear correctly on android with dark mode

## Screenshots

<table>
<tr>
 <td><b>iOS Light
 <td><b>iOS Dark
 <td><b>Android Light
 <td><b>Android Dark
<tr>
 <td><img width="428" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/7659210d-2c33-42df-9c1e-f83fa687a1e0">
 <td><img width="422" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/8376b7ac-a2bc-454c-9c72-daff744630e0">
 <td><img width="302" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/0f0808eb-d3d7-49e8-b448-91d24cf1942b">
 <td><img width="300" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/4b9792b7-595d-455d-a625-6934ccfdf51b">
<tr>
 <td><img width="422" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/b8624699-5c25-4fa6-87ce-ad6a105a0594">
 <td><img width="425" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/ea15be48-ed28-461e-a2fc-cc02d9990b0b">
 <td><img width="302" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/9674bec0-14d9-4bef-9a7e-6585778dca78">
 <td><img width="300" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/e8e01169-0444-4926-96df-e1bd51fd5419">
<tr>
 <td><img width="426" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/5cd4fb85-b5dc-4f7b-9fa1-c98afd55cf00">
 <td><img width="423" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/163bde60-dd49-472d-89a8-9bc09769a8f9">
 <td><img width="302" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/ec252e13-bca3-4b30-9ed1-bee6c4d5d873">
 <td><img width="305" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/d55b5603-71a2-49bc-9ff1-1a951e525d57">
</table>

## Notes
It's surprising that this is one of the first dark mode issues we have had. However, I think we will have more down the road and it might be a good idea to start thinking about a dark mode solution, even if that is figuring out how to prevent react native paper from reacting at all.
