### PR TITLE
fix: Filter Conversation Notification Badge

### DIFF
--- a/src/components/MessagesTile/MessagesTile.tsx
+++ b/src/components/MessagesTile/MessagesTile.tsx
@@ -12,7 +12,7 @@ interface Props extends Pick<HomeStackScreenProps<'Home'>, 'navigation'> {
 }
 
 export function MessagesTile({ navigation, title, id, Icon }: Props) {
-  const hasUnread = useHasUnread();
+  const hasUnread = useHasUnread(id);
 
   return (
     <Tile

--- a/src/hooks/useConversations.test.tsx
+++ b/src/hooks/useConversations.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { mockGraphQLResponse } from '../common/testHelpers/mockGraphQLResponse';
+import { useHasUnread } from './useConversations';
+import { useProfilesForTile } from './useMessagingProfiles';
+import { useUser } from './useUser';
+import { GraphQLClientContextProvider } from './useGraphQLClient';
+
+const baseURL = 'http://localhost:8080/unit-test';
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+jest.mock('./useActiveAccount', () => ({
+  useActiveAccount: jest.fn().mockReturnValue({ account: 'account' }),
+}));
+jest.mock('./useMessagingProfiles', () => ({
+  useProfilesForTile: jest.fn(),
+}));
+jest.mock('./useUser', () => ({
+  useUser: jest.fn(),
+}));
+
+const useProfilesForTileMock = useProfilesForTile as jest.Mock;
+const useUserMock = useUser as jest.Mock;
+
+const renderHookInContext = <T extends any>(useHook: () => T) => {
+  return renderHook(() => useHook(), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        <GraphQLClientContextProvider baseURL={baseURL}>
+          {children}
+        </GraphQLClientContextProvider>
+      </QueryClientProvider>
+    ),
+  });
+};
+
+beforeEach(() => {
+  useProfilesForTileMock.mockReturnValue({
+    data: [{ id: 'profile1' }],
+  });
+  useUserMock.mockReturnValue({ data: { id: 'userId' } });
+});
+
+describe('useHasUnread', () => {
+  test('returns true if there are matching conversations', async () => {
+    const scope = mockGraphQLResponse(
+      `${baseURL}/v1/graphql`,
+      {},
+      {
+        conversations: {
+          edges: [
+            {
+              node: {
+                conversationId: 'conversation1',
+                userIds: ['userId', 'profile1'],
+                hasUnread: true,
+              },
+            },
+          ],
+          pageInfo: { hasNextPage: false },
+        },
+      },
+    );
+
+    const { result } = renderHookInContext(() => useHasUnread(''));
+
+    await waitFor(() => scope.done());
+
+    expect(result.current).toBe(true);
+  });
+
+  test('returns false if there are conversations with no matching profiles', async () => {
+    const scope = mockGraphQLResponse(
+      `${baseURL}/v1/graphql`,
+      {},
+      {
+        conversations: {
+          edges: [
+            {
+              node: {
+                conversationId: 'conversation2',
+                userIds: ['userId', 'profile2'],
+                hasUnread: true,
+              },
+            },
+          ],
+          pageInfo: { hasNextPage: false },
+        },
+      },
+    );
+
+    const { result } = renderHookInContext(() => useHasUnread(''));
+
+    await waitFor(() => scope.done());
+
+    expect(result.current).toBe(false);
+  });
+
+  test('handles missing user and profile data', async () => {
+    // Simulate data not loaded
+    useProfilesForTileMock.mockReturnValue({ data: undefined });
+    useUserMock.mockReturnValue({ data: undefined });
+
+    const scope = mockGraphQLResponse(
+      `${baseURL}/v1/graphql`,
+      {},
+      {
+        conversations: {
+          edges: [
+            {
+              node: {
+                conversationId: 'conversation2',
+                userIds: ['userId', 'profile1'],
+                hasUnread: true,
+              },
+            },
+          ],
+          pageInfo: { hasNextPage: false },
+        },
+      },
+    );
+
+    const { result } = renderHookInContext(() => useHasUnread(''));
+
+    await waitFor(() => scope.done());
+
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds logic to filter the conversation notification badge to only be true if there are conversations within the message tile that have unread messages

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<img width="375" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/4804637c-6cc9-49a3-a625-ca7fdba94e9a">
