### PR TITLE
fix: To Chip Sizing for Font Scaling

### DIFF
--- a/src/screens/ComposeMessageScreen.tsx
+++ b/src/screens/ComposeMessageScreen.tsx
@@ -280,9 +280,8 @@ const defaultStyles = createStyles('ComposeMessageScreen', (theme) => ({
   },
   chipView: {
     marginLeft: theme.spacing.tiny,
-    marginVertical: 2,
+    marginVertical: 4,
     backgroundColor: theme.colors.primary,
-    maxHeight: 30,
   },
   chipText: {
     color: theme.colors.surface,
@@ -291,7 +290,7 @@ const defaultStyles = createStyles('ComposeMessageScreen', (theme) => ({
     color: theme.colors.surface,
     justifyContent: 'center',
     paddingLeft: 6,
-    marginTop: -2,
+    marginTop: -6.5,
     marginRight: -4,
     height: '100%',
   },


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Your changes...

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><b>Before
 <td><b>After
<tr>
 <td><img width="393" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/3dca3d72-c230-469e-b6ea-a28ff4d8ebae">
 <td><img width="411" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/1ca64713-f84d-4932-ae37-a4c695496462">
</table>