### PR TITLE
fix: Modify image message bubble styles

### DIFF
--- a/src/screens/DirectMessagesScreen.tsx
+++ b/src/screens/DirectMessagesScreen.tsx
@@ -447,10 +447,13 @@ const CustomMessageImage = React.memo(
         Image.getSize(image, (width, height) => {
           const aspectRatio = width / height;
           const largerDimension = width > height ? 'width' : 'height';
-          setDimensions({
-            [largerDimension]: 'auto',
-            aspectRatio,
-          });
+
+          if (isFinite(aspectRatio)) {
+            setDimensions({
+              [largerDimension]: 'auto',
+              aspectRatio,
+            });
+          }
         });
       }
     }, [props.currentMessage?.image]);


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Adjusts the default image styles to not have a background and not display the time
  - Adds logic to make the image display with the correct aspect ratio
  - Tweaks the lightbox settings to avoid the black background display when interacting with the image (open/close)

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><b>Before
 <td><b>After
<tr>
 <td><img src="https://github.com/lifeomic/react-native-sdk/assets/2295908/68161418-f41f-4a9d-9427-b5fe8be1141f" />
 <td><img src="https://github.com/lifeomic/react-native-sdk/assets/2295908/817d390a-4386-461f-ad56-c8d7151004a4" />
</table>

Text messages still have bubbles:
![image](https://github.com/lifeomic/react-native-sdk/assets/2295908/38df0c48-e61c-480d-93c6-b2f52d3b616c)
