### PR TITLE
feat: Allow for users to accept consent from openConsent app tile message

### DIFF
--- a/src/hooks/useHandleAppTileEvents.ts
+++ b/src/hooks/useHandleAppTileEvents.ts
@@ -15,7 +15,7 @@ import {
   TRACKER_PILLAR_CODE,
   TRACKER_PILLAR_CODE_SYSTEM,
 } from '../components/TrackTile/services/TrackTileService';
-import { HomeStackParamList } from '../navigators/types';
+import { HomeStackParamList, LoggedInRootParamList } from '../navigators/types';
 import { CircleTile, useAppConfig } from './useAppConfig';
 import { openURL } from '../common/urls';
 
@@ -57,7 +57,14 @@ export type OpenUrlAppletMessage = {
   data: OpenUrlDataType;
 };
 
-export type AppTileMessage = DeepLinkAppletMessage | OpenUrlAppletMessage;
+export type OpenConsentAppletMessage = {
+  type: AppTileMessageType.openConsent;
+};
+
+export type AppTileMessage =
+  | DeepLinkAppletMessage
+  | OpenUrlAppletMessage
+  | OpenConsentAppletMessage;
 
 type BeforeRemoveListener = EventListenerCallback<
   EventMapCore<any>,
@@ -68,7 +75,10 @@ export const useHandleAppTileEvents = (webView: WebView | null = null) => {
   const { data } = useAppConfig();
   const { pillarTrackers } = useTrackers();
   const { todayTileSettings, tiles } = data?.homeTab || {};
-  const navigation = useNavigation<StackNavigationProp<HomeStackParamList>>();
+  const navigation =
+    useNavigation<
+      StackNavigationProp<HomeStackParamList & LoggedInRootParamList>
+    >();
   const [blockGoBack, setBlockGoBack] = useState(false);
 
   useEffect(() => {
@@ -163,6 +173,12 @@ export const useHandleAppTileEvents = (webView: WebView | null = null) => {
     await openURL(url);
   };
 
+  const handleOpenConsentMessage = async () => {
+    navigation.push('screens/ConsentScreen', {
+      noNavOnAccept: true,
+    });
+  };
+
   const handleAppTileMessage = (event: WebViewMessageEvent) => {
     const eventData = event.nativeEvent.data;
     if (!eventData) {
@@ -177,6 +193,9 @@ export const useHandleAppTileEvents = (webView: WebView | null = null) => {
           break;
         case AppTileMessageType.openUrl:
           handleOpenUrlMessage(appTileMessage);
+          break;
+        case AppTileMessageType.openConsent:
+          handleOpenConsentMessage();
           break;
 
         // no default

--- a/src/navigators/types.tsx
+++ b/src/navigators/types.tsx
@@ -18,7 +18,7 @@ import { ComposeMessageParams } from '../screens/ComposeMessageScreen';
 
 export type LoggedInRootParamList = {
   app: NavigatorScreenParams<TabParamList> | undefined;
-  'screens/ConsentScreen': undefined;
+  'screens/ConsentScreen': { noNavOnAccept?: boolean };
   'Circle/Thread': { post: Post; createNewComment?: boolean };
   'screens/OnboardingCourseScreen': undefined;
 };

--- a/src/screens/ConsentScreen.tsx
+++ b/src/screens/ConsentScreen.tsx
@@ -17,6 +17,7 @@ import { LoggedInRootScreenProps } from '../navigators/types';
 
 export const ConsentScreen = ({
   navigation,
+  route,
 }: LoggedInRootScreenProps<'screens/ConsentScreen'>) => {
   const { styles } = useStyles(defaultStyles);
   const { CustomConsentScreen } = useDeveloperConfig();
@@ -30,10 +31,14 @@ export const ConsentScreen = ({
         return logout({});
       }
 
-      const route = shouldLaunchOnboardingCourse
+      if (route.params?.noNavOnAccept) {
+        navigation.pop();
+        return;
+      }
+      const nextRoute = shouldLaunchOnboardingCourse
         ? 'screens/OnboardingCourseScreen'
         : 'app';
-      navigation.replace(route);
+      navigation.replace(nextRoute);
     },
   });
   const { logout } = useOAuthFlow();


### PR DESCRIPTION
## Screenshots
https://github.com/lifeomic/react-native-sdk/assets/1445395/a7e3ee2c-c4cb-486c-bd9f-850a968b5c65

## Manual tests performed:
- Consent in program, accept
- Consent in program, decline
- Startup consent, accept (regression test)
- Startup consent, decline (regression test)
