### PR TITLE
fix: Add messaging placeholder

### DIFF
--- a/src/components/Messaging/SearchRecipientsModal.tsx
+++ b/src/components/Messaging/SearchRecipientsModal.tsx
@@ -7,7 +7,7 @@ import {
   ViewStyle,
 } from 'react-native';
 import { GiftedAvatar, User as GiftedUser } from 'react-native-gifted-chat';
-import { Button, Divider, List, Searchbar } from 'react-native-paper';
+import { Button, Divider, List, Searchbar, Text } from 'react-native-paper';
 import { tID } from '../TrackTile/common/testID';
 import { useStyles, useUser } from '../../hooks';
 import { createStyles, useIcons } from '../BrandConfigProvider';
@@ -77,6 +77,16 @@ export const SearchRecipientsModal = ({
         clearIcon={ClearList}
         testID={tID('search-bar')}
       />
+      {others.length < 1 && (
+        <View>
+          <Text style={{ textAlign: 'center' }}>
+            {t(
+              'no-recipients-message',
+              'No available message recipients. \nYou must be added to a messaging group to use this feature. Ask your administrator for more information.',
+            )}
+          </Text>
+        </View>
+      )}
       <ScrollView
         scrollEventThrottle={400}
         contentContainerStyle={styles.scrollView}

--- a/src/screens/MessageScreen.tsx
+++ b/src/screens/MessageScreen.tsx
@@ -236,6 +236,18 @@ export function MessageScreen<ParamList extends ParamListBase>({
             </TouchableOpacity>
           </Swipeable>
         ))}
+        {!conversations?.length && !isLoading && (
+          <Swipeable>
+            <List.Item
+              titleStyle={styles.listItemText}
+              title={t('no-direct-messages', 'No message history.')}
+              style={styles.listItemView}
+              description={t('no-direct-messages', 'New messages appear here.')}
+              descriptionStyle={styles.listItemSubtitleText}
+            />
+            <Divider style={styles.listItemDividerView} />
+          </Swipeable>
+        )}
         {isLoading ? (
           <ActivityIndicatorView />
         ) : (


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Add explanation for when the messages screen is empty
  - Add explanation for when the compose messaging screen has no recipients

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<img width="404" alt="Screenshot 2024-03-21 at 9 33 51 AM" src="https://github.com/lifeomic/react-native-sdk/assets/76954025/e0f3a6b2-e01e-4a1f-9e80-c4e82b7d39f4">
<img width="404" alt="Screenshot 2024-03-21 at 9 44 43 AM" src="https://github.com/lifeomic/react-native-sdk/assets/76954025/625178e4-ad83-4cda-a471-3038611dbfe1">
