### PR TITLE
feat: support unsubscribe method from add listener

### DIFF
--- a/src/common/Analytics/AnalyticsEvents.test.ts
+++ b/src/common/Analytics/AnalyticsEvents.test.ts
@@ -11,9 +11,9 @@ describe('AnalyticsEvents', () => {
       usedInvite: true,
     };
     const listener = jest.fn();
-    analyticsListener.addListener('track', listener);
+    const { remove } = analyticsListener.addListener('track', listener);
     _sdkAnalyticsEvent.track(eventKey, event);
-    analyticsListener.removeListener('track', listener);
+    remove();
     _sdkAnalyticsEvent.track(eventKey, event);
 
     expect(listener).toHaveBeenCalledTimes(1);

--- a/src/common/Analytics/AnalyticsEvents.ts
+++ b/src/common/Analytics/AnalyticsEvents.ts
@@ -62,7 +62,7 @@ type AnalyticsListener = {
   addListener<EventType extends AnalyticsEventTypes>(
     eventType: EventType,
     listener: AnalyticsEventTypeHandler<EventType>,
-  ): void;
+  ): { unsubscribe: () => void; remove: () => void };
 
   removeListener<EventType extends AnalyticsEventTypes>(
     eventType: EventType,

--- a/src/common/Analytics/AnalyticsEvents.ts
+++ b/src/common/Analytics/AnalyticsEvents.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { SDKEventEmitter } from '../SDKEventEmitter';
 
 export type AnalyticsEventTypeHandlers = {
   track: (eventName: string, event: unknown) => void;
@@ -14,7 +14,7 @@ export type AnalyticsEventTypes = keyof AnalyticsEventTypeHandlers;
 export type AnalyticsEventTypeHandler<T extends AnalyticsEventTypes> =
   AnalyticsEventTypeHandlers[T];
 
-const emitter = new EventEmitter();
+const emitter = new SDKEventEmitter();
 
 export type Tracker<CustomEventMap extends Record<string, unknown>> = {
   track<Key extends keyof CustomEventMap>(

--- a/src/common/AppConfigNotifier.tsx
+++ b/src/common/AppConfigNotifier.tsx
@@ -1,10 +1,10 @@
-import { EventEmitter } from 'events';
 import { AppConfig } from '../hooks';
+import { SDKEventEmitter } from './SDKEventEmitter';
 
 export const appConfigChangeEventType = 'appConfigChanged';
 export type AppConfigChangeHandler = (config: AppConfig | undefined) => void;
 export class AppConfigNotifier {
-  private emitter = new EventEmitter();
+  private emitter = new SDKEventEmitter();
 
   public addListener(listener: AppConfigChangeHandler) {
     return this.emitter.addListener(appConfigChangeEventType, listener);

--- a/src/common/RefreshNotifier.tsx
+++ b/src/common/RefreshNotifier.tsx
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { SDKEventEmitter } from './SDKEventEmitter';
 
 export type RefreshParams = {
   context?: 'HomeScreen';
@@ -7,7 +7,7 @@ export type RefreshParams = {
 export const refreshEventType = 'refreshRequested';
 export type RefreshHandler = (refreshParams: RefreshParams) => void;
 export class RefreshNotifier {
-  private emitter = new EventEmitter();
+  private emitter = new SDKEventEmitter();
 
   public addListener(listener: RefreshHandler) {
     return this.emitter.addListener(refreshEventType, listener);

--- a/src/common/SDKEventEmitter.ts
+++ b/src/common/SDKEventEmitter.ts
@@ -1,0 +1,42 @@
+import { EventEmitter } from 'events';
+
+/**
+ * A wrapper around node's events module for convenience.
+ * Adds unsubscribe method to the returned result of `addListener`
+ */
+export class SDKEventEmitter {
+  public emitter = new EventEmitter();
+
+  public addListener<
+    Type extends string,
+    Listener extends (...args: any[]) => void,
+  >(eventType: Type, listener: Listener) {
+    const subscription = this.emitter.addListener(eventType, listener);
+    const unsubscribe = () => {
+      this.emitter.removeListener(eventType, listener);
+    };
+
+    return {
+      ...subscription,
+      /**
+       * Removes this subscription from the emitter that registered it.
+       * Similar to using emitter.removeEventListener(eventName, listener)
+       * except it does not return the EventEmitter instance.
+       */
+      unsubscribe,
+      /**  @alias unsubscribe */
+      remove: unsubscribe,
+    };
+  }
+
+  public removeListener<
+    Type extends string,
+    Listener extends (...args: any[]) => void,
+  >(eventType: Type, listener: Listener) {
+    return this.emitter.removeListener(eventType, listener);
+  }
+
+  public emit<Type extends string>(eventType: Type, ...params: any) {
+    return this.emitter.emit(eventType, ...params);
+  }
+}

--- a/src/components/BrandConfigProvider/BrandConfigProvider.tsx
+++ b/src/components/BrandConfigProvider/BrandConfigProvider.tsx
@@ -33,11 +33,9 @@ export function BrandConfigProvider({ theme, styles, icons, children }: Props) {
       }
     };
 
-    appConfigNotifier.addListener(listener);
+    const { unsubscribe } = appConfigNotifier.addListener(listener);
 
-    return () => {
-      appConfigNotifier.removeListener(listener);
-    };
+    return unsubscribe;
   }, []);
 
   return (

--- a/src/components/Invitations/InviteNotifier.test.ts
+++ b/src/components/Invitations/InviteNotifier.test.ts
@@ -1,6 +1,10 @@
-import { inviteNotifier } from './InviteNotifier';
+import { InviteNotifier } from './InviteNotifier';
+
+const setup = () => new InviteNotifier();
 
 it('allows simplified EventEmitter functionality', async () => {
+  const inviteNotifier = setup();
+
   const inviteParams = {
     inviteId: 'invite-id',
     evc: 'evc',
@@ -15,7 +19,26 @@ it('allows simplified EventEmitter functionality', async () => {
   expect(listener).toHaveBeenCalledWith(inviteParams);
 });
 
+it('allows unsubscribing from attached listener', async () => {
+  const inviteNotifier = setup();
+
+  const inviteParams = {
+    inviteId: 'invite-id',
+    evc: 'evc',
+  };
+  const listener = jest.fn();
+  const subscription = inviteNotifier.addListener('inviteDetected', listener);
+  inviteNotifier.emit('inviteDetected', inviteParams);
+  subscription.unsubscribe();
+  inviteNotifier.emit('inviteDetected', inviteParams);
+
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith(inviteParams);
+});
+
 it('caches last emitted invite detected so new listeners can consume invite params', async () => {
+  const inviteNotifier = setup();
+
   const inviteParams = {
     inviteId: 'invite-id',
     evc: 'evc',
@@ -29,6 +52,8 @@ it('caches last emitted invite detected so new listeners can consume invite para
 });
 
 it('allows for clearing cache', async () => {
+  const inviteNotifier = setup();
+
   const inviteParams = {
     inviteId: 'invite-id',
     evc: 'evc',

--- a/src/components/Invitations/InviteNotifier.ts
+++ b/src/components/Invitations/InviteNotifier.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { SDKEventEmitter } from '../../common/SDKEventEmitter';
 import { PendingInvite } from './InviteProvider';
 
 export type InviteParams = PendingInvite;
@@ -10,7 +10,7 @@ export type EventTypeHandlers = {
 export type EventTypes = keyof EventTypeHandlers;
 export type EventTypeHandler<T extends EventTypes> = EventTypeHandlers[T];
 export class InviteNotifier {
-  private emitter = new EventEmitter();
+  private emitter = new SDKEventEmitter();
   private lastInviteDetectedParams: InviteParams | undefined;
 
   public addListener<T extends EventTypes>(
@@ -22,6 +22,7 @@ export class InviteNotifier {
         this.lastInviteDetectedParams,
       );
     }
+
     return this.emitter.addListener(eventType, listener);
   }
 
@@ -29,7 +30,7 @@ export class InviteNotifier {
     eventType: EventTypes,
     listener: EventTypeHandler<T>,
   ) {
-    return this.emitter.removeListener(eventType, listener);
+    this.emitter.removeListener(eventType, listener);
   }
 
   public emit<T extends EventTypes>(

--- a/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/AdvancedTrackerEditor.tsx
+++ b/src/components/TrackTile/TrackerDetails/AdvancedTrackerEditor/AdvancedTrackerEditor.tsx
@@ -108,11 +108,12 @@ export const AdvancedTrackerEditor = (props: AdvancedTrackerEditorProps) => {
       }
     };
 
-    notifier.addListener('saveEditTrackerValue', handler);
+    const { unsubscribe } = notifier.addListener(
+      'saveEditTrackerValue',
+      handler,
+    );
 
-    return () => {
-      notifier.removeListener('saveEditTrackerValue', handler);
-    };
+    return unsubscribe;
   }, [
     valuesContext,
     metricId,

--- a/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
+++ b/src/components/TrackTile/hooks/useAxiosTrackTileService.ts
@@ -78,10 +78,8 @@ export const useAxiosTrackTileService = (): TrackTileService => {
         cache.trackerValues = {};
       }
     };
-    refreshNotifier.addListener(refreshHandler);
-    return () => {
-      refreshNotifier.removeListener(refreshHandler);
-    };
+    const { unsubscribe } = refreshNotifier.addListener(refreshHandler);
+    return unsubscribe;
   }, [cache]);
 
   const updateSettingsInCache = (settings: BulkInstalledMetricSettings) => {

--- a/src/components/TrackTile/hooks/useRecentCodedValues.ts
+++ b/src/components/TrackTile/hooks/useRecentCodedValues.ts
@@ -54,11 +54,9 @@ export const useRecentCodedValues = (metricId: string) => {
       });
     };
 
-    notifier.addListener('valuesChanged', handler);
+    const { unsubscribe } = notifier.addListener('valuesChanged', handler);
 
-    return () => {
-      notifier.removeListener('valuesChanged', handler);
-    };
+    return unsubscribe;
   }, [metricId]);
 
   return recentCodedValues;

--- a/src/components/TrackTile/hooks/useTrackerValues.ts
+++ b/src/components/TrackTile/hooks/useTrackerValues.ts
@@ -80,10 +80,8 @@ export const useTrackerValues = (
         fetchData();
       }
     };
-    refreshNotifier.addListener(refreshHandler);
-    return () => {
-      refreshNotifier.removeListener(refreshHandler);
-    };
+    const { unsubscribe } = refreshNotifier.addListener(refreshHandler);
+    return unsubscribe;
   }, [fetchData]);
 
   useEffect(() => {
@@ -122,11 +120,9 @@ export const useTrackerValues = (
       });
     };
 
-    notifier.addListener('valuesChanged', handler);
+    const { unsubscribe } = notifier.addListener('valuesChanged', handler);
 
-    return () => {
-      notifier.removeListener('valuesChanged', handler);
-    };
+    return unsubscribe;
   }, [valuesContext]);
 
   useEffect(() => {

--- a/src/components/TrackTile/hooks/useTrackers.ts
+++ b/src/components/TrackTile/hooks/useTrackers.ts
@@ -104,12 +104,18 @@ export const useTrackers = (trackersToUse?: Trackers) => {
       }
     };
     if (!trackersToUse) {
-      notifier.addListener('trackerChanged', onChange);
-      notifier.addListener('trackerRemoved', onRemoved);
+      const trackerChangedSubscription = notifier.addListener(
+        'trackerChanged',
+        onChange,
+      );
+      const trackerRemovedSubscription = notifier.addListener(
+        'trackerRemoved',
+        onRemoved,
+      );
 
       return () => {
-        notifier.removeListener('trackerChanged', onChange);
-        notifier.removeListener('trackerRemoved', onRemoved);
+        trackerChangedSubscription.unsubscribe();
+        trackerRemovedSubscription.unsubscribe();
       };
     }
   }, [trackersToUse]);

--- a/src/components/TrackTile/services/EmitterService.ts
+++ b/src/components/TrackTile/services/EmitterService.ts
@@ -1,4 +1,5 @@
-import { EventEmitter } from 'events';
+import { SDKEventEmitter } from '../../../common/SDKEventEmitter';
+
 import {
   Tracker,
   TrackerValue,
@@ -26,26 +27,28 @@ export type EventTypeHandlers = {
 export type EventTypes = keyof EventTypeHandlers;
 export type EventTypeHandler<T extends EventTypes> = EventTypeHandlers[T];
 
-export class TrackTileEmitter extends EventEmitter {
+export class TrackTileEmitter {
+  private emitter = new SDKEventEmitter();
+
   public addListener<T extends EventTypes>(
     eventType: T,
     listener: EventTypeHandler<T>,
   ) {
-    return super.addListener(eventType, listener);
+    return this.emitter.addListener(eventType, listener);
   }
 
   public removeListener<T extends EventTypes>(
     eventType: EventTypes,
     listener: EventTypeHandler<T>,
   ) {
-    return super.removeListener(eventType, listener);
+    return this.emitter.removeListener(eventType, listener);
   }
 
   public emit<T extends EventTypes>(
     eventType: T,
     ...params: Parameters<EventTypeHandler<T>>
   ) {
-    return super.emit(eventType, ...params);
+    return this.emitter.emit(eventType, ...params);
   }
 }
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - return an short cut to remove event listeners to sdk event notifiers
  - update internal uses instead

To accomplish this a wrapper around node event's `EventEmitter` was added and then used in place

The commits are split between first, adding that wrapper and making use of it then the second was calling `unsubscribe` in place of `removeEventListener` 

I think the next move would be to deprecate the `removeEventListener` methods and then eventually removing it completely - for now it is left in place as to not break any consumers

## Screenshots
<!-- include screen recordings, if relevant to your changes -->