### PR TITLE
feat: allow for providing dynamic auth config based on current auth result

### DIFF
--- a/src/common/RootProviders.tsx
+++ b/src/common/RootProviders.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AuthConfiguration } from 'react-native-app-auth';
 import { AuthContextProvider } from '../hooks/useAuth';
 import { HttpClientContextProvider } from '../hooks/useHttpClient';
-import { OAuthContextProvider } from '../hooks/useOAuthFlow';
+import { AuthConfigGetter, OAuthContextProvider } from '../hooks/useOAuthFlow';
 import { GraphQLClientContextProvider } from '../hooks/useGraphQLClient';
 import { useDeveloperConfig } from '../hooks/useDeveloperConfig';
 import { BrandConfigProvider } from '../components/BrandConfigProvider';
@@ -20,7 +20,7 @@ const queryClient = new QueryClient();
 
 export type RootProvidersProps = {
   account: string;
-  authConfig: AuthConfiguration;
+  authConfig: AuthConfiguration | AuthConfigGetter;
   children?: React.ReactNode;
 };
 


### PR DESCRIPTION


## Changes
Alternative pr to #521. Instead of allowing a consumer to intercept the config at the time an action is about to take place, this provides a function that takes the current auth result and then will return the auth config 

Also noticed the setup function for the tests here was async and didn't need to be. Likely drifted from a time it was required 

## Screenshots
<!-- include screen recordings, if relevant to your changes -->