### PR TITLE
Add Sleep Summary View

### DIFF
--- a/src/components/MyData/SleepChart/SleepSummary.tsx
+++ b/src/components/MyData/SleepChart/SleepSummary.tsx
@@ -1,0 +1,285 @@
+import React, { useMemo } from 'react';
+import { SleepChartData } from './useSleepChartData';
+import { ColorValue, StyleSheet, View } from 'react-native';
+import { Svg, Path, ForeignObject } from 'react-native-svg';
+import {
+  Badge,
+  Divider,
+  MD3TypescaleKey,
+  Text,
+  TextProps,
+} from 'react-native-paper';
+import { differenceInMinutes } from 'date-fns';
+import groupBy from 'lodash/groupBy';
+import mapValues from 'lodash/mapValues';
+import { ActivityIndicatorView } from '../../ActivityIndicatorView';
+import { SleepType, useSleepDisplay } from './useSleepDisplay';
+import { t } from 'i18next';
+import { ComponentNamedStyles, createStyles } from '../../BrandConfigProvider';
+import { useStyles } from '../../../hooks';
+
+type Props = SleepChartData;
+
+export const SleepSummary = (props: Props) => {
+  const { sleepData, isFetching } = props;
+  const toDisplay = useSleepDisplay();
+  const { styles } = useStyles(defaultStyles);
+
+  const groupedData = useMemo(() => {
+    const data = groupBy(
+      sleepData.flatMap((d) => d.component),
+      (d) => toDisplay(d?.code).codeType,
+    ) as Partial<Record<SleepType, fhir3.ObservationComponent[]>>;
+
+    delete data.default;
+
+    return mapValues(data, (obs = [], key) => ({
+      duration: obs.reduce(
+        (total, v) => total + timeInMinutes(v?.valuePeriod),
+        0,
+      ),
+      ...toDisplay(key as SleepType),
+    }));
+  }, [sleepData, toDisplay]);
+
+  return (
+    <View>
+      <RadialChart data={Object.values(groupedData)} />
+      <View style={styles.summaryValuesContainer}>
+        <View style={styles.summaryValueRowContainer}>
+          <SummaryValue {...toDisplay('deep')} {...groupedData.deep} />
+          <SummaryValue {...toDisplay('rem')} {...groupedData.rem} />
+        </View>
+        <View style={styles.summaryValueRowContainer}>
+          <SummaryValue {...toDisplay('light')} {...groupedData.light} />
+          <SummaryValue {...toDisplay('awake')} {...groupedData.awake} />
+        </View>
+      </View>
+
+      <ActivityIndicatorView
+        animating={isFetching}
+        style={{ view: StyleSheet.absoluteFillObject }}
+      />
+    </View>
+  );
+};
+
+const timeInMinutes = (p?: fhir3.Period) => {
+  return !p?.start || !p.end
+    ? 0
+    : differenceInMinutes(new Date(p.end), new Date(p.start));
+};
+
+type DurationTextComponent = <T extends keyof typeof MD3TypescaleKey>(
+  props: Omit<TextProps<T>, 'children'> & { duration?: number },
+) => React.JSX.Element;
+
+const DurationText: DurationTextComponent = ({ duration, ...textProps }) => {
+  let text = t('sleep-analysis-missing-value', '--');
+
+  if (typeof duration === 'number') {
+    const days = Math.floor(duration / 60 / 24);
+    const hours = Math.floor(duration / 60) % 24;
+    const minutes = duration % 60;
+
+    text = t(
+      'sleep-analysis-sleep-amount-with-prefix',
+      '{{prefix}}{{hours}}h {{minutes}}m',
+      {
+        hours,
+        minutes,
+        prefix:
+          days > 0
+            ? t('sleep-analysis-sleep-amount-days', '{{days}}d ', {
+                days,
+              })
+            : '',
+      },
+    );
+  }
+
+  return <Text {...textProps}>{text}</Text>;
+};
+
+const SummaryValue = (props: {
+  duration?: number;
+  color: string;
+  name: string;
+}) => {
+  const { styles } = useStyles(defaultStyles);
+
+  return (
+    <View style={styles.summaryValueContainer}>
+      <Divider />
+      <View style={styles.summaryValueContentContainer}>
+        <DurationText variant="bodyLarge" duration={props.duration} />
+        <View style={styles.summaryValueDescriptionContainer}>
+          <View>
+            <Badge
+              size={6}
+              style={[
+                { backgroundColor: props.color },
+                styles.summaryValueBadgeView,
+              ]}
+            />
+          </View>
+          <Text variant="bodySmall">{props.name}</Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+type RadialChartProps = {
+  data: { duration: number; color: string }[];
+} & ComponentNamedStyles<
+  typeof defaultStyles
+>['SleepAnalysisSummary']['radialChart'];
+
+const RadialChart = (incomingProps: RadialChartProps) => {
+  const { styles } = useStyles(defaultStyles);
+
+  const props = { ...incomingProps, ...styles.radialChart };
+  const { gapDeg = 1, size = 160, startAngle = 270 } = props;
+  const { stroke = 7, radius = (size - 2 * stroke) / 2 } = props;
+  const { defaultStroke, fill, data } = props;
+
+  const { segments, duration } = useMemo(() => {
+    const parts = data.filter((d) => d.duration > 0);
+
+    return {
+      segments: parts,
+      duration: parts.length
+        ? parts.reduce((acc, item) => acc + item.duration, 0)
+        : undefined,
+    };
+  }, [data]);
+
+  const renderArcs = () => {
+    let currentAngle = startAngle; // Where to draw the circle from, defaults to top middle
+    const angles: number[] = segments.map(
+      (item) =>
+        (item.duration / (duration || 1)) * (360 - segments.length * gapDeg),
+    );
+
+    return angles.map((angle, index) => {
+      const endAngle = currentAngle + angle;
+      const arcPath = describeArc({
+        origin: size / 2,
+        radius,
+        startAngle: currentAngle,
+        endAngle,
+      });
+
+      currentAngle = endAngle + gapDeg;
+
+      return (
+        <Path
+          key={index}
+          d={arcPath}
+          fill={fill}
+          stroke={data[index].color}
+          strokeWidth={stroke}
+        />
+      );
+    });
+  };
+
+  return (
+    <View style={styles.summaryChartContainer}>
+      <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        {renderArcs()}
+
+        {/* Empty circle if there is no data */}
+        {segments.length === 0 && (
+          <Path
+            d={describeArc({
+              origin: size / 2,
+              radius,
+              startAngle: 0,
+              endAngle: 360,
+            })}
+            fill={fill}
+            stroke={defaultStroke}
+            strokeWidth={stroke}
+          />
+        )}
+
+        <ForeignObject key={`description-${duration}`}>
+          <View
+            style={[
+              styles.summaryChartTextContainer,
+              {
+                width: size,
+                height: size,
+                paddingHorizontal: 2 * stroke,
+              },
+            ]}
+          >
+            <DurationText
+              adjustsFontSizeToFit
+              numberOfLines={1}
+              variant="headlineMedium"
+              duration={duration}
+            />
+            <Text adjustsFontSizeToFit numberOfLines={1} variant="bodySmall">
+              {t('sleep-analysis-summary-total-sleep', 'Total Sleep')}
+            </Text>
+          </View>
+        </ForeignObject>
+      </Svg>
+    </View>
+  );
+};
+
+type ArcProps = {
+  origin: number;
+  radius: number;
+  startAngle: number;
+  endAngle: number;
+};
+const describeArc = ({ origin, radius, startAngle, endAngle }: ArcProps) => {
+  const startRadians = (startAngle * Math.PI) / 180;
+  const endRadians = (endAngle * Math.PI) / 180;
+
+  const x1 = origin + radius * Math.cos(startRadians);
+  const y1 = origin + radius * Math.sin(startRadians);
+
+  const x2 = origin + radius * Math.cos(endRadians);
+  const y2 = origin + radius * Math.sin(endRadians);
+
+  const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1'; // Set large-arc-flag
+  const sweepFlag = 1; // Always sweep (1) for a circular arc
+
+  return `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArcFlag} ${sweepFlag} ${x2} ${y2}`;
+};
+
+const defaultStyles = createStyles('SleepAnalysisSummary', (theme) => ({
+  radialChart: {
+    fill: 'transparent',
+    defaultStroke: theme.colors.border,
+  } as Record<'gapDeg' | 'size' | 'stroke' | 'radius' | 'startAngle', number> &
+    Record<'fill' | 'defaultStroke', ColorValue>,
+  summaryChartTextContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  summaryValuesContainer: { flexDirection: 'row', columnGap: 10 },
+  summaryValueRowContainer: { flex: 1 },
+  summaryChartContainer: { alignItems: 'center', width: '100%' },
+  summaryValueContainer: {},
+  summaryValueContentContainer: {
+    paddingVertical: 6,
+  },
+  summaryValueDescriptionContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: 4,
+  },
+  summaryValueBadgeView: {},
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}

--- a/src/components/MyData/SleepChart/index.test.tsx
+++ b/src/components/MyData/SleepChart/index.test.tsx
@@ -185,6 +185,102 @@ describe('SleepChart', () => {
     ).toBeDefined();
   });
 
+  it('should render daily summary', async () => {
+    const dateRange = {
+      start: startOfDay(new Date(0)),
+      end: startOfDay(new Date(0)),
+    };
+    mockUseSleepChartData.mockReturnValue({
+      isFetching: false,
+      sleepData: [
+        {
+          resourceType: 'Observation',
+          code: {},
+          status: 'final',
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: new Date(0).toISOString(),
+                end: addMinutes(new Date(0), 1).toISOString(),
+              },
+            },
+            {
+              code: {
+                coding: [Awake],
+              },
+              valuePeriod: {
+                start: addMinutes(new Date(0), 1).toISOString(),
+                end: addMinutes(new Date(0), 3).toISOString(),
+              },
+            },
+            {
+              code: {
+                coding: [Light],
+              },
+              valuePeriod: {
+                start: addMinutes(new Date(0), 3).toISOString(),
+                end: addMinutes(new Date(0), 6).toISOString(),
+              },
+            },
+            {
+              code: {
+                coding: [Deep],
+              },
+              valuePeriod: {
+                start: addMinutes(new Date(0), 6).toISOString(),
+                end: addHours(new Date(0), 3).toISOString(),
+              },
+            },
+            // malformed components - not rendered:
+            {
+              code: {
+                coding: [],
+              },
+              valuePeriod: {
+                start: new Date(0).toISOString(),
+              },
+            },
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                end: addMinutes(new Date(0), 5).toISOString(),
+              },
+            },
+          ],
+        },
+      ],
+      xDomain: scaleTime().domain([new Date(0), addHours(new Date(0), 3)]),
+      dateRange: [dateRange.start, dateRange.end],
+    });
+
+    const { findByText } = render(
+      <SleepChart
+        dateRange={dateRange}
+        title="Single Day Test Title"
+        onBlockScrollChange={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(await findByText('Summary'));
+
+    expect(await findByText('Single Day Test Title')).toBeDefined();
+    expect(await findByText('0h 1m')).toBeDefined();
+    expect(await findByText('Awake')).toBeDefined();
+    expect(await findByText('0h 2m')).toBeDefined();
+    expect(await findByText('REM')).toBeDefined();
+    expect(await findByText('0h 3m')).toBeDefined();
+    expect(await findByText('Light')).toBeDefined();
+    expect(await findByText('2h 54m')).toBeDefined();
+    expect(await findByText('Deep')).toBeDefined();
+    expect(await findByText('3h 0m')).toBeDefined();
+    expect(await findByText('Total Sleep')).toBeDefined();
+  });
+
   it('should select data on daily chart', async () => {
     const dateRange = {
       start: startOfDay(new Date(0)),
@@ -357,6 +453,160 @@ describe('SleepChart', () => {
         )}`,
       ),
     ).toBeDefined();
+  });
+
+  it('should render multi day summary', async () => {
+    const dateRange = {
+      start: startOfDay(new Date(0)),
+      end: startOfDay(addDays(new Date(0), 7)),
+    };
+    mockUseSleepChartData.mockReturnValue({
+      isFetching: false,
+      sleepData: [
+        {
+          resourceType: 'Observation',
+          code: {},
+          status: 'final',
+          effectiveDateTime: addMinutes(new Date(0), 7 * 60).toISOString(),
+          valuePeriod: {
+            start: new Date(0).toISOString(),
+            end: addMinutes(new Date(0), 7 * 60).toISOString(),
+          },
+        },
+        {
+          resourceType: 'Observation',
+          code: {},
+          status: 'final',
+          effectiveDateTime: addHours(
+            addDays(new Date(0), 1),
+            9.5,
+          ).toISOString(),
+          valueQuantity: {
+            value: 9.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
+          },
+          component: [
+            {
+              code: {
+                coding: [Light],
+              },
+              valuePeriod: {
+                start: addDays(new Date(0), 1).toISOString(),
+                end: addMinutes(addDays(new Date(0), 1), 30).toISOString(),
+              },
+            },
+          ],
+        },
+        {
+          resourceType: 'Observation',
+          code: {},
+          status: 'final',
+          effectiveDateTime: addHours(
+            addDays(new Date(0), 2),
+            9.5,
+          ).toISOString(),
+          valueQuantity: {
+            value: 9.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
+          },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addDays(new Date(0), 2).toISOString(),
+                end: addMinutes(
+                  addDays(new Date(0), 2),
+                  9.5 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
+        },
+        {
+          resourceType: 'Observation',
+          code: {},
+          status: 'final',
+          effectiveDateTime: addHours(
+            addDays(new Date(0), 3),
+            9.5,
+          ).toISOString(),
+          valueQuantity: {
+            value: 9.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
+          },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addDays(new Date(0), 3).toISOString(),
+                end: addMinutes(
+                  addDays(new Date(0), 3),
+                  9.5 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
+        },
+        {
+          resourceType: 'Observation',
+          code: {},
+          status: 'final',
+          effectiveDateTime: addHours(
+            addDays(new Date(0), 4),
+            9.5,
+          ).toISOString(),
+          valueQuantity: {
+            value: 9.5 * 60,
+            code: 'min',
+            system: 'http://unitsofmeasure.org',
+          },
+          component: [
+            {
+              code: {
+                coding: [REM],
+              },
+              valuePeriod: {
+                start: addDays(new Date(0), 4).toISOString(),
+                end: addMinutes(
+                  addDays(new Date(0), 4),
+                  9.5 * 60,
+                ).toISOString(),
+              },
+            },
+          ],
+        },
+      ],
+      xDomain: scaleTime().domain([dateRange.start, dateRange.end]),
+      dateRange: [dateRange.start, dateRange.end],
+    });
+
+    const { findByText, debug } = render(
+      <SleepChart
+        dateRange={dateRange}
+        title="Multi Day Test Title"
+        onBlockScrollChange={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(await findByText('Summary'));
+
+    expect(await findByText('Multi Day Test Title')).toBeDefined();
+    expect(await findByText('Awake')).toBeDefined();
+    debug();
+    expect(await findByText('1d 4h 30m')).toBeDefined();
+    expect(await findByText('REM')).toBeDefined();
+    expect(await findByText('0h 30m')).toBeDefined();
+    expect(await findByText('Light')).toBeDefined();
+    expect(await findByText('Deep')).toBeDefined();
+    expect(await findByText('1d 5h 0m')).toBeDefined();
+    expect(await findByText('Total Sleep')).toBeDefined();
   });
 
   it('should select data on multi-day chart', async () => {

--- a/src/components/MyData/SleepChart/index.tsx
+++ b/src/components/MyData/SleepChart/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { startOfDay, differenceInDays } from 'date-fns';
 import ViewShot from 'react-native-view-shot';
+import { t } from 'i18next';
 import { useVictoryTheme } from '../useVictoryTheme';
 import { Title } from '../common/Title';
 import { View, Dimensions } from 'react-native';
@@ -11,6 +12,8 @@ import { defaultChartStyles } from '../styles';
 import { useSleepChartData } from './useSleepChartData';
 import { DailyChart } from './DailyChart';
 import { MultiDayChart } from './MultiDayChart';
+import { SegmentedButtons } from 'react-native-paper';
+import { SleepSummary } from './SleepSummary';
 
 type Props = {
   title: string;
@@ -31,6 +34,7 @@ const SleepChart = (props: Props) => {
   const { title, dateRange: incomingDateRange, onShare } = props;
   const { onBlockScrollChange } = props;
   const viewShotRef = useRef<ViewShot>(null);
+  const [isTimelineView, setIsTimelineView] = React.useState(true);
   const dateRange = useMemo<[Date, Date]>(
     () => [
       startOfDay(incomingDateRange.start),
@@ -68,16 +72,39 @@ const SleepChart = (props: Props) => {
       <Title {...props} onShare={handleExport} />
 
       <View style={styles.chartWrapper}>
-        <ChartType
-          viewShotRef={viewShotRef}
-          onBlockScrollChange={onBlockScrollChange}
-          {...chartData}
-          // Hide data when switching, multi-day data does not render well on daily
-          sleepData={isSwitchingChartType ? [] : chartData.sleepData}
-          // Use incoming date range when switching, multi-day chart shows single day when switching from daily
-          dateRange={isSwitchingChartType ? dateRange : chartData.dateRange}
-        />
+        {isTimelineView ? (
+          <ChartType
+            viewShotRef={viewShotRef}
+            onBlockScrollChange={onBlockScrollChange}
+            {...chartData}
+            // Hide data when switching, multi-day data does not render well on daily
+            sleepData={isSwitchingChartType ? [] : chartData.sleepData}
+            // Use incoming date range when switching, multi-day chart shows single day when switching from daily
+            dateRange={isSwitchingChartType ? dateRange : chartData.dateRange}
+          />
+        ) : (
+          <ViewShot ref={viewShotRef} options={{ format: 'png' }}>
+            <SleepSummary {...chartData} />
+          </ViewShot>
+        )}
       </View>
+
+      <SegmentedButtons
+        onValueChange={(value) => setIsTimelineView(value === 'true')}
+        value={`${isTimelineView}`}
+        density="high"
+        style={styles.chartToggleView}
+        buttons={[
+          {
+            value: 'true',
+            label: t('sleep-analysis-toggle-details', 'Details'),
+          },
+          {
+            value: 'false',
+            label: t('sleep-analysis-toggle-summary', 'Summary'),
+          },
+        ]}
+      />
     </View>
   );
 };
@@ -107,8 +134,10 @@ const SleepChartWrapper = (props: Props & { padding?: number }) => {
 
 export { SleepChartWrapper as SleepChart };
 
-const defaultStyles = createStyles('LineChart', () => ({
-  container: {},
+const defaultStyles = createStyles('SleepChart', () => ({
+  container: {
+    width: '100%',
+  },
   chartWrapper: {
     position: 'relative',
   },
@@ -118,6 +147,9 @@ const defaultStyles = createStyles('LineChart', () => ({
     right: 0,
     top: 0,
     bottom: 0,
+  },
+  chartToggleView: {
+    margin: 16,
   },
 }));
 

--- a/src/components/MyData/SleepChart/useSleepDisplay.ts
+++ b/src/components/MyData/SleepChart/useSleepDisplay.ts
@@ -1,0 +1,74 @@
+import { useCallback } from 'react';
+import { CodeableConcept } from 'fhir/r3';
+import { useStyles } from '../../../hooks';
+import { createStyles, ComponentStyles } from '../../BrandConfigProvider';
+import { t } from 'i18next';
+
+export const useSleepDisplay = (
+  stageColors?: ComponentStyles['SleepAnalysisDisplay']['stageColors'],
+) => {
+  const styles = useStyles(defaultStyles, { stageColors });
+
+  return useCallback(
+    (coding?: CodeableConcept | SleepType) => {
+      const codeType =
+        typeof coding === 'string' ? coding : codeToType(coding ?? {});
+      const num = {
+        deep: 1,
+        light: 2,
+        rem: 3,
+        awake: 4,
+        default: 0,
+      }[codeType];
+
+      return {
+        codeType,
+        num,
+        name: valToName(num),
+        color: styles.styles.stageColors?.[codeType] ?? 'transparent',
+      };
+    },
+    [styles.styles.stageColors],
+  );
+};
+
+export const valToName = (value: number) =>
+  ({
+    4: t('sleep-analysis-type-awake', 'Awake'),
+    3: t('sleep-analysis-type-rem', 'REM'),
+    2: t('sleep-analysis-type-light', 'Light'),
+    1: t('sleep-analysis-type-deep', 'Deep'),
+  }[value] ?? '');
+
+export type SleepType = ReturnType<typeof codeToType>;
+
+const codeToType = (coding: CodeableConcept) => {
+  for (const code of coding.coding ?? []) {
+    if (code.system === 'http://loinc.org' && code.code === '93830-8') {
+      return 'light' as const;
+    } else if (code.system === 'http://loinc.org' && code.code === '93831-6') {
+      return 'deep' as const;
+    } else if (code.system === 'http://loinc.org' && code.code === '93829-0') {
+      return 'rem' as const;
+    } else if (code.system === 'http://loinc.org' && code.code === '93828-2') {
+      return 'awake' as const;
+    }
+  }
+
+  return 'default' as const;
+};
+
+const defaultStyles = createStyles('SleepAnalysisDisplay', () => ({
+  stageColors: {
+    awake: 'hotpink',
+    deep: 'dodgerblue',
+    light: 'deepskyblue',
+    rem: 'deeppink',
+    default: 'transparent',
+  },
+}));
+
+declare module '@styles' {
+  interface ComponentStyles
+    extends ComponentNamedStyles<typeof defaultStyles> {}
+}


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds a summary view to the sleep analysis chart
  - Adds a visual representation of the total of each stage type to the multiday view

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

https://github.com/lifeomic/react-native-sdk/assets/2295908/7af30bd2-019b-4157-a690-93124afaf7a7

