### PR TITLE
Add Messaging Markdown (light) Support

### DIFF
--- a/src/screens/MessageScreen.tsx
+++ b/src/screens/MessageScreen.tsx
@@ -29,7 +29,10 @@ import { useUser } from '../hooks';
 import { useProfilesForTile } from '../hooks/useMessagingProfiles';
 import { User } from '../types';
 import { ParamListBase } from '@react-navigation/native';
-import { DirectMessageParams } from './DirectMessagesScreen';
+import {
+  DirectMessageParams,
+  messageTextParsers,
+} from './DirectMessagesScreen';
 import { ComposeMessageParams } from './ComposeMessageScreen';
 import {
   ScreenParamTypes as BaseScreenParamTypes,
@@ -38,6 +41,7 @@ import {
 import compact from 'lodash/compact';
 import Swipeable from 'react-native-gesture-handler/Swipeable';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import ParsedText from 'react-native-parsed-text';
 
 export type MessageTileParams = {
   tileId: string;
@@ -206,7 +210,7 @@ export function MessageScreen<ParamList extends ParamListBase>({
                 style={styles.listItemView}
                 descriptionNumberOfLines={1}
                 descriptionStyle={
-                  node
+                  node.hasUnread
                     ? [styles.listItemSubtitleText, styles.newMessageText]
                     : styles.listItemSubtitleText
                 }
@@ -223,12 +227,19 @@ export function MessageScreen<ParamList extends ParamListBase>({
                   .map((profile) => profile.profile.displayName)
                   .join(', ')}
                 description={
-                  node.latestMessageUserId === userData?.id
-                    ? t('message-preview-prefixed', {
-                        defaultValue: 'You: {{messageText}}',
-                        messageText: node.latestMessageText,
-                      })
-                    : node.latestMessageText
+                  <ParsedText
+                    parse={messageTextParsers(
+                      styles.linkMessagePreviewText,
+                      true,
+                    )}
+                  >
+                    {node.latestMessageUserId === userData?.id
+                      ? t('message-preview-prefixed', {
+                          defaultValue: 'You: {{messageText}}',
+                          messageText: node.latestMessageText,
+                        })
+                      : node.latestMessageText}
+                  </ParsedText>
                 }
                 right={() => renderRight(node.latestMessageTime)}
               />
@@ -375,7 +386,6 @@ const defaultStyles = createStyles('MessageScreen', (theme) => {
     listItemTimeText: { paddingLeft: 15 },
     newMessageText: {
       color: theme.colors.text,
-      fontWeight: '600',
     },
     multiGiftedAvatarView: {
       flex: 1,
@@ -433,6 +443,9 @@ const defaultStyles = createStyles('MessageScreen', (theme) => {
       paddingVertical: 20,
     },
     createMessageIcon: {} as { color: string | undefined },
+    linkMessagePreviewText: {
+      textDecorationLine: 'underline',
+    },
   };
 });
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adds some basic markdown support to the DirectMessageScreen and the MessageScreen (list of messages)
  - Adds formatting of email, phone, and urls to the DirectMessageScreen and the MessageScreen (list of messages)

### Supported Markdown
  -  `[text](https://google.com)` - renders a link. Example:  [text](https://google.com)
  - `***text***` - renders text as bold and italic. Example:   ***text***
  - `**text**` or `__text__` - renders text as bold. Example:   **text**
  - `*text*` or `_text_` - renders text as italic. Example:   _text_
  - `~~text~~` - renders text as strikethrough. Example:   ~~text~~
  - `![image](https://reactnative.dev/img/tiny_logo.png)` - renders an image in it's own bubble. Example:
![image](https://github.com/lifeomic/react-native-sdk/assets/2295908/dc6557d4-b106-4586-aa0d-91b7989fe2f3)

Note: Markdown does not support nested styling. i.e. Markdown like `**Bold text with _emphasis_ text**` will not italicize the text, it will look like this: **Bold text with \_emphasis\_ text**. The desired result can be achieved with the following `**Bold text with** ***emphasis*** **text**` which looks like this: **Bold text with** ***emphasis*** **text**

## Screenshots
<!-- include screen recordings, if relevant to your changes -->
<table>
<tr>
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/ac23c0ca-1cf8-4a51-95c2-a7def2c2c3a7" />
 <td><video src="https://github.com/lifeomic/react-native-sdk/assets/2295908/a4e0bd76-6a4e-4aaa-9f2d-685333387f67" />
</table>