### PR TITLE
fix: export getActivitiesQueryDocument

### DIFF
--- a/src/hooks/useActivities.tsx
+++ b/src/hooks/useActivities.tsx
@@ -2,7 +2,7 @@ import { gql } from 'graphql-request';
 import { useGraphQLClient } from './useGraphQLClient';
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 
-const getActivitiesQueryDocument = gql`
+export const getActivitiesQueryDocument = gql`
   query GetAllActivities($input: GetAllActivitiesInput!) {
     getAllActivities(input: $input) {
       edges {


### PR DESCRIPTION
## Changes
- Just exporting `getActivitiesQueryDocument` for individual use when necessary. We're needing this in our client.

## Screenshots
N/A