### PR TITLE
fix: Sleep Chart Bug Fixes

### DIFF
--- a/src/components/MyData/SleepChart/DailyChart.tsx
+++ b/src/components/MyData/SleepChart/DailyChart.tsx
@@ -175,10 +175,12 @@ export const DailyChart = (props: Props) => {
         <ActivityIndicatorView animating={isFetching} />
       </View>
 
-      <DataSelector
-        onBlockScrollChange={onBlockScrollChange}
-        prepareTooltipData={prepareTooltipData}
-      />
+      {data.length > 0 && (
+        <DataSelector
+          onBlockScrollChange={onBlockScrollChange}
+          prepareTooltipData={prepareTooltipData}
+        />
+      )}
     </View>
   );
 };

--- a/src/components/MyData/SleepChart/MultiDayChart.tsx
+++ b/src/components/MyData/SleepChart/MultiDayChart.tsx
@@ -207,10 +207,12 @@ export const MultiDayChart = (props: Props) => {
         <ActivityIndicatorView animating={isFetching} />
       </View>
 
-      <DataSelector
-        onBlockScrollChange={onBlockScrollChange}
-        prepareTooltipData={prepareTooltipData}
-      />
+      {data.length > 0 && (
+        <DataSelector
+          onBlockScrollChange={onBlockScrollChange}
+          prepareTooltipData={prepareTooltipData}
+        />
+      )}
     </View>
   );
 };
@@ -225,6 +227,10 @@ const SleepBar = (props: BarProps) => {
     default: 0,
   };
   let total = 0;
+
+  if (props.datum.components.length === 0) {
+    return null;
+  }
 
   props.datum.components.forEach((component: ObservationComponent) => {
     if (!component?.valuePeriod?.start || !component?.valuePeriod?.end) {

--- a/src/components/MyData/SleepChart/useSleepChartData.ts
+++ b/src/components/MyData/SleepChart/useSleepChartData.ts
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useFhirClient } from '../../../hooks';
 import { ScaleTime, scaleTime } from 'd3-scale';
-import { differenceInDays, min, max, startOfDay, endOfDay } from 'date-fns';
+import {
+  differenceInDays,
+  min,
+  max,
+  startOfDay,
+  endOfDay,
+  isValid,
+} from 'date-fns';
 import { useCommonChartProps } from '../useCommonChartProps';
 import { Observation } from 'fhir/r3';
 import compact from 'lodash/compact';
@@ -87,9 +94,12 @@ export const useSleepChartData = (props: Props) => {
         {} as { start?: Date; end?: Date },
       );
 
+      const startDate = start && isValid(start) ? start : new Date(0);
+      const endDate = end && isValid(end) ? end : new Date(0);
+
       const newXDomain = scaleTime()
         .range([0, common.plotAreaWidth])
-        .domain([new Date(start ?? 0), new Date(end ?? 0)]);
+        .domain([startDate, endDate]);
 
       setChartData({ sleepData: newSleepData, xDomain: newXDomain, dateRange });
       setIsLoading(false);

--- a/src/screens/MyDataScreen.tsx
+++ b/src/screens/MyDataScreen.tsx
@@ -110,6 +110,7 @@ export const MyDataScreen = () => {
         {config?.homeTab?.myDataSettings?.components.map((component, index) => (
           <React.Fragment key={`${component.type}-${index}`}>
             <View
+              style={styles.chartWrapperContainer}
               onLayout={(e) => {
                 chartDimensions.current[index] = e.nativeEvent.layout;
               }}
@@ -326,6 +327,9 @@ const defaultStyles = createStyles('MyDataScreen', (theme) => ({
     backgroundColor: theme.colors.onSurface,
     marginBottom: 24,
     marginTop: 5,
+  },
+  chartWrapperContainer: {
+    width: '100%',
   },
 }));
 


### PR DESCRIPTION
## Changes
<!-- list your changes here -->
  - Fixes a bug where the start and end dates were null, causing the app to crash
  - Removes data selector on empty charts to prevent empty selection bar/flag
  - Hides stage bar if no components exist. Before the chart would render an misaligned arbitrary bar
  - Fixes a bug where the chart wrapper did not fill the full width of its parent, resulting in the summary view being squished