### PR TITLE
feat: FLME-323 add patient to Observation SearchParams

### DIFF
--- a/src/types/fhir-api-types.ts
+++ b/src/types/fhir-api-types.ts
@@ -51,6 +51,9 @@ type AdditionalSearchParamsByName = {
     patient?: string;
     status?: Appointment['status'];
   };
+  Observation: {
+    patient?: string;
+  };
 };
 
 type SearchParamsForResourceType<Name extends keyof FhirResourcesByName> =


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Add `patient` search param Observations in fhir-api-types so users can get their own Observations