### PR TITLE
Support valueQuantity for Sleep Duration When Coded in Minutes

### DIFF
--- a/src/components/MyData/SleepChart/MultiDayChart.tsx
+++ b/src/components/MyData/SleepChart/MultiDayChart.tsx
@@ -50,6 +50,22 @@ export const MultiDayChart = (props: Props) => {
       groupFn(new Date(d.effectiveDateTime!)),
     );
 
+    const getDurationInMinutes = (obs: fhir3.Observation) => {
+      if (
+        obs.valueQuantity?.code === 'min' &&
+        obs.valueQuantity?.system === 'http://unitsofmeasure.org'
+      ) {
+        return obs.valueQuantity.value ?? 0;
+      } else if (obs.valuePeriod?.end && obs.valuePeriod?.start) {
+        return differenceInMinutes(
+          new Date(obs.valuePeriod.end),
+          new Date(obs.valuePeriod.start),
+        );
+      }
+
+      return 0;
+    };
+
     return {
       isYear: isYearChart,
       ticks: ticksFromRange,
@@ -58,15 +74,7 @@ export const MultiDayChart = (props: Props) => {
         .map(([date, d]) => {
           const duration =
             d.reduce(
-              (total, observation) =>
-                total +
-                (!observation.valuePeriod?.end ||
-                !observation.valuePeriod?.start
-                  ? 0
-                  : differenceInMinutes(
-                      new Date(observation.valuePeriod.end),
-                      new Date(observation.valuePeriod.start),
-                    )),
+              (total, observation) => total + getDurationInMinutes(observation),
               0,
             ) / (isYearChart ? d.length : 1);
 

--- a/src/components/MyData/SleepChart/index.test.tsx
+++ b/src/components/MyData/SleepChart/index.test.tsx
@@ -303,10 +303,25 @@ describe('SleepChart', () => {
             addDays(new Date(0), 1),
             9.5 * 60,
           ).toISOString(),
-          valuePeriod: {
-            start: addDays(new Date(0), 1).toISOString(),
-            end: addMinutes(addDays(new Date(0), 1), 9.5 * 60).toISOString(),
+          valueQuantity: {
+            value: 9.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addDays(new Date(0), 1).toISOString(),
+                end: addMinutes(
+                  addDays(new Date(0), 1),
+                  9.5 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
         },
       ],
       xDomain: scaleTime().domain([dateRange.start, dateRange.end]),
@@ -358,10 +373,22 @@ describe('SleepChart', () => {
           code: {},
           status: 'final',
           effectiveDateTime: addMinutes(new Date(0), 7 * 60).toISOString(),
-          valuePeriod: {
-            start: new Date(0).toISOString(),
-            end: addMinutes(new Date(0), 7 * 60).toISOString(),
+          valueQuantity: {
+            value: 7 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: new Date(0).toISOString(),
+                end: addMinutes(new Date(0), 7 * 60).toISOString(),
+              },
+            },
+          ],
         },
         {
           resourceType: 'Observation',
@@ -371,10 +398,25 @@ describe('SleepChart', () => {
             addDays(new Date(0), 1),
             15.5 * 60,
           ).toISOString(),
-          valuePeriod: {
-            start: addDays(new Date(0), 1).toISOString(),
-            end: addMinutes(addDays(new Date(0), 1), 15.5 * 60).toISOString(),
+          valueQuantity: {
+            value: 15.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addDays(new Date(0), 1).toISOString(),
+                end: addMinutes(
+                  addDays(new Date(0), 1),
+                  15.5 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
         },
       ],
       xDomain,
@@ -432,10 +474,22 @@ describe('SleepChart', () => {
           code: {},
           status: 'final',
           effectiveDateTime: addMinutes(new Date(0), 18 * 60).toISOString(),
-          valuePeriod: {
-            start: new Date(0).toISOString(),
-            end: addMinutes(new Date(0), 18 * 60).toISOString(),
+          valueQuantity: {
+            value: 18 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: new Date(0).toISOString(),
+                end: addMinutes(new Date(0), 18 * 60).toISOString(),
+              },
+            },
+          ],
         },
         {
           resourceType: 'Observation',
@@ -445,10 +499,25 @@ describe('SleepChart', () => {
             addMonths(new Date(0), 1),
             9.5 * 60,
           ).toISOString(),
-          valuePeriod: {
-            start: addMonths(new Date(0), 1).toISOString(),
-            end: addMinutes(addMonths(new Date(0), 1), 9.5 * 60).toISOString(),
+          valueQuantity: {
+            value: 9.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addMonths(new Date(0), 1).toISOString(),
+                end: addMinutes(
+                  addMonths(new Date(0), 1),
+                  9.5 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
         },
       ],
       xDomain: scaleTime().domain([dateRange.start, dateRange.end]),
@@ -502,10 +571,22 @@ describe('SleepChart', () => {
           code: {},
           status: 'final',
           effectiveDateTime: addMinutes(new Date(0), 18 * 60).toISOString(),
-          valuePeriod: {
-            start: new Date(0).toISOString(),
-            end: addMinutes(new Date(0), 18 * 60).toISOString(),
+          valueQuantity: {
+            value: 18 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: new Date(0).toISOString(),
+                end: addMinutes(new Date(0), 18 * 60).toISOString(),
+              },
+            },
+          ],
         },
         {
           resourceType: 'Observation',
@@ -515,10 +596,25 @@ describe('SleepChart', () => {
             addMonths(new Date(0), 4),
             9.5 * 60,
           ).toISOString(),
-          valuePeriod: {
-            start: addMonths(new Date(0), 4).toISOString(),
-            end: addMinutes(addMonths(new Date(0), 4), 9.5 * 60).toISOString(),
+          valueQuantity: {
+            value: 9.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addMonths(new Date(0), 4).toISOString(),
+                end: addMinutes(
+                  addMonths(new Date(0), 4),
+                  9.5 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
         },
         {
           resourceType: 'Observation',
@@ -528,13 +624,25 @@ describe('SleepChart', () => {
             addDays(addMonths(new Date(0), 4), 1),
             8 * 60,
           ).toISOString(),
-          valuePeriod: {
-            start: addDays(addMonths(new Date(0), 4), 1).toISOString(),
-            end: addMinutes(
-              addDays(addMonths(new Date(0), 4), 1),
-              8 * 60,
-            ).toISOString(),
+          valueQuantity: {
+            value: 8 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
           },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addDays(addMonths(new Date(0), 4), 1).toISOString(),
+                end: addMinutes(
+                  addDays(addMonths(new Date(0), 4), 1),
+                  8 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
         },
       ],
       xDomain,

--- a/src/components/MyData/SleepChart/useSleepChartData.test.ts
+++ b/src/components/MyData/SleepChart/useSleepChartData.test.ts
@@ -112,9 +112,8 @@ describe('useSleepChartData', () => {
       status: 'final',
       code: {},
       effectiveDateTime: new Date(10).toISOString(),
-      valuePeriod: {
-        start: new Date(0).toISOString(),
-        end: new Date(10).toISOString(),
+      valueQuantity: {
+        value: 0,
       },
     };
     const observation2: fhir3.Observation = {
@@ -122,9 +121,8 @@ describe('useSleepChartData', () => {
       status: 'final',
       code: {},
       effectiveDateTime: new Date(10).toISOString(),
-      valuePeriod: {
-        start: new Date(0).toISOString(),
-        end: new Date(10).toISOString(),
+      valueQuantity: {
+        value: 0,
       },
       component: [
         // two data points, so this observation has the most detail
@@ -149,10 +147,18 @@ describe('useSleepChartData', () => {
       status: 'final',
       code: {},
       effectiveDateTime: addDays(new Date(10), 1).toISOString(),
-      valuePeriod: {
-        start: addDays(new Date(0), 1).toISOString(),
-        end: addDays(new Date(10), 1).toISOString(),
+      valueQuantity: {
+        value: 0,
       },
+      component: [
+        {
+          code: {},
+          valuePeriod: {
+            start: addDays(new Date(0), 1).toISOString(),
+            end: addDays(new Date(10), 1).toISOString(),
+          },
+        },
+      ],
     };
     useSearchResourcesQuery.mockReturnValue({
       isFetching: false,
@@ -223,10 +229,18 @@ describe('useSleepChartData', () => {
       id: 'first',
       code: {},
       effectiveDateTime: new Date(10).toISOString(),
-      valuePeriod: {
-        start: new Date(0).toISOString(),
-        end: new Date(10).toISOString(),
+      valueQuantity: {
+        value: 0,
       },
+      component: [
+        {
+          code: {},
+          valuePeriod: {
+            start: new Date(0).toISOString(),
+            end: new Date(10).toISOString(),
+          },
+        },
+      ],
     };
     const observation2: fhir3.Observation = {
       ...observation1,


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - We are changing how sleep analysis is ingested so this adds logic to support observations with either a valuePeriod or a valueQuantity represented as unitsofmesaure/minutes.