### PR TITLE
fix: Fix Pending Image Border Style

### DIFF
--- a/src/screens/DirectMessagesScreen.tsx
+++ b/src/screens/DirectMessagesScreen.tsx
@@ -371,6 +371,7 @@ export const DirectMessagesScreen = ({
         pendingImages.length
           ? () => (
               <ScrollView
+                style={styles.pendingImagesScrollView}
                 contentContainerStyle={styles.pendingImagesContainer}
                 horizontal
               >
@@ -605,10 +606,12 @@ const defaultStyles = createStyles('DirectMessagesScreen', (theme) => ({
   },
   footer: {},
   accessoryContainer: {},
+  pendingImagesScrollView: {
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.outlineVariant,
+  },
   pendingImagesContainer: {
     height: 68,
-    borderTopWidth: 1,
-    borderTopColor: 'lightgrey',
     justifyContent: 'flex-start',
     gap: 8,
     paddingHorizontal: 8,


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes the border style for the pending images view

## Screenshots
<!-- include screen recordings, if relevant to your changes -->

<table>
<tr>
 <td><b>Before
 <td><b>After
<tr>
 <td><img width="370" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/3e514f99-7fdf-47ca-b070-2511ab63a217">
 <td><img width="375" alt="image" src="https://github.com/lifeomic/react-native-sdk/assets/2295908/462d6852-6504-4de9-b6a6-212bde0c6b7a">
</table>




