### PR TITLE
feat: add DocumentReference FHIR resource typing

### DIFF
--- a/src/types/fhir-api-types.ts
+++ b/src/types/fhir-api-types.ts
@@ -8,6 +8,7 @@ import {
   Questionnaire,
   QuestionnaireResponse,
   ProcedureRequest,
+  DocumentReference,
 } from 'fhir/r3';
 
 // These "better" types strongly type the bundle
@@ -26,13 +27,14 @@ type BetterBundle<T> = Omit<Bundle<T>, 'entry'> & {
  * Add entries to this type to support them in the hooks.
  */
 type FhirResourcesByName = {
-  Patient: Patient;
-  Observation: Observation;
-  Questionnaire: Questionnaire;
-  QuestionnaireResponse: QuestionnaireResponse;
   Appointment: Appointment;
+  DocumentReference: DocumentReference;
+  Observation: Observation;
+  Patient: Patient;
   Practitioner: Practitioner;
   ProcedureRequest: ProcedureRequest;
+  Questionnaire: Questionnaire;
+  QuestionnaireResponse: QuestionnaireResponse;
 };
 
 /**


### PR DESCRIPTION
## Changes
Adding support for `DocumentReference`

## Screenshots
<!-- include screen recordings, if relevant to your changes -->