### PR TITLE
fix: dynamic oauth config getter

### DIFF
--- a/src/hooks/useOAuthFlow.test.tsx
+++ b/src/hooks/useOAuthFlow.test.tsx
@@ -116,7 +116,7 @@ test('allows for providing auth config as a function', () => {
   });
 
   expect(authConfigFn).toHaveBeenCalledTimes(1);
-  expect(authConfigFn).toHaveBeenCalledWith(authResult);
+  expect(authConfigFn).toHaveBeenCalledWith(authResult.accessToken);
   expect(result.current.authConfig).toEqual({
     ...authConfig,
     additionalParameters,

--- a/src/hooks/useOAuthFlow.tsx
+++ b/src/hooks/useOAuthFlow.tsx
@@ -38,11 +38,11 @@ export interface LogoutParams {
  * OAuth flows.
  *
  * While typically not needed, this function is invoked with the current
- * auth result to be able to provide a dynamic auth configuration.
+ * access token to be able to provide a dynamic auth configuration.
  *
  * @example
  * <RootProviders
- *   authConfig={(currentAuthResult) => {
+ *   authConfig={(currentAccessToken) => {
  *     if (...) {
  *       return {
  *         ...config,
@@ -53,9 +53,7 @@ export interface LogoutParams {
  *   }}
  * />
  */
-export type AuthConfigGetter = (
-  currentAuthResult?: AuthResult,
-) => AuthConfiguration;
+export type AuthConfigGetter = (accessToken?: string) => AuthConfiguration;
 
 const OAuthContext = createContext<OAuthConfig>({
   login: (_) => Promise.reject(),
@@ -82,9 +80,9 @@ export const OAuthContextProvider = ({
   const authConfig = useMemo(
     () =>
       typeof authConfigOrGetter === 'function'
-        ? authConfigOrGetter(authResult)
+        ? authConfigOrGetter(authResult?.accessToken)
         : authConfigOrGetter,
-    [authConfigOrGetter, authResult],
+    [authConfigOrGetter, authResult?.accessToken],
   );
 
   // PKCE is required
@@ -143,7 +141,13 @@ export const OAuthContextProvider = ({
         onFail?.(error);
       }
     },
-    [queryClient, isLoggedIn, authResult, clearAuthResult, authConfig],
+    [
+      queryClient,
+      isLoggedIn,
+      authResult?.refreshToken,
+      clearAuthResult,
+      authConfig,
+    ],
   );
 
   const login = useCallback(


### PR DESCRIPTION
## Changes

We found out there was an infinite render cycle caused by the dynamic config getter. The issue was caused by the `authResult` being different every time, which triggered the `useMemo` to be calculated infinitely.

We really only needed the `accessToken` from `authResult`, and since that's just a string, it fix the infinite render cycle since we can just pass the string as the `useMemo` dependency. 

The consumer does have to make sure that the getter is stable on their end though.

## Screenshots

I confirmed this changes locally.