### PR TITLE
Emit Latest Invite State Value on Subscribe

### DIFF
--- a/src/components/Invitations/InviteNotifier.ts
+++ b/src/components/Invitations/InviteNotifier.ts
@@ -3,13 +3,15 @@ import { PendingInvite } from './InviteProvider';
 
 export type InviteParams = PendingInvite;
 
+type InviteState = {
+  loading?: boolean;
+  failedToDecode?: boolean;
+  failureMessage?: string;
+};
+
 export type EventTypeHandlers = {
   inviteDetected: (inviteParams: InviteParams) => void;
-  inviteLoadingStateChanged: (state: {
-    loading?: boolean;
-    failedToDecode?: boolean;
-    failureMessage?: string;
-  }) => void;
+  inviteLoadingStateChanged: (state: InviteState) => void;
 };
 
 export type EventTypes = keyof EventTypeHandlers;
@@ -17,6 +19,7 @@ export type EventTypeHandler<T extends EventTypes> = EventTypeHandlers[T];
 export class InviteNotifier {
   private emitter = new EventEmitter();
   private lastInviteDetectedParams: InviteParams | undefined;
+  private lastInviteState: InviteState | undefined;
 
   public addListener<T extends EventTypes>(
     eventType: T,
@@ -25,6 +28,13 @@ export class InviteNotifier {
     if (eventType === 'inviteDetected' && this.lastInviteDetectedParams) {
       (listener as EventTypeHandler<'inviteDetected'>)(
         this.lastInviteDetectedParams,
+      );
+    } else if (
+      eventType === 'inviteLoadingStateChanged' &&
+      this.lastInviteState
+    ) {
+      (listener as EventTypeHandler<'inviteLoadingStateChanged'>)(
+        this.lastInviteState,
       );
     }
     return this.emitter.addListener(eventType, listener);


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - If a inviteLoadingStateChanged listener mounts after the event has been emitted, it misses the state value. This updates the logic to emit the most recent value when the listener is added.