### PR TITLE
feat: add operations for fhir procedure request resource

### DIFF
--- a/src/types/fhir-api-types.ts
+++ b/src/types/fhir-api-types.ts
@@ -7,6 +7,7 @@ import {
   Practitioner,
   Questionnaire,
   QuestionnaireResponse,
+  ProcedureRequest,
 } from 'fhir/r3';
 
 // These "better" types strongly type the bundle
@@ -31,6 +32,7 @@ type FhirResourcesByName = {
   QuestionnaireResponse: QuestionnaireResponse;
   Appointment: Appointment;
   Practitioner: Practitioner;
+  ProcedureRequest: ProcedureRequest;
 };
 
 /**
@@ -52,6 +54,9 @@ type AdditionalSearchParamsByName = {
     status?: Appointment['status'];
   };
   Observation: {
+    patient?: string;
+  };
+  ProcedureRequest: {
     patient?: string;
   };
 };


### PR DESCRIPTION
## Changes

Unfortunately, this resource type does _not_ currently support a status filter or date sorting. Tested this by hitting the api directly with different options

as fyi sorting by date for observations works something like this

```
    const { data } = await this.client.get(
      `/${encodeURIComponent(account)}/dstu3/Observation`,
      {
        params: {
          patient: 'ef876b82-92d8-433b-b0e6-86365116401d',
          date: ['gt2022-12-12T19:55:24.079Z', 'lt2023-29-12T19:55:24.079Z'],
          _sort: '-date' | 'date',
        },
      },
    );
```



## Screenshots
<!-- include screen recordings, if relevant to your changes -->