### PR TITLE
feat: Add option to wait for subjectId

### DIFF
--- a/src/common/DeveloperConfig.ts
+++ b/src/common/DeveloperConfig.ts
@@ -139,6 +139,12 @@ export type DeveloperConfig = {
   skipInviteParams?: boolean;
   tileListMode?: 'list' | 'column';
   showPreLoginWarning?: boolean;
+  /***
+   * Instead of showing the invite required screen when no patientId
+   * is found retry indefinitely. This is useful if createPatientMapping rule
+   * is present for a given account and we do not expect the usual invite to project flow.
+   ***/
+  keepWaitingForPatientId?: boolean;
 };
 
 export type LogoHeaderConfig = { [key in Route]?: LogoHeaderOptions };

--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -10,6 +10,7 @@ import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
 import { useRestQuery } from './rest-api';
 import { useActiveAccount } from './useActiveAccount';
 import { useDeveloperConfig } from './useDeveloperConfig';
+import { tID } from '../common/testID';
 
 const selectedProjectIdKey = 'selectedProjectIdKey';
 
@@ -154,10 +155,14 @@ export const ActiveProjectContextProvider: React.FC<ActiveProjectContextProvider
     const state = calculateState();
 
     useEffect(() => {
-      if (!query.isRefetching && state.status === 'not-a-patient') {
+      if (
+        !query.isRefetching &&
+        state.status === 'not-a-patient' &&
+        keepWaitingForPatientId
+      ) {
         query.refetchAll();
       }
-    }, [query, state.status]);
+    }, [keepWaitingForPatientId, query, state.status]);
 
     // This effect handles setting the initial value in async storage.
     const activeProjectId =
@@ -180,6 +185,7 @@ export const ActiveProjectContextProvider: React.FC<ActiveProjectContextProvider
       if (keepWaitingForPatientId) {
         return (
           <ActivityIndicatorView
+            testID={tID('waiting-for-patient-loader')}
             style={{
               text: {
                 alignSelf: 'center',

--- a/src/hooks/useActiveProject.tsx
+++ b/src/hooks/useActiveProject.tsx
@@ -9,6 +9,7 @@ import { t } from 'i18next';
 import { InviteRequiredScreen } from '../screens/InviteRequiredScreen';
 import { useRestQuery } from './rest-api';
 import { useActiveAccount } from './useActiveAccount';
+import { useDeveloperConfig } from './useDeveloperConfig';
 
 const selectedProjectIdKey = 'selectedProjectIdKey';
 
@@ -115,6 +116,7 @@ export type ActiveProjectContextProviderProps = {
 
 export const ActiveProjectContextProvider: React.FC<ActiveProjectContextProviderProps> =
   withAccountRequired(({ children }) => {
+    const { keepWaitingForPatientId } = useDeveloperConfig();
     const query = combineQueries([useSubjectProjects(), useMe(), useUser()]);
     const userId = query.data?.[2].id;
     const [storedProjectIdResult, setStoredProjectId, isStorageLoaded] =
@@ -151,6 +153,12 @@ export const ActiveProjectContextProvider: React.FC<ActiveProjectContextProvider
 
     const state = calculateState();
 
+    useEffect(() => {
+      if (!query.isRefetching && state.status === 'not-a-patient') {
+        query.refetchAll();
+      }
+    }, [query, state.status]);
+
     // This effect handles setting the initial value in async storage.
     const activeProjectId =
       state.status === 'success' ? state.activeProject.id : undefined;
@@ -169,6 +177,22 @@ export const ActiveProjectContextProvider: React.FC<ActiveProjectContextProvider
     }
     // TODO: handle error state.
     if (state.status === 'not-a-patient') {
+      if (keepWaitingForPatientId) {
+        return (
+          <ActivityIndicatorView
+            style={{
+              text: {
+                alignSelf: 'center',
+              },
+            }}
+            message={t(
+              'expected-waiting-for-account-and-project',
+              'Please wait while we complete the initial setup for your first login.',
+            )}
+          />
+        );
+      }
+
       return <InviteRequiredScreen />;
     }
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - In the event that we are expecting auto-patient mapping to occur do not show the invite required screen but instead keep querying for subjectId and project.

## Screenshots
<!-- include screen recordings, if relevant to your changes -->